### PR TITLE
Wip/bewest/autoconfigure ns

### DIFF
--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -15,18 +15,92 @@ $self <cmd>
 * latest-openaps-treatment
 * cull-latest-openaps-treatments
 
-* ns-get
-* ns-upload
-* ns-dedupe-treatments
-* ns-status
-* ns-upload-entries
+* get
+* upload
+* dedupe-treatments
+* status
+* upload-entries
+* autoconfigure-device-crud
 
 EOF
 }
 
+function setup_help ( ) {
+
+cat <<EOF
+$self autoconfigure-device-crud <NIGHTSCOUT_HOST> <API_SECRET>
+
+sets up:
+openaps use ns shell get entries.json 'count=10'
+openaps use ns shell upload treatments.json recently/combined-treatments.json
+EOF
+}
+
+function ns_help ( ) {
+cat <<EOF
+TODO: improve help
+openaps use ns shell get entries.json 'count=10'
+openaps use ns shell upload treatments.json recently/combined-treatments.json
+EOF
+}
 case $NAME in
 latest-openaps-treatment)
   ns-get treatments.json'?find[enteredBy]=/openaps:\/\//&count=1' $* | json 0
+  ;;
+ns)
+  NIGHTSCOUT_HOST=$1
+  API_SECRET=$2
+  OP=$3
+  shift
+  shift
+  shift
+
+  case $OP in
+    -h|--help|help)
+    ns_help
+    exit 0
+    ;;
+    get)
+    exec ns-get host $NIGHTSCOUT_HOST $*
+    ;;
+    upload)
+    exec ns-upload $NIGHTSCOUT_HOST $API_SECRET $*
+    ;;
+    *)
+    echo "Unknown request:" $OP
+    ns_help
+    exit 1;
+    ;;
+  esac
+
+  ;;
+hash-api-secret)
+  if [[ -z "$1" ]] ; then
+    echo "Missing plain Nightscout passphrase".
+    echo "Usage: $self hash-api-secret 'myverylongsecret'".
+    exit 1;
+  fi
+  API_SECRET=$(echo -n $1 | sha1sum | cut -d ' ' -f 1 | tr -d "\n")
+  echo $API_SECRET
+  ;;
+autoconfigure-device-crud)
+  NIGHTSCOUT_HOST=$1
+  PLAIN_NS_SECRET=$2
+  API_SECRET=$($self hash-api-secret $2)
+  case $1 in
+    help|-h|--help)
+      setup_help
+      exit 0
+      ;;
+  esac
+  # openaps device add ns-get host
+  test -z "$NIGHTSCOUT_HOST" && setup_help && exit 1;
+  test -z "$API_SECRET" && setup_help && exit 1;
+  openaps device add ns process --require "oper remote input" nightscout ns "NIGHTSCOUT_HOST" "API_SECRET"
+  openaps device show ns --json | json \
+    | json -e "this.extra.args = this.extra.args.replace(' NIGHTSCOUT_HOST ', ' $NIGHTSCOUT_HOST ')" \
+    | json -e "this.extra.args = this.extra.args.replace(' API_SECRET', ' $API_SECRET')" \
+    | openaps import
   ;;
 cull-latest-openaps-treatments)
   INPUT=$1

--- a/bin/ns-get.sh
+++ b/bin/ns-get.sh
@@ -40,6 +40,8 @@ EOF
     QUERY=${4}
     OUTPUT=${5-/dev/fd/1}
     REPORT_ENDPOINT=$NIGHTSCOUT_HOST/api/v1/${REPORT}'?'${QUERY}
+    test -z "$NIGHTSCOUT_HOST" && usage && exit 1;
+    curl -g -s $REPORT_ENDPOINT | json
 
     ;;
   type)

--- a/bin/ns-upload.sh
+++ b/bin/ns-upload.sh
@@ -54,6 +54,12 @@ EOF
 fi
 # requires API_SECRET and NIGHTSCOUT_HOST to be set in calling environment
 # (i.e. in crontab)
+if [[ "$ENTRIES" != "-" ]] ; then
+  if [[ ! -f $ENTRIES ]] ; then
+    echo "Input file $ENTRIES" does not exist.
+    exit 1;
+  fi
+fi
 (test "$ENTRIES" != "-" && cat $ENTRIES || cat )| (
 curl -m 30 -s -X POST --data-binary @- \
   -H "API-SECRET: $API_SECRET" \

--- a/bin/oref0-copy-fresher
+++ b/bin/oref0-copy-fresher
@@ -1,0 +1,37 @@
+#!/bin/bash
+self=$(basename $0)
+WITHIN=0
+
+function usage ( ) {
+cat <<EOF
+$self [--since <seconds|0>] <file> [<file>...]
+cat files mentioned.
+If --since seconds is specified, the file will only be cat'd if the files last
+modification occurred within <seconds>.
+Default <seconds> is 0, it will cat all files.
+EOF
+}
+case $1 in
+  --help|-h|help)
+    usage
+    exit 0
+    ;;
+  --since)
+    shift
+    WITHIN=$1
+    shift
+  ;;
+esac
+
+
+for file in $* ; do
+  if [[ -f $file && ($WITHIN -eq 0 || $(expr $(date +%s) - $(date +%s -r $file)) -lt $WITHIN) ]] ; then
+    cat $file
+  fi
+done
+
+
+ # 2783  test $(expr $(date +%s) - $(date +%s  -r openaps.ini )) -gt 1000  && echo "OK" || echo "NOT"
+ # 2784  test $(expr $(date +%s) - $(date +%s  -r openaps.ini )) -gt 1000000  && echo "OK" || echo "NOT"
+ # 2785  history | tail -n 3 > blah
+

