### PR TITLE
a tool to support filling in raw glucose values

### DIFF
--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
+'use strict';
 
-var fs = require('fs');
 var os = require("os");
+
+var requireUtils = require('../lib/require-utils')
+  , safeRequire = requireUtils.safeRequire
+  , requireWithTimestamp = requireUtils.requireWithTimestamp
+  ;
 
 /*
   Prepare Status info to for upload to Nightscout
@@ -18,28 +23,6 @@ var os = require("os");
   THE SOFTWARE.
 
 */
-
-function safeRequire (path) {
-  var resolved;
-
-  try {
-    resolved = require(path);
-  } catch (e) {
-    console.error("Could not require: " + path, e);
-  }
-
-  return resolved;
-}
-
-function requireWithTimestamp (path) {
-  var resolved = safeRequire(path);
-
-  if (resolved) {
-    resolved.timestamp = fs.statSync(path).mtime;
-  }
-
-  return resolved;
-}
 
 function fixRecFlag (enacted) {
   if (enacted) {

--- a/bin/oref0-raw.js
+++ b/bin/oref0-raw.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+
+var fs = require('fs');
+var os = require("os");
+
+var safeRequire = require('../lib/require-utils').safeRequire;
+var getLastGlucose = require('../lib/glucose-get-last');
+var withRawGlucose = require('../lib/with-raw-glucose');
+
+/*
+ Fills CGM data doesn't already contain an EVG, if we have unfiltered, filtered, and a cal
+
+ Released under MIT license. See the accompanying LICENSE.txt file for
+ full terms and conditions
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ */
+
+if (!module.parent) {
+  var glucose_input = process.argv.slice(2, 3).pop();
+  var cal_input = process.argv.slice(3, 4).pop();
+
+  //limit to prevent high temping
+  var max_raw = process.argv.slice(4, 5).pop();
+
+  try {
+    var cwd = process.cwd();
+    var glucose_data = safeRequire(cwd + '/' + glucose_input);
+    var cal = safeRequire(cwd + '/' + cal_input);
+
+
+    glucose_data = glucose_data.map(function each (entry) {
+      return withRawGlucose(entry, cal, max_raw);
+    });
+
+    console.log(JSON.stringify(glucose_data));
+
+  } catch (e) {
+    return console.error("Could not parse input data: ", e);
+  }
+
+}

--- a/lib/require-utils.js
+++ b/lib/require-utils.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var fs = require('fs');
+
+function safeRequire (path) {
+  var resolved;
+
+  try {
+    resolved = require(path);
+  } catch (e) {
+    console.error("Could not require: " + path, e);
+  }
+
+  return resolved;
+}
+
+function requireWithTimestamp (path) {
+  var resolved = safeRequire(path);
+
+  if (resolved) {
+    resolved.timestamp = fs.statSync(path).mtime;
+  }
+
+  return resolved;
+}
+
+
+module.exports = {
+  safeRequire: safeRequire
+  , requireWithTimestamp: requireWithTimestamp
+};

--- a/lib/with-raw-glucose.js
+++ b/lib/with-raw-glucose.js
@@ -1,0 +1,38 @@
+'use strict';
+
+function cleanCal (cal) {
+  var clean = {
+    scale: parseFloat(cal.scale) || 0
+    , intercept: parseFloat(cal.intercept) || 0
+    , slope: parseFloat(cal.slope) || 0
+  };
+
+  clean.valid = ! (clean.slope === 0 || clean.unfiltered === 0 || clean.scale === 0);
+
+  return clean;
+}
+
+module.exports = function withRawGlucose (entry, cal, maxRaw) {
+  maxRaw = maxRaw || 150;
+
+  var glucose = entry.glucose || entry.sgv || 0;
+
+  entry.unfiltered = parseInt(entry.unfiltered) || 0;
+  entry.filtered = parseInt(entry.filtered) || 0;
+
+  cal = cleanCal(cal);
+
+  if (cal.valid && (cal.filtered === 0 || glucose < 40)) {
+    entry.raw = Math.round(cal.scale * (entry.unfiltered - cal.intercept) / cal.slope);
+  } else if (cal.valid) {
+    var ratio = cal.scale * (entry.filtered - cal.intercept) / cal.slope / glucose;
+    entry.raw = Math.round(cal.scale * (entry.unfiltered - cal.intercept) / cal.slope / ratio);
+  }
+
+  if (entry.raw && (entry.glucose < 40 || !entry.glucose) && entry.raw < maxRaw) {
+    entry.glucose = entry.raw;
+    entry.fromRaw = true;
+  }
+
+  return entry;
+};

--- a/tests/with-raw-glucose.test.js
+++ b/tests/with-raw-glucose.test.js
@@ -26,7 +26,7 @@ describe('IOB', function ( ) {
     entry.raw.should.equal(115);
   });
 
-  it('should add raw glucose, but set missing glucose above maxRaw', function ( ) {
+  it('should add raw glucose, but not set missing glucose above maxRaw', function ( ) {
     var entry = {unfiltered: 143680, filtered: 141232, noise: 1};
     withRawGlucose(entry, cal, 150);
 

--- a/tests/with-raw-glucose.test.js
+++ b/tests/with-raw-glucose.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var should = require('should');
+var withRawGlucose = require('../lib/with-raw-glucose');
+
+var cal = {
+  scale: 1
+  , intercept: 25717.82377004309
+  , slope: 766.895601715918
+};
+
+describe('IOB', function ( ) {
+  it('should add raw glucose and not mess with real glucose', function ( ) {
+    var entry = {unfiltered: 113680, filtered: 111232, glucose: 110, noise: 1};
+    withRawGlucose(entry, cal);
+
+    entry.glucose.should.equal(110);
+    entry.raw.should.equal(113);
+  });
+
+  it('should add raw glucose and set missing glucose', function ( ) {
+    var entry = {unfiltered: 113680, filtered: 111232, noise: 1};
+    withRawGlucose(entry, cal);
+
+    entry.glucose.should.equal(115);
+    entry.raw.should.equal(115);
+  });
+
+  it('should add raw glucose, but set missing glucose above maxRaw', function ( ) {
+    var entry = {unfiltered: 143680, filtered: 141232, noise: 1};
+    withRawGlucose(entry, cal, 150);
+
+    should.not.exist(entry.glucose);
+    entry.raw.should.equal(154);
+  });
+
+  it('should add raw glucose, and set missing glucose when maxRaw is higher', function ( ) {
+    var entry = {unfiltered: 143680, filtered: 141232, noise: 1};
+    withRawGlucose(entry, cal, 250);
+
+    entry.glucose.should.equal(154);
+    entry.raw.should.equal(154);
+  });
+
+});


### PR DESCRIPTION
I want to be able to use raw bg in some times, but also want to be safe about it.  In this first pass theres a `maxRaw` that defaults to 150.  The tool will always add a `raw` field, but will only set `glucose` to `raw` when `glucose` is missing or `< 40` and `raw < maxRaw` to prevent a lot high temping from raw.

Might be good to add some limits around the delta to ignore big swings.

This should be helpful with the wixel too.