### PR TITLE
Wip/bewest/dev

### DIFF
--- a/bin/mm-format-ns-profile.sh
+++ b/bin/mm-format-ns-profile.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Author: Ben West
+
+SETTINGS=${1-monitor/settings.json}
+CARBS=${2-monitor/carb-ratios.json}
+BASALRATES=${3-monitor/active-basal-profile.json}
+SENSITIVITIES=${4-monitor/insulin-sensitivities.json}
+TARGETS=${4-monitor/bg-targets.json}
+OUTPUT=${2-/dev/fd/1}
+# DIA
+# CARBRATIO
+#TZ=${3-$(date +%z)}
+
+function usage ( ) {
+cat <<EOF
+EOF
+}
+
+function dia ( ) {
+  cat $1 | json insulin_action_curve
+}
+
+function fix-schedule ( ) {
+  field=$1
+  json -e "this.time = this.start; this.value = this.$field.toString( );"
+}
+
+function carb-ratios ( ) {
+  units=$(cat $1 | json units)
+  if [[ $units = "grams" ]] ; then
+    cat $1 | json schedule \
+      | fix-schedule ratio
+      # | json -e "this.time = this.start; this.value = this.ratio;"
+  else
+    echo "[ ]" | json
+  fi
+
+}
+
+function add-carbs ( ) {
+  json -e "this.carbratio = $(carb-ratios $1 )"
+}
+
+function basal-rates ( ) {
+  (
+   test -n "$1" && cat $1 || echo "[ ]"
+  ) | json  \
+    | fix-schedule rate \
+    | json -A -e "this.length > 0 ? this : [ ];" \
+    | json -e "this.seconds = this.minutes * 60;"
+}
+
+function add-basals ( ) {
+  json -e "this.basal = $(basal-rates $1 )"
+}
+
+function sensitivities ( ) {
+  (
+   test -n "$1" && cat $1 || echo "{ }" | json
+  )   \
+    | json -e "this.sens = (this.sensitivities && this.sensitivities.length > 0) ? this.sensitivities : [ ];" \
+    | json  sens  \
+    | fix-schedule sensitivity
+}
+
+function add-isf ( ) {
+  #json -e "this.sens =
+  # sensitivities $1
+  json -e "this.sens = $(sensitivities $1 )"
+}
+
+function targets ( ) {
+  category="$2"
+  test -z "$category" && category=$1 && shift 
+  (
+   test -n "${1}${2}" && cat $1 || echo "{ }" | json
+  )   \
+    | target-category $category
+
+}
+
+function target-category ( ) {
+  category="$1"
+  name="target_$category"
+  json -e "this.$name = (this.targets && this.targets.length > 0) ? this.targets : [ ];" \
+   | json -e "this.$name = this.$name.map(function (elem) { if (elem.$category) { return {value: elem.$category.toString( ), time: elem.start }; } })" \
+   json $name
+}
+
+function add-targets ( ) {
+  json -e "this.target_low = $(targets $1 low)" \
+    | json -e "this.target_high = $(targets $1 high)" \
+    | json -e "this.units = '$(bgunits $1)'"
+
+}
+
+function bgunits ( ) {
+  cat $1 | json units
+}
+
+
+function stub ( ) {
+  zone=$(date +%Z)
+  dt=$(date --rfc-3339=ns | tr ' ' 'T')
+  DIA=$(dia $SETTINGS)
+  cat <<EOF | json
+  {
+    "dia" : "$DIA"
+  , "carbratio": [ ]
+  , "carbs_hr": "30"
+  , "delay": "20"
+  , "sens": [ ]
+  , "startDate": "$dt"
+  , "timezone": "$zone"
+  , "basal": [ ]
+  , "target_low": [ ]
+  , "target_high": [ ]
+  , "created_at": "$dt"
+  , "units": ""
+  }
+EOF
+}
+
+stub $SETTINGS | add-carbs $CARBS | add-basals $BASALRATES | add-isf $SENSITIVITIES | add-targets $TARGETS | json \
+  > $OUTPUT
+
+

--- a/bin/mm-format-ns-treatments.sh
+++ b/bin/mm-format-ns-treatments.sh
@@ -3,17 +3,21 @@
 # Author: Ben West
 
 HISTORY=${1-monitor/pump-history-zoned.json}
+MODEL=${2-model.json}
 OUTPUT=${2-/dev/fd/1}
 #TZ=${3-$(date +%z)}
 self=$(basename $0)
 
 # | json -e "this.type = 'mm://openaps/$self'" \
