### PR TITLE
Add additional 'should low-temp' test

### DIFF
--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -213,6 +213,16 @@ describe('determine-basal', function ( ) {
         output.duration.should.equal(30);
         output.reason.should.match(/Eventual BG .*<110, no temp, setting .*/);
     });
+    
+    it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
+        var glucose_status = {"delta":-2,"glucose":156,"avgdelta":-1.33};
+        var iob_data = {"iob":3.51,"activity":0.06,"bolusiob":0.08};
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined,setTempBasal);
+        console.log(output);
+        output.rate.should.be.below(0.8);
+        output.duration.should.equal(30);
+        output.reason.should.match(/Eventual BG .*<110, no temp, setting .*/);
+    });
 
     it('should low-temp much less when eventualBG < min_bg with delta barely negative', function () {
         var glucose_status = {"delta":-1,"glucose":115,"avgdelta":-1};


### PR DESCRIPTION
eventualBG < min_bg with delta > exp. delta
Reflects situation I encountered where no low temp was given despite eventualBG being well below min_bg because bg was not falling as fast as expected