### PR TITLE
Generate a warning, not a fatal error, on insufficient glucose data for autosens

### DIFF
--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -37,8 +37,8 @@ if (!module.parent) {
         var cwd = process.cwd();
         var glucose_data = require(cwd + '/' + glucose_input);
         if (glucose_data.length < 72) {
-            console.log('Error: not enough glucose data to calculate autosens.');
-            process.exit(2);
+            return console.log('{ "ratio": 1, "reason": "not enough glucose data to calculate autosens" }');
+            //process.exit(2);
         }
 
         var pumphistory_data = require(cwd + '/' + pumphistory_input);

--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -37,6 +37,7 @@ if (!module.parent) {
         var cwd = process.cwd();
         var glucose_data = require(cwd + '/' + glucose_input);
         if (glucose_data.length < 72) {
+            console.error("Optional feature autosens disabled: not enough glucose data to calculate sensitivity");
             return console.log('{ "ratio": 1, "reason": "not enough glucose data to calculate autosens" }');
             //process.exit(2);
         }


### PR DESCRIPTION
This should fix #117.

edison@edison-rl ~/openaps-dev $ openaps report invoke settings/autosens.json
detect-sensitivity://text/shell/settings/autosens.json
Optional feature autosens disabled: not enough glucose data to calculate sensitivity
reporting settings/autosens.json
edison@edison-rl ~/openaps-dev $ cat settings/autosens.json
{ "ratio": 1, "reason": "not enough glucose data to calculate autosens" }