### PR TITLE
Corrected positional arguments for NS profile creation

### DIFF
--- a/bin/mm-format-ns-profile.sh
+++ b/bin/mm-format-ns-profile.sh
@@ -6,8 +6,8 @@ SETTINGS=${1-monitor/settings.json}
 CARBS=${2-monitor/carb-ratios.json}
 BASALRATES=${3-monitor/active-basal-profile.json}
 SENSITIVITIES=${4-monitor/insulin-sensitivities.json}
-TARGETS=${4-monitor/bg-targets.json}
-OUTPUT=${2-/dev/fd/1}
+TARGETS=${5-monitor/bg-targets.json}
+OUTPUT=${6-settings/ns-profile.json}
 # DIA
 # CARBRATIO
 #TZ=${3-$(date +%z)}


### PR DESCRIPTION
It seems there were some typos, positional variables were overlapping each other. Also I have put a default output file name.