### PR TITLE
Now carbs.js is able to handle the pump setting "exchanges" as well

### DIFF
--- a/lib/profile/carbs.js
+++ b/lib/profile/carbs.js
@@ -6,7 +6,7 @@ function carbRatioLookup (inputs) {
     var carbratio_data = inputs.carbratio;
     if (typeof(carbratio_data) != "undefined" && typeof(carbratio_data.schedule) != "undefined") {
         var carbRatio;
-        if (carbratio_data.units == "grams") {
+        if ((carbratio_data.units == "grams") || (carbratio_data.units == "exchanges")) {
             //carbratio_data.schedule.sort(function (a, b) { return a.offset > b.offset });
             carbRatio = carbratio_data.schedule[carbratio_data.schedule.length - 1];
 
@@ -16,25 +16,14 @@ function carbRatioLookup (inputs) {
                     break;
                 }
             }
-            return carbRatio.ratio;
-        } else {
             if (carbratio_data.units == "exchanges") {
-            //carbratio_data.schedule.sort(function (a, b) { return a.offset > b.offset });
-            carbRatio = carbratio_data.schedule[carbratio_data.schedule.length - 1];
-
-            for (var i = 0; i < carbratio_data.schedule.length - 1; i++) {
-                if ((now >= getTime(carbratio_data.schedule[i].offset)) && (now < getTime(carbratio_data.schedule[i + 1].offset))) {
-                    carbRatio = carbratio_data.schedule[i];
-                    break;
-                }
+                carbRatio.ratio = 12 / carbRatio.ratio
             }
-            carbRatio.ratio = 12 / carbRatio.ratio
-            return carbRatio.ratio;
+        return carbRatio.ratio;
         } else {
             console.error("Error: Unsupported carb_ratio units " + carbratio_data.units);
             return;
         }
-    }
     //return carbRatio.ratio;
     //profile.carbratio = carbRatio.ratio;
     } else { return; }

--- a/lib/profile/carbs.js
+++ b/lib/profile/carbs.js
@@ -16,11 +16,26 @@ function carbRatioLookup (inputs) {
                     break;
                 }
             }
+            return carbRatio.ratio;
+        } else {
+            if (carbratio_data.units == "exchanges") {
+            //carbratio_data.schedule.sort(function (a, b) { return a.offset > b.offset });
+            carbRatio = carbratio_data.schedule[carbratio_data.schedule.length - 1];
+
+            for (var i = 0; i < carbratio_data.schedule.length - 1; i++) {
+                if ((now >= getTime(carbratio_data.schedule[i].offset)) && (now < getTime(carbratio_data.schedule[i + 1].offset))) {
+                    carbRatio = carbratio_data.schedule[i];
+                    break;
+                }
+            }
+            carbRatio.ratio = 12 / carbRatio.ratio
+            return carbRatio.ratio;
         } else {
             console.error("Error: Unsupported carb_ratio units " + carbratio_data.units);
             return;
         }
-    return carbRatio.ratio;
+    }
+    //return carbRatio.ratio;
     //profile.carbratio = carbRatio.ratio;
     } else { return; }
 }


### PR DESCRIPTION
I added a check for the carbratio.data == "exchanges" because this is the alternative setting to the unit "grams". If "exchanges" is used in the pump the information behind the ratio is how many insulin units are needed for 1 bread exchange unit (= 12 grams of carbohydrate). To make this entered value fitting in the Openaps system, which uses "grams" as an value that says how many grams are matching 1 unit of insulin, the carbRatio.ratio is recalculated to grams per unit in the case the pump value is based on insulin per bread exchange unit. For some users (like me) it could be better to adjust the recalculating factor from 12 to 10. This is the case if the German "Kohlenhydrateinheit" (= 10 grams of carbohydrate) is used instead of the classic bread exchange unit (= 12 grams of carbohydrate). First I was thinking about taking 11 as a mean value between this to options with a calculating error of 10 percent or even less, but then I thought that nobody in the community had a problem so far with the carb_ratio in "exchanges" and if someone has a problem like me, the possibility that he uses "Kohlenhydrateinheit" is even less. Therefor I decided to enter 12 and adjust it to 10 in my one version ;-)