### PR TITLE
Fix typo for profile.min_bg

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -34,7 +34,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (typeof profile.target_bg !== 'undefined') {
         target_bg = profile.target_bg;
     } else {
-        if (typeof profile.max_bg !== 'undefined' && typeof profile.max_bg !== 'undefined') {
+        if (typeof profile.min_bg !== 'undefined' && typeof profile.max_bg !== 'undefined') {
             target_bg = (profile.min_bg + profile.max_bg) / 2;
         } else {
             rT.error ='Error: could not determine target_bg';


### PR DESCRIPTION
Check for both min and max exist. Typo was just checking max twice.