### PR TITLE
remove carb_ratio

### DIFF
--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -24,11 +24,10 @@ if (!module.parent) {
     var bgtargets_input = process.argv.slice(3, 4).pop()
     var isf_input = process.argv.slice(4, 5).pop()
     var basalprofile_input = process.argv.slice(5, 6).pop()
-    var carbratio_input = process.argv.slice(6, 7).pop()
-    var maxiob_input = process.argv.slice(7, 8).pop()
+    var maxiob_input = process.argv.slice(6, 7).pop()
     
-    if (!pumpsettings_input || !bgtargets_input || !isf_input || !basalprofile_input || !carbratio_input) {
-        console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <isf.json> <current_basal_profile.json> <carb_ratio.json> [<max_iob.json>]');
+    if (!pumpsettings_input || !bgtargets_input || !isf_input || !basalprofile_input) {
+        console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <insulin_sensitivies.json> <basal_profile.json> [<max_iob.json>]');
         process.exit(1);
     }
     
@@ -42,7 +41,6 @@ if (!module.parent) {
     }
     var isf_data = require(cwd + '/' + isf_input);
     var basalprofile_data = require(cwd + '/' + basalprofile_input);
-    var carbratio_data = require(cwd + '/' + carbratio_input);;
 
     var maxiob_data = { max_iob: 0 };
     if (typeof maxiob_input != 'undefined') {
@@ -54,7 +52,6 @@ if (!module.parent) {
     , basals: basalprofile_data
     , isf: isf_data
     , max_iob: maxiob_data.max_iob || 0
-    , carbs: carbratio_data
 
     };
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -1,7 +1,6 @@
 
 var basal = require('./basal');
 var targets = require('./targets');
-var carbs = require('./carbs');
 var isf = require('./isf');
 
 function defaults ( ) {
@@ -32,7 +31,6 @@ function generate (inputs, opts) {
   var range = targets.bgTargetsLookup(inputs);
   profile.min_bg = range.min_bg;
   profile.max_bg = range.max_bg;
-  profile.carbratio = carbs.carbRatioLookup(inputs);
   profile.sens = isf.isfLookup(inputs);
 
   return profile;


### PR DESCRIPTION
get-profile collects carb_ratio, but we don't use that anywhere else in oref0, so before people get all their aliases set up, we should remove it.