+model=$(json -f $MODEL)
 
 oref0-normalize-temps $HISTORY  \
   | json -e "this.medtronic = 'mm://openaps/$self/' + (this._type || this.eventType);" \
   | json -e "this.created_at = this.created_at ? this.created_at : this.timestamp" \
-  | json -e "this.enteredBy = 'openaps://medtronic'" \
+  | json -e "this.enteredBy = 'openaps://medtronic/$model'" \
+  | json -e "if (this.glucose && !this.glucoseType && this.glucose > 0) { this.glucoseType = this._type + '/$model' }" \
   | json -e "this.eventType = (this.eventType ?  this.eventType : 'Note')" \
+  | json -e "if (this.eventType == 'Note') { this.notes = this._type + ' $model ' + (this.notes ? this.notes : '')}" \
   | json > $OUTPUT
 
 

--- a/bin/mm-format-ns-treatments.sh
+++ b/bin/mm-format-ns-treatments.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Author: Ben West
+
+HISTORY=${1-monitor/pump-history-zoned.json}
+OUTPUT=${2-/dev/fd/1}
+#TZ=${3-$(date +%z)}
+self=$(basename $0)
+
+# | json -e "this.type = 'mm://openaps/$self'" \
+
+oref0-normalize-temps $HISTORY  \
+  | json -e "this.medtronic = 'mm://openaps/$self/' + (this._type || this.eventType);" \
+  | json -e "this.created_at = this.created_at ? this.created_at : this.timestamp" \
+  | json -e "this.enteredBy = 'openaps://medtronic'" \
+  | json -e "this.eventType = (this.eventType ?  this.eventType : 'Note')" \
+  | json > $OUTPUT
+
+

--- a/bin/mm-format-ns-treatments.sh
+++ b/bin/mm-format-ns-treatments.sh
@@ -4,7 +4,7 @@
 
 HISTORY=${1-monitor/pump-history-zoned.json}
 MODEL=${2-model.json}
-OUTPUT=${2-/dev/fd/1}
+OUTPUT=${3-/dev/fd/1}
 #TZ=${3-$(date +%z)}
 self=$(basename $0)
 
@@ -15,7 +15,7 @@ oref0-normalize-temps $HISTORY  \
   | json -e "this.medtronic = 'mm://openaps/$self/' + (this._type || this.eventType);" \
   | json -e "this.created_at = this.created_at ? this.created_at : this.timestamp" \
   | json -e "this.enteredBy = 'openaps://medtronic/$model'" \
-  | json -e "if (this.glucose && !this.glucoseType && this.glucose > 0) { this.glucoseType = this._type + '/$model' }" \
+  | json -e "if (this.glucose && !this.glucoseType && this.glucose > 0) { this.glucoseType = this.enteredBy }" \
   | json -e "this.eventType = (this.eventType ?  this.eventType : 'Note')" \
   | json -e "if (this.eventType == 'Note') { this.notes = this._type + ' $model ' + (this.notes ? this.notes : '')}" \
   | json > $OUTPUT

--- a/bin/ns-get.sh
+++ b/bin/ns-get.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Author: Ben West
+
+self=$(basename $0)
+NIGHTSCOUT_HOST=${NIGHTSCOUT_HOST-${1-localhost:1337}}
+# QUERY=${3}
+REPORT=${2-entries.json}
+OUTPUT=${3-/dev/fd/1}
+
+function usage ( ) {
+cat <<EOF
+Usage: $self <NIGHTSCOUT_HOST|localhost:1337> [entries.json] [stdout|-]
+
+$self --config <NIGHTSCOUT_HOST> <entries.json> monitor/entries.json
+EOF
+}
+
+REPORT_ENDPOINT=$NIGHTSCOUT_HOST/api/v1/$REPORT
+case $1 in
+  --config)
+    test -z $3 && usage && exit 1;
+    # echo openaps device add $2 process $self $3
+    cat <<EOF
+openaps device add $self process --require report $self $2
+openaps report add $4 text $self shell "$3"
+EOF
+    exit 0;
+    ;;
+  --noop)
+    echo "curl -s $REPORT_ENDPOINT | json"
+    ;;
+  help)
+    usage
+    ;;
+  *)
+    curl -s $REPORT_ENDPOINT | json
+    ;;
+esac
+
+

