### PR TITLE
test capturing @audiefile scenario and overcompensatory quick-fix

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -162,8 +162,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // calculate 30m low-temp required to get projected BG up to target
             // use snoozeBG instead of eventualBG to more gradually ramp in any counteraction of the user's boluses
             var insulinReq = Math.min(0, (snoozeBG - target_bg) / profile.sens);
-            if (minDelta > 0 && minDelta < expectedDelta) {
-                var newinsulinReq = Math.round(( insulinReq * (1 - (minDelta / expectedDelta)) ) * 100)/100;
+            if (minDelta < 0 && minDelta > expectedDelta) {
+                // if we're barely falling, newinsulinReq should be barely negative
+                var newinsulinReq = Math.round(( insulinReq * (minDelta / expectedDelta) ) * 100)/100;
                 //console.log("Increasing insulinReq from " + insulinReq + " to " + newinsulinReq);
                 insulinReq = newinsulinReq;
             }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -139,8 +139,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 rT.reason = rT.reason += "; no temp to cancel";
                 return rT;
                 }
-            } else { // BG is falling slower than expected delta
-                // TODO: possibly reduce low-temp by setting newinsulinReq
             }
         }
         

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -125,19 +125,22 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } 
     if (eventualBG < profile.min_bg) { // if eventual BG is below target:
         rT.reason = "Eventual BG " + eventualBG + "<" + profile.min_bg;
-        // if 5m or 15m avg BG is rising faster than expected delta
         if (minDelta > expectedDelta) {
-            if (glucose_status.delta > glucose_status.avgdelta) {
-                rT.reason += ", but Delta " + tick + " > Exp. Delta " + expectedDelta;
-            } else {
-                rT.reason += ", but Avg. Delta " + glucose_status.avgdelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
-            }
-            if (currenttemp.duration > 0) { // if there is currently any temp basal running
-                rT.reason = rT.reason += "; cancel";
-                return setTempBasal(0, 0, profile, rT, offline); // cancel temp
-            } else {
-            rT.reason = rT.reason += "; no temp to cancel";
-            return rT;
+            if (minDelta > 0) { // if 5m or 15m avg BG is rising faster than expected delta
+                if (glucose_status.delta > glucose_status.avgdelta) {
+                    rT.reason += ", but Delta " + tick + " > Exp. Delta " + expectedDelta;
+                } else {
+                    rT.reason += ", but Avg. Delta " + glucose_status.avgdelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
+                }
+                if (currenttemp.duration > 0) { // if there is currently any temp basal running
+                    rT.reason = rT.reason += "; cancel";
+                    return setTempBasal(0, 0, profile, rT, offline); // cancel temp
+                } else {
+                rT.reason = rT.reason += "; no temp to cancel";
+                return rT;
+                }
+            } else { // BG is falling slower than expected delta
+                // TODO: possibly reduce low-temp by setting newinsulinReq
             }
         }
         

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -208,7 +208,18 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":-5,"glucose":115,"avgdelta":-6};
         var iob_data = {"iob":2,"activity":0.05,"bolusiob":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined,setTempBasal);
-        console.log(output);
+        //console.log(output);
+        output.rate.should.be.below(0.2);
+        output.duration.should.equal(30);
+        output.reason.should.match(/Eventual BG .*<110, no temp, setting .*/);
+    });
+
+    it('should low-temp much less when eventualBG < min_bg with delta barely negative', function () {
+        var glucose_status = {"delta":-1,"glucose":115,"avgdelta":-1};
+        var iob_data = {"iob":2,"activity":0.05,"bolusiob":0};
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined,setTempBasal);
+        //console.log(output);
+        output.rate.should.be.above(0.5);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
         output.reason.should.match(/Eventual BG .*<110, no temp, setting .*/);
@@ -255,6 +266,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":1,"glucose":85,"avgdelta":1};
         var iob_data = {"iob":-0.5,"activity":-0.01,"bolusiob":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined,setTempBasal);
+        //console.log(output);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
         output.reason.should.match(/no temp, setting/);

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -204,6 +204,16 @@ describe('determine-basal', function ( ) {
         output.reason.should.match(/Eventual BG .*<110, no temp, setting .*/);
     });
     
+    it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
+        var glucose_status = {"delta":-5,"glucose":115,"avgdelta":-6};
+        var iob_data = {"iob":2,"activity":0.05,"bolusiob":0};
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined,setTempBasal);
+        console.log(output);
+        output.rate.should.be.below(0.8);
+        output.duration.should.equal(30);
+        output.reason.should.match(/Eventual BG .*<110, no temp, setting .*/);
+    });
+
     it('should do nothing when eventualBG < min_bg but low temp in progress', function () {
         var glucose_status = {"delta":-3,"glucose":110,"avgdelta":-1};
         var currenttemp = {"duration":20,"rate":0.0,"temp":"absolute"};


### PR DESCRIPTION
This creates a unit test for #48, the issue @audiefile and @jasoncalabrese identified where expected-delta wouldn't low-temp when eventualBG < min but delta > expected delta (BG is falling more slowly than expected delta, mostly due to BGI).  Previously, I believe we were comparing delta to BGI/2, but in the expected-delta branch I changed it to compare to expected_delta (basically BGI), and haven't yet applied the newinsulinReq adjustment logic that I did for reducing high-temps.

This basic fix will disable the expected delta comparison completely (and low-temp) any time you’re falling with eventualBG < min.  That fixes the new unit test and doesn’t break any others, but I think the quick-fix will be too aggressive at low-temping when carbs are causing you to fall a lot slower than BGI, until we apply the newinsulinReq adjustment logic.

However, I think this is at least safer than the code currently running in dev.  If someone could give it a look through and confirm that, it might be worth merging this to dev even before I get the newinsulinReq adjustment logic in place.