### PR TITLE
Lower max override from 100 to 90

### DIFF
--- a/lib/profile/targets.js
+++ b/lib/profile/targets.js
@@ -25,7 +25,7 @@ function lookup (inputs) {
 
 function bound_target_range (target) {
     // hard-code lower bounds for min_bg and max_bg in case pump is set too low, or units are wrong
-    target.max_bg = Math.max(100, target.high);
+    target.max_bg = Math.max(90, target.high);
     target.min_bg = Math.max(90, target.low);
     // hard-code upper bound for min_bg in case pump is set too high
     target.min_bg = Math.min(200, target.min_bg);


### PR DESCRIPTION
Change from 100 to 90 as it is meant to be a minimum bound in case of user entry error. In this case a user (me) is trying to set it to 90 on purpose which is a reasonable value.