--- a/bin/ns-upload.sh
+++ b/bin/ns-upload.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Author: Ben West
+
+self=$(basename $0)
+NIGHTSCOUT_HOST=${NIGHTSCOUT_HOST-${1-localhost:1337}}
+API_SECRET=${2-${API_SECRET}}
+TYPE=${3-entries.json}
+ENTRIES=${4-entries.json}
+#TZ=${3-$(date +%z)}
+OUTPUT=${5}
+
+REST_ENDPOINT="${NIGHTSCOUT_HOST}/api/v1/${TYPE}"
+
+function usage ( ) {
+cat <<EOF
+Usage: $self <NIGHTSCOUT_HOST|localhost:1337> <API_SECRET> [API-TYPE|entries.json] <monitor/entries-to-upload.json> [stdout|-]
+
+$self --config <NIGHTSCOUT_HOST> <PLAIN_API_SECRET> <API-TYPE|entries.json> <monitor/entries-to-upload.json> output-report.json
+
+$self help - This message.
+EOF
+}
+
+case $1 in
+  --config)
+    test -z $3 && usage && exit 1;
+    # echo openaps device add $2 process $self $3
+API_SECRET=$(echo -n $3 | sha1sum | cut -d ' ' -f 1 | tr -d "\n")
+    cat <<EOF
+openaps device add $self process --require "type report" $self "$self-NIGHTSCOUT" "$self-APIKEY"
+sed -i -e "s/$self-NIGHTSCOUT/$2/g" $self.ini
+sed -i -e "s/$self-APIKEY/$API_SECRET/g" $self.ini
+openaps report add $6 text $self shell "$4" "$5"
+EOF
+    exit 0;
+    ;;
+  help)
+    usage
+    ;;
+  *)
+    # curl -s $REPORT_ENDPOINT | json
+    ;;
+esac
+export ENTRIES API_SECRET NIGHTSCOUT_HOST REST_ENDPOINT
+if [[ -z $API_SECRET ]] ; then
+  echo "$self: missing API_SECRET"
+  test -z "$NIGHTSCOUT_HOST" && echo "$self: also missing NIGHTSCOUT_HOST"
+  cat <<EOF > /dev/fd/2
+Usage: $self <NIGHTSCOUT_HOST-http://localhost:1337> <API_SECRET> [entries|treatments|profile/] <file-to-upload.json> 
+EOF
+  exit 1;
+fi
+# requires API_SECRET and NIGHTSCOUT_HOST to be set in calling environment
+# (i.e. in crontab)
+echo $ENTRIES > /dev/fd/2
+(test "$ENTRIES" != "-" && cat $ENTRIES || cat )| (
+curl -s -X POST --data-binary @- \
+  -H "API-SECRET: $API_SECRET" \
+  -H "content-type: application/json" \
+  $REST_ENDPOINT
+) && ( test -n "$OUTPUT" && touch $OUTPUT ; logger "Uploaded $ENTRIES to $NIGHTSCOUT_HOST" ) || logger "Unable to upload to $NIGHTSCOUT_HOST"
+

