### PR TITLE
fix error introduced in divide and conqeuor

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ git checkout -b wip/my-enhancement-fix-or-proposal
 This command installs new versions from source:
 `sudo npm install -g`
 
+Alternately, `sudo npm link` or `sudo npm link oref0` should allow you to
+edit from your checkout while using your checkout globally on your system.
+
 ### Fork on github.
 
 Fork the repository on github. Add your personal "remote" with something like

--- a/bin/oref0-calculate-iob.js
+++ b/bin/oref0-calculate-iob.js
@@ -35,7 +35,7 @@ if (!module.parent) {
   var profile_data = require(cwd + '/' + profile_input);
   var clock_data = require(cwd + '/' + clock_input);
 
-  all_data.sort(function (a, b) { return a.date > b.date });
+  // all_data.sort(function (a, b) { return a.date > b.date });
 
   var inputs = {
     history: all_data

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -1,4 +1,6 @@
 
+var tz = require('timezone');
+
 function calcTempTreatments (inputs) {
   var pumpHistory = inputs.history;
   var profile_data = inputs.profile;
@@ -14,7 +16,7 @@ function calcTempTreatments (inputs) {
                 var temp = {};
                 temp.timestamp = current.timestamp;
                 //temp.started_at = new Date(current.date);
-                temp.started_at = new Date(current.timestamp + timeZone);
+                temp.started_at = new Date(tz(current.timestamp));
                 //temp.date = current.date
                 temp.date = temp.started_at.getTime();
                 temp.insulin = current.amount
@@ -67,6 +69,8 @@ function calcTempTreatments (inputs) {
             }
         }
     }
-    return [ ].concat(tempBoluses).concat(tempHistory);
+    var all_data =  [ ].concat(tempBoluses).concat(tempHistory);
+    all_data.sort(function (a, b) { return a.date > b.date });
+    return all_data;
 }
 exports = module.exports = calcTempTreatments;


### PR DESCRIPTION

The only difference in `calculate-iob` and this version was that I added sorting to the data before `calcTempTreatments` was run, instead of after.  It turns out it's important to not change the ordering before `calcTempTreatments` figures things out.