--- a/bin/oref0-template.js
+++ b/bin/oref0-template.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+
+
+var argv = require('yargs')
+  .usage("$0 <cmd> <type> [args]")
+  /*
+  .option('', {
+  })
+  */
+  .command('mint <type>', 'generate template for import', require('oref0/lib/templates/'))
+  // .choices('type', ['devices', 'reports', 'alias', '*'])
+  /*
+  .command('devices', 'generate common device loops', function (yargs) {
+    return yargs.option('b', {
+      alias: 'bar'
+    });
+  })
+  */
+  .help('help')
+  .alias('h', 'help')
+  .completion( )
+  .strict( )
+  .argv
+  ;
+
+// console.log('after', argv);

--- a/lib/templates/exported-loop.json
+++ b/lib/templates/exported-loop.json
@@ -1,0 +1,687 @@
+[
+  {
+    "type": "alias",
+    "name": "rm-warmup",
+    "rm-warmup": {
+      "command": "! bash -c \"rm -f model.json monitor/clock.json > /dev/null\""
+    }
+  },
+  {
+    "type": "alias",
+    "name": "warmup",
+    "warmup": {
+      "command": "report invoke model.json raw-pump/clock-raw.json monitor/clock.json"
+    }
+  },
+  {
+    "fail-warmup": {
+      "command": "! bash -c \"echo PREFLIGHT FAIL; exit 1\""
+    },
+    "type": "alias",
+    "name": "fail-warmup"
+  },
+  {
+    "type": "alias",
+    "preflight": {
+      "command": "! bash -c \"(openaps rm-warmup; echo PREFLIGHT ) && openaps warmup 2>&1 >/dev/null && grep -q T monitor/clock.json && echo PREFLIGHT OK || openaps fail-warmup\""
+    },
+    "name": "preflight"
+  },
+  {
+    "type": "alias",
+    "name": "monitor-cgm",
+    "monitor-cgm": {
+      "command": "report invoke monitor/glucose-raw.json monitor/glucose.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "monitor-pump-history",
+    "monitor-pump-history": {
+      "command": "report invoke monitor/pump-history-raw.json monitor/pump-history.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "get-basal-status",
+    "get-basal-status": {
+      "command": "report invoke monitor/temp-basal-status.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "get-pump-details",
+    "get-pump-details": {
+      "command": "report invoke monitor/reservoir.json monitor/status.json monitor/battery.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "get-settings",
+    "get-settings": {
+      "command": "report invoke settings/bg-targets-raw.json settings/bg-targets.json settings/insulin-sensitivities-raw.json settings/insulin-sensitivities.json settings/selected-basal-profile.json settings/settings.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "gather-pump-data",
+    "gather-pump-data": {
+      "command": "! bash -c \"openaps get-basal-status; openaps get-pump-details; openaps monitor-pump-history;  openaps get-settings\""
+    }
+  },
+  {
+    "type": "alias",
+    "name": "gather-clean-data",
+    "gather-clean-data": {
+      "command": "! bash -c \"openaps monitor-cgm && openaps gather-pump-data\""
+    }
+  },
+  {
+    "type": "alias",
+    "name": "do-oref0",
+    "do-oref0": {
+      "command": "report invoke oref0-monitor/profile.json oref0-monitor/iob.json oref0-predict/oref0.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "enact-oref0",
+    "enact-oref0": {
+      "command": "report invoke oref0-enacted/enacted-temp-basal.json"
+    }
+  },
+  {
+    "do-everything": {
+      "command": "! bash -c \"openaps preflight && openaps gather-clean-data && openaps do-oref0 && openaps enact-oref0\""
+    },
+    "type": "alias",
+    "name": "do-everything"
+  },
+  {
+    "type": "alias",
+    "ping": {
+      "command": "! echo PING"
+    },
+    "name": "ping"
+  },
+  {
+    "pong": {
+      "command": "! echo PONG"
+    },
+    "type": "alias",
+    "name": "pong"
+  },
+  {
+    "type": "alias",
+    "name": "hello",
+    "hello": {
+      "command": "! echo hello"
+    }
+  },
+  {
+    "type": "vendor",
+    "name": "mmeowlink.vendors.mmeowlink",
+    "mmeowlink.vendors.mmeowlink": {
+      "path": ".",
+      "module": "mmeowlink.vendors.mmeowlink"
+    }
+  },
+  {
+    "type": "vendor",
+    "name": "openxshareble",
+    "openxshareble": {
+      "path": ".",
+      "module": "openxshareble"
+    }
+  },
+  {
+    "openapscontrib.timezones": {
+      "path": ".",
+      "module": "openapscontrib.timezones"
+    },
+    "type": "vendor",
+    "name": "openapscontrib.timezones"
+  },
+  {
+    "openapscontrib.mmhistorytools": {
+      "path": ".",
+      "module": "openapscontrib.mmhistorytools"
+    },
+    "type": "vendor",
+    "name": "openapscontrib.mmhistorytools"
+  },
+  {
+    "pancreabble": {
+      "path": ".",
+      "module": "pancreabble"
+    },
+    "type": "vendor",
+    "name": "pancreabble"
+  },
+  {
+    "main": {
+      "phases": "",
+      "rrule": "RRULE:FREQ=MINUTELY;INTERVAL=1"
+    },
+    "type": "schedule",
+    "name": "main"
+  },
+  {
+    "do-everything": {
+      "phases": "",
+      "rrule": "RRULE:FREQ=MINUTELY;INTERVAL=1"
+    },
+    "type": "schedule",
+    "name": "do-everything"
+  },
+  {
+    "pump": {
+      "vendor": "mmeowlink.vendors.mmeowlink",
+      "extra": "pump.ini"
+    },
+    "type": "device",
+    "name": "pump",
+    "extra": {
+      "serial": "000000",
+      "radio_type": "subg_rfspy",
+      "port": "/dev/serial/by-id/usb-Nightscout_subg_rfspy_000002-if00"
+    }
+  },
+  {
+    "extra": {
+      "fields": "",
+      "cmd": "oref0",
+      "args": ""
+    },
+    "type": "device",
+    "name": "oref0",
+    "oref0": {
+      "vendor": "openaps.vendors.process",
+      "extra": "oref0.ini"
+    }
+  },
+  {
+    "extra": {
+      "fields": "settings bg-targets insulin-sensitivities basal-profile max-iob",
+      "cmd": "oref0",
+      "args": "get-profile"
+    },
+    "type": "device",
+    "name": "get-profile",
+    "get-profile": {
+      "vendor": "openaps.vendors.process",
+      "extra": "get-profile.ini"
+    }
+  },
+  {
+    "type": "device",
+    "calculate-iob": {
+      "vendor": "openaps.vendors.process",
+      "extra": "calculate-iob.ini"
+    },
+    "name": "calculate-iob",
+    "extra": {
+      "fields": "pump-history oref0-profile clock",
+      "cmd": "oref0",
+      "args": "calculate-iob"
+    }
+  },
+  {
+    "determine-basal": {
+      "vendor": "openaps.vendors.process",
+      "extra": "determine-basal.ini"
+    },
+    "type": "device",
+    "name": "determine-basal",
+    "extra": {
+      "fields": "oref0-iob temp-basal glucose oref0-profile",
+      "cmd": "oref0",
+      "args": "determine-basal"
+    }
+  },
+  {
+    "type": "device",
+    "tz": {
+      "vendor": "openapscontrib.timezones",
+      "extra": "tz.ini"
+    },
+    "name": "tz",
+    "extra": {}
+  },
+  {
+    "units": {
+      "vendor": "openaps.vendors.units",
+      "extra": "units.ini"
+    },
+    "type": "device",
+    "name": "units",
+    "extra": {}
+  },
+  {
+    "extra": {},
+    "type": "device",
+    "name": "mmhistorytools",
+    "mmhistorytools": {
+      "vendor": "openapscontrib.mmhistorytools",
+      "extra": "mmhistorytools.ini"
+    }
+  },
+  {
+    "type": "device",
+    "cgm": {
+      "vendor": "openxshareble",
+      "extra": "cgm.ini"
+    },
+    "name": "cgm",
+    "extra": {
+      "serial": "SM12345678"
+    }
+  },
+  {
+    "pong": {
+      "vendor": "openaps.vendors.process",
+      "extra": "pong.ini"
+    },
+    "type": "device",
+    "name": "pong",
+    "extra": {
+      "fields": "thing",
+      "cmd": "echo",
+      "args": ""
+    }
+  },
+  {
+    "ns": {
+      "vendor": "openaps.vendors.process",
+      "extra": "ns.ini"
+    },
+    "type": "device",
+    "name": "ns",
+    "extra": {
+      "fields": "oper remote input",
+      "cmd": "nightscout",
+      "args": "ns myhost.com 143505794bdd283f7daed50f42d201b6926892c8"
+    }
+  },
+  {
+    "pebble": {
+      "vendor": "pancreabble",
+      "extra": "pebble.ini"
+    },
+    "type": "device",
+    "name": "pebble",
+    "extra": {}
+  },
+  {
+    "DoPing": {
+      "then": ""
+    },
+    "type": "trigger",
+    "name": "DoPing"
+  },
+  {
+    "type": "trigger",
+    "ping": {
+      "then": "pong"
+    },
+    "name": "ping"
+  },
+  {
+    "pong": {
+      "then": ""
+    },
+    "type": "trigger",
+    "name": "pong"
+  },
+  {
+    "settings/settings.json": {
+      "device": "pump",
+      "use": "read_settings",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "settings/settings.json"
+  },
+  {
+    "type": "report",
+    "name": "settings/bg-targets-raw.json",
+    "settings/bg-targets-raw.json": {
+      "device": "pump",
+      "use": "read_bg_targets",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "settings/bg-targets.json": {
+      "device": "units",
+      "to": "mg/dL",
+      "use": "bg_targets",
+      "input": "raw-pump/bg-targets-raw.json",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "settings/bg-targets.json"
+  },
+  {
+    "settings/insulin-sensitivities-raw.json": {
+      "device": "pump",
+      "use": "read_insulin_sensitivities",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "settings/insulin-sensitivities-raw.json"
+  },
+  {
+    "type": "report",
+    "name": "settings/insulin-sensitivities.json",
+    "settings/insulin-sensitivities.json": {
+      "device": "units",
+      "to": "mg/dL",
+      "use": "insulin_sensitivities",
+      "input": "raw-pump/insulin-sensitivities-raw.json",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "type": "report",
+    "name": "settings/selected-basal-profile.json",
+    "settings/selected-basal-profile.json": {
+      "device": "pump",
+      "use": "read_selected_basal_profile",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/clock-raw.json": {
+      "device": "pump",
+      "use": "read_clock",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/clock-raw.json"
+  },
+  {
+    "monitor/clock.json": {
+      "use": "clock",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "None",
+      "adjust": "missing",
+      "timezone": "PST",
+      "device": "tz",
+      "input": "raw-pump/clock-raw.json"
+    },
+    "type": "report",
+    "name": "monitor/clock.json"
+  },
+  {
+    "monitor/temp-basal-status.json": {
+      "device": "pump",
+      "use": "read_temp_basal",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/temp-basal-status.json"
+  },
+  {
+    "monitor/pump-history-raw.json": {
+      "hours": "8.0",
+      "device": "pump",
+      "use": "iter_pump_hours",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/pump-history-raw.json"
+  },
+  {
+    "monitor/pump-history.json": {
+      "use": "rezone",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "timestamp dateString start_at end_at created_at",
+      "adjust": "missing",
+      "timezone": "PST",
+      "device": "tz",
+      "input": "raw-pump/pump-history-raw.json"
+    },
+    "type": "report",
+    "name": "monitor/pump-history.json"
+  },
+  {
+    "type": "report",
+    "name": "model.json",
+    "model.json": {
+      "device": "pump",
+      "use": "model",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/reservoir.json": {
+      "device": "pump",
+      "use": "reservoir",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/reservoir.json"
+  },
+  {
+    "type": "report",
+    "name": "monitor/status.json",
+    "monitor/status.json": {
+      "device": "pump",
+      "use": "read_status",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/battery.json": {
+      "device": "pump",
+      "use": "read_battery_status",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/battery.json"
+  },
+  {
+    "type": "report",
+    "name": "oref0-monitor/profile.json",
+    "oref0-monitor/profile.json": {
+      "insulin-sensitivities": "settings/insulin-sensitivities.json",
+      "use": "shell",
+      "settings": "settings/settings.json",
+      "reporter": "text",
+      "json_default": "True",
+      "device": "get-profile",
+      "bg-targets": "settings/bg-targets.json",
+      "basal-profile": "settings/selected-basal-profile.json",
+      "max-iob": "max-iob.json",
+      "remainder": ""
+    }
+  },
+  {
+    "type": "report",
+    "name": "oref0-monitor/iob.json",
+    "oref0-monitor/iob.json": {
+      "use": "shell",
+      "clock": "monitor/clock.json",
+      "reporter": "text",
+      "json_default": "True",
+      "pump-history": "monitor/pump-history.json",
+      "oref0-profile": "oref0-monitor/profile.json",
+      "device": "calculate-iob",
+      "remainder": ""
+    }
+  },
+  {
+    "type": "report",
+    "name": "oref0-predict/oref0.json",
+    "oref0-predict/oref0.json": {
+      "use": "shell",
+      "oref0-iob": "oref0-monitor/iob.json",
+      "temp-basal": "monitor/temp-basal-status.json",
+      "reporter": "text",
+      "json_default": "True",
+      "oref0-profile": "oref0-monitor/profile.json",
+      "device": "determine-basal",
+      "remainder": "",
+      "glucose": "monitor/glucose.json"
+    }
+  },
+  {
+    "type": "report",
+    "name": "oref0-enacted/enacted-temp-basal.json",
+    "oref0-enacted/enacted-temp-basal.json": {
+      "device": "pump",
+      "input": "oref0-predict/oref0.json",
+      "use": "set_temp_basal",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/glucose-raw.json": {
+      "count": "20",
+      "device": "cgm",
+      "use": "iter_glucose",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/glucose-raw.json"
+  },
+  {
+    "type": "report",
+    "name": "monitor/glucose.json",
+    "monitor/glucose.json": {
+      "use": "rezone",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "timestamp dateString start_at end_at created_at",
+      "adjust": "missing",
+      "timezone": "PST",
+      "device": "tz",
+      "input": "raw-cgm/glucose-raw.json"
+    }
+  },
+  {
+    "cgm-vendor.json": {
+      "device": "cgm",
+      "use": "GetFirmwareHeader",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "cgm-vendor.json"
+  },
+  {
+    "blah.txt": {
+      "thing": "foo",
+      "use": "shell",
+      "reporter": "text",
+      "device": "pong",
+      "remainder": "bar",
+      "json_default": "False"
+    },
+    "type": "report",
+    "name": "blah.txt"
+  },
+  {
+    "raw-pump/settings.json": {
+      "device": "pump",
+      "use": "read_settings",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/settings.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-pump/bg-targets-raw.json",
+    "raw-pump/bg-targets-raw.json": {
+      "device": "pump",
+      "use": "read_bg_targets",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/insulin-sensitivities-raw.json": {
+      "device": "pump",
+      "use": "read_insulin_sensitivities",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/insulin-sensitivities-raw.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-pump/selected-basal-profile.json",
+    "raw-pump/selected-basal-profile.json": {
+      "device": "pump",
+      "use": "read_selected_basal_profile",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/clock-raw.json": {
+      "device": "pump",
+      "use": "read_clock",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/clock-raw.json"
+  },
+  {
+    "raw-pump/temp-basal-status.json": {
+      "device": "pump",
+      "use": "read_temp_basal",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/temp-basal-status.json"
+  },
+  {
+    "raw-pump/pump-history-raw.json": {
+      "hours": "8.0",
+      "device": "pump",
+      "use": "iter_pump_hours",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/pump-history-raw.json"
+  },
+  {
+    "raw-pump/reservoir.json": {
+      "device": "pump",
+      "use": "reservoir",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/reservoir.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-pump/status.json",
+    "raw-pump/status.json": {
+      "device": "pump",
+      "use": "read_status",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/battery.json": {
+      "device": "pump",
+      "use": "read_battery_status",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/battery.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-cgm/glucose-raw.json",
+    "raw-cgm/glucose-raw.json": {
+      "count": "20",
+      "device": "cgm",
+      "use": "iter_glucose",
+      "reporter": "JSON"
+    }
+  }
+]

--- a/lib/templates/index.js
+++ b/lib/templates/index.js
@@ -1,0 +1,96 @@
+
+
+exports.xyzbuilder = {
+  foo: {
+    default: 'ok'
+  },
+  baz: {
+    default: 'optional'
+  }
+
+};
+
+var reference = require('./exported-loop.json');
+
+
+function oref0_reports (argv) {
+  var reference = require('./some-reports');
+  var devs = [ ];
+  if (argv.oref0) {
+    reference.forEach(function (item) {
+      if (item.type == 'report') {
+        // if (item[item.name].device == 'pump') {
+        if ([null, 'get-profile', 'calculate-iob', 'determine-basal'].indexOf(item[item.name].device) > 0) {
+          devs.push(item);
+        }
+      }
+    });
+
+  }
+  console.log(JSON.stringify(devs, '  '));
+}
+
+function oref0_devices (argv) {
+  var devs = [ ];
+  if (argv.oref0) {
+    reference.forEach(function (item) {
+      if (item.type == 'device') {
+        if (item.extra.cmd == 'oref0') {
+          devs.push(item);
+        }
+      }
+    });
+
+  }
+  console.log(JSON.stringify(devs, '  '));
+}
+
+function per_type (yargs) {
+  return yargs
+     .command('oref0', 'generate oref0 devices', {oref0: {default: true}}, oref0_devices)
+    ;
+}
+
+function per_shape (yargs) {
+  return yargs
+     .command('oref0-inputs', 'generate reports for oref0', {oref0: {default: true}}, oref0_reports)
+     .command('medtronic-pump', 'organize output from medtronic pump', {name: {default: 'pump'}}, medtronic_pump_reports)
+     // .command('glucose', '', { }, oref0_reports)
+    ;
+}
+
+function medtronic_pump_reports (argv) {
+  var reference = require('./medtronic-pump-reports');
+  var out = [ ];
+  reference.forEach(function (item) {
+    if (item[item.name].device == 'pump') {
+      if (argv.name != 'pump') {
+        item[item.name].device = argv.name;
+      }
+    }
+    out.push(item);
+  });
+  console.log(JSON.stringify(out));
+  return out;
+}
+
+function run ( ) {
+}
+
+exports.builder = function (yargs) {
+  return yargs
+     .command('device <type>', 'generate devices', per_type, run)
+     .command('reports <shape>', 'generate reports', per_shape, run)
+     .strict( )
+     // .usage('$0 mint <type>')
+     // .demand('type', 1)
+     // .choices('type', ['devices', 'reports', 'alias', '*'])
+     // .options('bazbaz', { default: 'blah' })
+    ;
+}
+
+exports.handler = function (argv) {
+  // console.log('args', argv);
+  // return argv.command(
+
+}

--- a/lib/templates/medtronic-pump-reports.json
+++ b/lib/templates/medtronic-pump-reports.json
@@ -1,0 +1,233 @@
+[
+  {
+    "type": "report",
+    "name": "raw-pump/bg-targets-raw.json",
+    "raw-pump/bg-targets-raw.json": {
+      "device": "pump",
+      "use": "read_bg_targets",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "settings/bg-targets.json": {
+      "device": "units",
+      "to": "mg/dL",
+      "use": "bg_targets",
+      "input": "raw-pump/bg-targets-raw.json",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "settings/bg-targets.json"
+  },
+  {
+    "raw-pump/insulin-sensitivities-raw.json": {
+      "device": "pump",
+      "use": "read_insulin_sensitivities",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/insulin-sensitivities-raw.json"
+  },
+  {
+    "type": "report",
+    "name": "settings/insulin-sensitivities.json",
+    "settings/insulin-sensitivities.json": {
+      "device": "units",
+      "to": "mg/dL",
+      "use": "insulin_sensitivities",
+      "input": "raw-pump/insulin-sensitivities-raw.json",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/clock-raw.json": {
+      "device": "pump",
+      "use": "read_clock",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/clock-raw.json"
+  },
+  {
+    "monitor/clock.json": {
+      "use": "clock",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "None",
+      "adjust": "missing",
+      "device": "tz",
+      "input": "raw-pump/clock-raw.json"
+    },
+    "type": "report",
+    "name": "monitor/clock.json"
+  },
+  {
+    "monitor/temp-basal-status.json": {
+      "device": "pump",
+      "use": "read_temp_basal",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/temp-basal-status.json"
+  },
+  {
+    "type": "report",
+    "name": "oref0-predict/oref0.json",
+    "oref0-predict/oref0.json": {
+      "use": "shell",
+      "oref0-iob": "oref0-monitor/iob.json",
+      "temp-basal": "monitor/temp-basal-status.json",
+      "reporter": "text",
+      "json_default": "True",
+      "oref0-profile": "oref0-monitor/profile.json",
+      "device": "determine-basal",
+      "remainder": "",
+      "glucose": "monitor/glucose.json"
+    }
+  },
+  {
+    "raw-pump/pump-history-raw.json": {
+      "hours": "8.0",
+      "device": "pump",
+      "use": "iter_pump_hours",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/pump-history-raw.json"
+  },
+  {
+    "monitor/pump-history.json": {
+      "use": "rezone",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "timestamp dateString start_at end_at created_at",
+      "adjust": "missing",
+      "device": "tz",
+      "input": "raw-pump/pump-history-raw.json"
+    },
+    "type": "report",
+    "name": "monitor/pump-history.json"
+  },
+  {
+    "type": "report",
+    "name": "model.json",
+    "model.json": {
+      "device": "pump",
+      "use": "model",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/reservoir.json": {
+      "device": "pump",
+      "use": "reservoir",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/reservoir.json"
+  },
+  {
+    "type": "report",
+    "name": "monitor/status.json",
+    "monitor/status.json": {
+      "device": "pump",
+      "use": "read_status",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/battery.json": {
+      "device": "pump",
+      "use": "read_battery_status",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/battery.json"
+  },
+  {
+    "type": "report",
+    "name": "oref0-enacted/enacted-temp-basal.json",
+    "oref0-enacted/enacted-temp-basal.json": {
+      "device": "pump",
+      "input": "oref0-predict/oref0.json",
+      "use": "set_temp_basal",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "settings/settings.json": {
+      "device": "oref0",
+      "remainder": "copy-fresher raw-pump/settings.json",
+      "use": "shell",
+      "json_default": "True",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "settings/settings.json"
+  },
+  {
+    "raw-pump/settings.json": {
+      "device": "pump",
+      "use": "read_settings",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/settings.json"
+  },
+  {
+    "type": "report",
+    "name": "settings/selected-basal-profile.json",
+    "settings/selected-basal-profile.json": {
+      "device": "oref0",
+      "remainder": "copy-fresher raw-pump/selected-basal-profile.json",
+      "use": "shell",
+      "json_default": "True",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "type": "report",
+    "name": "raw-pump/selected-basal-profile.json",
+    "raw-pump/selected-basal-profile.json": {
+      "device": "pump",
+      "use": "read_selected_basal_profile",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/temp-basal-status.json": {
+      "device": "pump",
+      "use": "read_temp_basal",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/temp-basal-status.json"
+  },
+  {
+    "raw-pump/reservoir.json": {
+      "device": "pump",
+      "use": "reservoir",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/reservoir.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-pump/status.json",
+    "raw-pump/status.json": {
+      "device": "pump",
+      "use": "read_status",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/battery.json": {
+      "device": "pump",
+      "use": "read_battery_status",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/battery.json"
+  }
+]

--- a/lib/templates/oref0-devices.json
+++ b/lib/templates/oref0-devices.json
@@ -1,0 +1,54 @@
+[
+  {
+    "extra": {
+      "fields": "",
+      "cmd": "oref0",
+      "args": ""
+    },
+    "type": "device",
+    "name": "oref0",
+    "oref0": {
+      "vendor": "openaps.vendors.process",
+      "extra": "oref0.ini"
+    }
+  },
+  {
+    "extra": {
+      "fields": "settings bg-targets insulin-sensitivities basal-profile max-iob",
+      "cmd": "oref0",
+      "args": "get-profile"
+    },
+    "type": "device",
+    "name": "get-profile",
+    "get-profile": {
+      "vendor": "openaps.vendors.process",
+      "extra": "get-profile.ini"
+    }
+  },
+  {
+    "type": "device",
+    "calculate-iob": {
+      "vendor": "openaps.vendors.process",
+      "extra": "calculate-iob.ini"
+    },
+    "name": "calculate-iob",
+    "extra": {
+      "fields": "pump-history oref0-profile clock",
+      "cmd": "oref0",
+      "args": "calculate-iob"
+    }
+  },
+  {
+    "determine-basal": {
+      "vendor": "openaps.vendors.process",
+      "extra": "determine-basal.ini"
+    },
+    "type": "device",
+    "name": "determine-basal",
+    "extra": {
+      "fields": "oref0-iob temp-basal glucose oref0-profile",
+      "cmd": "oref0",
+      "args": "determine-basal"
+    }
+  }
+]

--- a/lib/templates/some-reports.json
+++ b/lib/templates/some-reports.json
@@ -1,0 +1,320 @@
+[
+  {
+    "settings/settings.json": {
+      "device": "oref0",
+      "remainder": "copy-fresher raw-pump/settings.json",
+      "use": "shell",
+      "json_default": "True",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "settings/settings.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-pump/bg-targets-raw.json",
+    "raw-pump/bg-targets-raw.json": {
+      "device": "pump",
+      "use": "read_bg_targets",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "settings/bg-targets.json": {
+      "device": "units",
+      "to": "mg/dL",
+      "use": "bg_targets",
+      "input": "raw-pump/bg-targets-raw.json",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "settings/bg-targets.json"
+  },
+  {
+    "raw-pump/insulin-sensitivities-raw.json": {
+      "device": "pump",
+      "use": "read_insulin_sensitivities",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/insulin-sensitivities-raw.json"
+  },
+  {
+    "type": "report",
+    "name": "settings/insulin-sensitivities.json",
+    "settings/insulin-sensitivities.json": {
+      "device": "units",
+      "to": "mg/dL",
+      "use": "insulin_sensitivities",
+      "input": "raw-pump/insulin-sensitivities-raw.json",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "type": "report",
+    "name": "settings/selected-basal-profile.json",
+    "settings/selected-basal-profile.json": {
+      "device": "oref0",
+      "remainder": "copy-fresher raw-pump/selected-basal-profile.json",
+      "use": "shell",
+      "json_default": "True",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/clock-raw.json": {
+      "device": "pump",
+      "use": "read_clock",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/clock-raw.json"
+  },
+  {
+    "monitor/clock.json": {
+      "use": "clock",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "None",
+      "adjust": "missing",
+      "timezone": "PDT",
+      "device": "tz",
+      "input": "raw-pump/clock-raw.json"
+    },
+    "type": "report",
+    "name": "monitor/clock.json"
+  },
+  {
+    "monitor/temp-basal-status.json": {
+      "device": "pump",
+      "use": "read_temp_basal",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/temp-basal-status.json"
+  },
+  {
+    "raw-pump/pump-history-raw.json": {
+      "hours": "8.0",
+      "device": "pump",
+      "use": "iter_pump_hours",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/pump-history-raw.json"
+  },
+  {
+    "monitor/pump-history.json": {
+      "use": "rezone",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "timestamp dateString start_at end_at created_at",
+      "adjust": "missing",
+      "timezone": "PDT",
+      "device": "tz",
+      "input": "raw-pump/pump-history-raw.json"
+    },
+    "type": "report",
+    "name": "monitor/pump-history.json"
+  },
+  {
+    "type": "report",
+    "name": "model.json",
+    "model.json": {
+      "device": "pump",
+      "use": "model",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/reservoir.json": {
+      "device": "pump",
+      "use": "reservoir",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/reservoir.json"
+  },
+  {
+    "type": "report",
+    "name": "monitor/status.json",
+    "monitor/status.json": {
+      "device": "pump",
+      "use": "read_status",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/battery.json": {
+      "device": "pump",
+      "use": "read_battery_status",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/battery.json"
+  },
+  {
+    "type": "report",
+    "name": "oref0-monitor/profile.json",
+    "oref0-monitor/profile.json": {
+      "insulin-sensitivities": "settings/insulin-sensitivities.json",
+      "use": "shell",
+      "settings": "settings/settings.json",
+      "reporter": "text",
+      "json_default": "True",
+      "device": "get-profile",
+      "bg-targets": "settings/bg-targets.json",
+      "basal-profile": "settings/selected-basal-profile.json",
+      "max-iob": "max-iob.json",
+      "remainder": ""
+    }
+  },
+  {
+    "type": "report",
+    "name": "oref0-monitor/iob.json",
+    "oref0-monitor/iob.json": {
+      "use": "shell",
+      "clock": "monitor/clock.json",
+      "reporter": "text",
+      "json_default": "True",
+      "pump-history": "monitor/pump-history.json",
+      "oref0-profile": "oref0-monitor/profile.json",
+      "device": "calculate-iob",
+      "remainder": ""
+    }
+  },
+  {
+    "type": "report",
+    "name": "oref0-predict/oref0.json",
+    "oref0-predict/oref0.json": {
+      "use": "shell",
+      "oref0-iob": "oref0-monitor/iob.json",
+      "temp-basal": "monitor/temp-basal-status.json",
+      "reporter": "text",
+      "json_default": "True",
+      "oref0-profile": "oref0-monitor/profile.json",
+      "device": "determine-basal",
+      "remainder": "",
+      "glucose": "monitor/glucose.json"
+    }
+  },
+  {
+    "type": "report",
+    "name": "oref0-enacted/enacted-temp-basal.json",
+    "oref0-enacted/enacted-temp-basal.json": {
+      "device": "pump",
+      "input": "oref0-predict/oref0.json",
+      "use": "set_temp_basal",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "monitor/glucose-raw.json": {
+      "count": "20",
+      "device": "cgm",
+      "use": "iter_glucose",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/glucose-raw.json"
+  },
+  {
+    "type": "report",
+    "name": "monitor/glucose.json",
+    "monitor/glucose.json": {
+      "use": "rezone",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "timestamp dateString start_at end_at created_at",
+      "adjust": "missing",
+      "timezone": "PDT",
+      "device": "tz",
+      "input": "raw-cgm/glucose-raw.json"
+    }
+  },
+  {
+    "cgm-vendor.json": {
+      "device": "cgm",
+      "use": "GetFirmwareHeader",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "cgm-vendor.json"
+  },
+  {
+    "blah.txt": {
+      "thing": "foo",
+      "use": "shell",
+      "reporter": "text",
+      "device": "pong",
+      "remainder": "bar",
+      "json_default": "False"
+    },
+    "type": "report",
+    "name": "blah.txt"
+  },
+  {
+    "raw-pump/settings.json": {
+      "device": "pump",
+      "use": "read_settings",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/settings.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-pump/selected-basal-profile.json",
+    "raw-pump/selected-basal-profile.json": {
+      "device": "pump",
+      "use": "read_selected_basal_profile",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/temp-basal-status.json": {
+      "device": "pump",
+      "use": "read_temp_basal",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/temp-basal-status.json"
+  },
+  {
+    "raw-pump/reservoir.json": {
+      "device": "pump",
+      "use": "reservoir",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/reservoir.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-pump/status.json",
+    "raw-pump/status.json": {
+      "device": "pump",
+      "use": "read_status",
+      "reporter": "JSON"
+    }
+  },
+  {
+    "raw-pump/battery.json": {
+      "device": "pump",
+      "use": "read_battery_status",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "raw-pump/battery.json"
+  },
+  {
+    "type": "report",
+    "name": "raw-cgm/glucose-raw.json",
+    "raw-cgm/glucose-raw.json": {
+      "count": "20",
+      "device": "cgm",
+      "use": "iter_glucose",
+      "reporter": "JSON"
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -45,12 +45,15 @@
     "nightscout": "./bin/nightscout.sh",
     "ns-dedupe-treatments": "./bin/ns-dedupe-treatments.sh",
     "oref0-html": "./bin/oref0-html.js",
+    "oref0-template": "./bin/oref0-template.js",
+    "oref0-copy-fresher": "./bin/oref0-copy-fresher",
     "oref0-pebble": "./bin/oref0-pebble.js"
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {
     "share2nightscout-bridge": "^0.1.5",
-    "timezone": "0.0.47"
+    "timezone": "0.0.47",
+    "yargs": "~4.3.2"
   },
   "devDependencies": {
     "mocha": "^2.3.3",


### PR DESCRIPTION
Provide some tools to set up nightscout devices easily.

This actually provides a single `ns` device that can both download and upload any content to/from NS:


`openaps use ns shell get entries.json "count=10"`, vs `openaps use ns shell upload treatments.json recently/created-treatments.json` should both work as expected, as well as many variants.  Note, this relies on certain fixes to the `remainder` argument in `openaps` : https://github.com/openaps/openaps/pull/80