--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -27,7 +27,7 @@ if (!module.parent) {
     var maxiob_input = process.argv.slice(6, 7).pop()
     
     if (!pumpsettings_input || !bgtargets_input || !isf_input || !basalprofile_input) {
-        console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <insulin_sensitivies.json> <basal_profile.json> [<max_iob.json>]');
+        console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <insulin_sensitivities.json> <basal_profile.json> [<max_iob.json>]');
         process.exit(1);
     }
     

--- a/bin/oref0-normalize-temps.js
+++ b/bin/oref0-normalize-temps.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/*
+  Released under MIT license. See the accompanying LICENSE.txt file for
+  full terms and conditions
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+*/
+
+var find_insulin = require('oref0/lib/temps');
+var find_bolus = require('oref0/lib/bolus');
+
+if (!module.parent) {
+  var iob_input = process.argv.slice(2, 3).pop()
+
+  if (!iob_input) {
+    console.log('usage: ', process.argv.slice(0, 2), '<pumphistory.json>');
+    process.exit(1);
+  }
+
+  var cwd = process.cwd()
+  var all_data = require(cwd + '/' + iob_input);
+
+  var inputs = {
+    history: all_data
+  };
+  var treatments = find_insulin(find_bolus(inputs.history));
+  // treatments.sort(function (a, b) { return a.date > b.date });
+
+
+  console.log(JSON.stringify(treatments));
+}
+

--- a/bin/oref0-normalize-temps.js
+++ b/bin/oref0-normalize-temps.js
@@ -16,6 +16,7 @@
 
 var find_insulin = require('oref0/lib/temps');
 var find_bolus = require('oref0/lib/bolus');
+var describe_pump = require('oref0/lib/pump');
 
 if (!module.parent) {
   var iob_input = process.argv.slice(2, 3).pop()
@@ -32,6 +33,7 @@ if (!module.parent) {
     history: all_data
   };
   var treatments = find_insulin(find_bolus(inputs.history));
+  treatments = describe_pump(treatments);
   // treatments.sort(function (a, b) { return a.date > b.date });
 
 

--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -34,6 +34,7 @@ function reduce (treatments) {
       state.carbs = ev.carb_input;
       state.ratio = ev.carb_ratio;
       state.bg = ev.bg;
+      state.glucose = ev.bg;
       state.wizard = ev;
       state.created_at = state.timestamp = ev.timestamp;
       previous.push(ev);
@@ -41,8 +42,13 @@ function reduce (treatments) {
 
     if (ev._type == 'Bolus') {
       state.duration = ev.duration;
-      state.insulin = ev.amount;
-      state.bolus = ev;
+      // if (state.square || state.bolus) { }
+      // state.insulin = (state.insulin ? state.insulin : 0) + ev.amount;
+      if (ev.duration && ev.duration > 0) {
+        state.square = ev;
+      } else {
+        state.bolus = ev;
+      }
       state.created_at = state.timestamp = ev.timestamp;
       previous.push(ev);
     }
@@ -60,10 +66,50 @@ function reduce (treatments) {
       // console.error("remaining", remaining);
       state.eventType = '<none>';
 
+      state.insulin = (state.square ? state.square.amount : 0) +
+                      (state.bolus ? state.bolus.amount : 0);
       var has_insulin = state.insulin && state.insulin > 0;
       var has_carbs = state.carbs && state.carbs > 0;
       var has_wizard = state.wizard ? true : false;
       var has_bolus = state.bolus ? true : false;
+      if (state.square && state.bolus) {
+        annotate("DualWave bolus for", state.square.duration, "minutes");
+      } else if (state.square && state.wizard) {
+        annotate("Square wave bolus for", state.square.duration, "minutes");
+      } else if (state.square) {
+        annotate("Solo Square wave bolus for", state.square.duration, "minutes");
+        annotate("No bolus wizard used.");
+      } else if (state.bolus && state.wizard) {
+        annotate("Normal bolus with wizard.");
+      } else if (state.bolus) {
+        annotate("Normal bolus (solo, no bolus wizard).");
+      }
+
+      if (state.bolus) {
+        annotate("Programmed bolus", state.bolus.programmed);
+        annotate("Delivered bolus", state.bolus.amount);
+        annotate("Percent delivered: ", (state.bolus.amount/state.bolus.programmed * 100).toString( ) + '%');
+      }
+      if (state.square) {
+        annotate("Programmed square", state.square.programmed);
+        annotate("Delivered square", state.square.amount);
+        annotate("Success: ", (state.square.amount/state.square.programmed * 100).toString( ) + '%');
+      }
+      if (state.wizard) {
+        state.created_at = state.wizard.timestamp;
+        annotate("Food estimate", state.wizard.food_estimate);
+        annotate("Correction estimate", state.wizard.correction_estimate);
+        annotate("Bolus estimate", state.wizard.bolus_estimate);
+        annotate("Target low", state.wizard.bg_target_low);
+        annotate("Target high", state.wizard.bg_target_high);
+        var delta = state.wizard.sensitivity * state.insulin * -1;
+        annotate("Hypothetical glucose delta", delta);
+        if (state.bg && state.bg > 0) {
+          annotate('Glucose was:', state.bg);
+          // state.glucose = state.bg;
+          // TODO: annotate prediction
+        }
+      }
       if (state.carbs && state.insulin && state.bg) {
         state.eventType = 'Meal Bolus';
       } else {
@@ -74,9 +120,21 @@ function reduce (treatments) {
           state.eventType = 'Correction Bolus';
         }
       }
+      if (state.notes && state.notes.length > 0) {
+        state.notes = state.notes.join('. ');
+      }
       results.push(state);
       state = { };
     }
+  }
+
+  function annotate (msg) {
+    var args = [ ].slice.apply(arguments);
+    msg = args.join(' ');
+    if (!state.notes) {
+      state.notes = [ ];
+    }
+    state.notes.push(msg);
   }
 
   function step (current, index) {

--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -1,0 +1,94 @@
+
+function reduce (treatments) {
+
+  var results = [ ];
+
+  var state = { };
+  var previous = [ ];
+  
+  function in_previous (ev) {
+    var found = false;
+    previous.forEach(function (elem) {
+      if (elem.timestamp == ev.timestamp && ev._type == elem._type) {
+        found = true;
+      }
+    });
+
+    return found;
+  }
+
+  function within_minutes_from (origin, tail, minutes) {
+    var ms = minutes * 1000 * 60;
+    var ts = Date.parse(origin.timestamp);
+    var candidates = tail.slice( ).filter(function (elem) {
+      var dt = Date.parse(origin.timestamp);
+      return ts - dt <= ms;
+      
+    });
+    return candidates;
+  }
+
+  function bolus (ev, remaining) {
+    if (!ev) { return; }
+    if (ev._type == 'BolusWizard') {
+      state.carbs = ev.carb_input;
+      state.ratio = ev.carb_ratio;
+      state.bg = ev.bg;
+      state.wizard = ev;
+      state.created_at = state.timestamp = ev.timestamp;
+      previous.push(ev);
+    }
+
+    if (ev._type == 'Bolus') {
+      state.duration = ev.duration;
+      state.insulin = ev.amount;
+      state.bolus = ev;
+      state.created_at = state.timestamp = ev.timestamp;
+      previous.push(ev);
+    }
+
+
+    if (remaining && remaining.length > 0) {
+      return bolus(remaining[0], remaining.slice(1));
+    } else {
+      state.eventType = '<none>';
+
+      var has_insulin = state.insulin && state.insulin > 0;
+      var has_carbs = state.carbs && state.carbs > 0;
+      var has_wizard = state.wizard ? true : false;
+      var has_bolus = state.bolus ? true : false;
+      if (state.carbs && state.insulin && state.bg) {
+        state.eventType = 'Meal Bolus';
+      } else {
+        if (has_carbs && !has_insulin) {
+          state.eventType = 'Carb Correction';
+        }
+        if (!has_carbs && has_insulin) {
+          state.eventType = 'Correction Bolus';
+        }
+      }
+      results.push(state);
+      state = { };
+    }
+  }
+
+  function step (current, index) {
+    if (in_previous(current)) {
+      return;
+    }
+    switch (current._type) {
+      case 'Bolus':
+      case 'BolusWizard':
+        var tail = within_minutes_from(current, treatments.slice(index+1), 4);
+        bolus(current, tail);
+        break;
+      default:
+        results.push(current);
+        break;
+    }
+  }
+  treatments.forEach(step);
+  return results;
+}
+
+exports = module.exports = reduce;

--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -29,7 +29,7 @@ function reduce (treatments) {
   }
 
   function bolus (ev, remaining) {
-    if (!ev) { return; }
+    if (!ev) { console.error('XXX', ev, remaining); return; }
     if (ev._type == 'BolusWizard') {
       state.carbs = ev.carb_input;
       state.ratio = ev.carb_ratio;
@@ -49,8 +49,15 @@ function reduce (treatments) {
 
 
     if (remaining && remaining.length > 0) {
+      if (state.bolus && state.wizard) {
+        // skip to end
+        return bolus({}, []); 
+      }
+      // keep recursing
       return bolus(remaining[0], remaining.slice(1));
     } else {
+      // console.error("state", state);
+      // console.error("remaining", remaining);
       state.eventType = '<none>';
 
       var has_insulin = state.insulin && state.insulin > 0;

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -37,7 +37,7 @@ function calcTempTreatments (inputs) {
                 //temp.date = date;
                 temp.timestamp = current.timestamp;
                 //temp.started_at = new Date(temp.date);
-                temp.started_at = new Date(temp.timestamp + timeZone);
+                temp.started_at = new Date(tz(temp.timestamp));
                 temp.date = temp.started_at.getTime();
                 temp.duration = duration;
                 tempHistory.push(temp);

--- a/lib/pump.js
+++ b/lib/pump.js
@@ -11,7 +11,6 @@ function translate (treatments) {
         current.glucose = current.amount;
         current.glucoseType = 'Finger';
         current.notes = "Pump received finger stick.";
-        results.push(current);
         break;
       default:
         break;

--- a/lib/pump.js
+++ b/lib/pump.js
@@ -1,0 +1,29 @@
+
+function translate (treatments) {
+
+  var results = [ ];
+  
+  function step (current, index) {
+    var invalid = false;
+    switch (current._type) {
+      case 'CalBGForPH':
+        current.eventType = '<none>';
+        current.glucose = current.amount;
+        current.glucoseType = 'Finger';
+        current.notes = "Pump received finger stick.";
+        results.push(current);
+        break;
+      default:
+        break;
+    }
+
+    if (!invalid) {
+      results.push(current);
+    }
+
+  }
+  treatments.forEach(step);
+  return results;
+}
+
+exports = module.exports = translate;

--- a/lib/temps.js
+++ b/lib/temps.js
@@ -1,0 +1,48 @@
+
+function filter (treatments) {
+
+  var results = [ ];
+
+  var state = { };
+  
+  function temp (ev) {
+    if ('duration (min)' in ev) {
+      state.duration = ev['duration (min)'];
+      state.raw_duration = ev;
+    }
+
+    if ('rate' in ev) {
+      state[ev.temp] = ev.rate;
+      state.rate = ev['rate'];
+      state.raw_rate = ev;
+    }
+
+    if ('timestamp' in state && ev.timestamp != state.timestamp) {
+      state.invalid = true;
+    } else {
+      state.timestamp = ev.timestamp;
+    }
+
+    if ('duration' in state && ('percent' in state || 'absolute' in state)) {
+      state.eventType = 'Temp Basal Start';
+      results.push(state);
+      state = { };
+    }
+  }
+
+  function step (current, index) {
+    switch (current._type) {
+      case 'TempBasalDuration':
+      case 'TempBasal':
+        temp(current);
+        break;
+      default:
+        results.push(current);
+        break;
+    }
+  }
+  treatments.forEach(step);
+  return results;
+}
+
+exports = module.exports = filter;

--- a/lib/temps.js
+++ b/lib/temps.js
@@ -24,7 +24,7 @@ function filter (treatments) {
     }
 
     if ('duration' in state && ('percent' in state || 'absolute' in state)) {
-      state.eventType = 'Temp Basal Start';
+      state.eventType = 'Temp Basal';
       results.push(state);
       state = { };
     }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "oref0-ifttt-notify": "./bin/oref0-ifttt-notify",
     "oref0-reset-usb": "bin/reset-usb.sh",
     "mm-format-ns-glucose": "./bin/mm-format-ns-glucose.sh",
+    "mm-format-ns-profile": "./bin/mm-format-ns-profile.sh",
     "mm-format-ns-pump-history": "./bin/mm-format-ns-pump-history.sh",
     "oref0": "./bin/oref0.sh",
     "mm-stick": "./bin/mm-stick.sh",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "bin": {
     "oref0-calculate-iob": "./bin/oref0-calculate-iob.js",
     "oref0-determine-basal": "./bin/oref0-determine-basal.js",
+    "oref0-normalize-temps": "./bin/oref0-normalize-temps.js",
     "send-tempbasal-Azure": "./bin/send-tempbasal-Azure.js",
     "oref0-get-profile": "./bin/oref0-get-profile.js",
     "oref0-mint-max-iob": "./bin/oref0-mint-max-iob.sh",
@@ -27,6 +28,7 @@
     "oref0-reset-usb": "bin/reset-usb.sh",
     "mm-format-ns-glucose": "./bin/mm-format-ns-glucose.sh",
     "mm-format-ns-profile": "./bin/mm-format-ns-profile.sh",
+    "mm-format-ns-treatments": "./bin/mm-format-ns-treatments.sh",
     "mm-format-ns-pump-history": "./bin/mm-format-ns-pump-history.sh",
     "oref0": "./bin/oref0.sh",
     "mm-stick": "./bin/mm-stick.sh",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "oref0": "./bin/oref0.sh",
     "mm-stick": "./bin/mm-stick.sh",
     "ns-upload-entries": "./bin/ns-upload-entries.sh",
+    "ns-upload": "./bin/ns-upload.sh",
+    "ns-get": "./bin/ns-get.sh",
     "oref0-pebble": "./bin/oref0-pebble.js"
   },
   "homepage": "https://github.com/openaps/oref0",


### PR DESCRIPTION
Tools to work with Nightscout.

These tells help translate pump-history to the treatments format Nightscout suspects.

It has a couple of nice features, including the ability to join pair wise `TempBasal` and `TempBasalDuration` commands, as well as the ability to combine `BolusWizard` events that are nearby their `Bolus` events into a single treatment event.  The combined bolus events allow classifying into *Correction* vs *Carb* vs *Meal* treatments, which is kind of nice.

I also demonstrate how other people can augment/extend these capabilities by enhancing the `notes` field.