### PR TITLE
create a cron-helper tool

### DIFF
--- a/bin/oref0.sh
+++ b/bin/oref0.sh
@@ -22,6 +22,7 @@ Valid commands:
   oref0 alias-helper  - <name> <spec>  : create/template a alias from bash commands easily
   oref0 cron-5-minute-helper  - <cmds> - generate a cron template for commands
                                          to run every 5 minutes:
+                                         oref0 cron-5-minute-helper openaps do-everything
   oref0 env                            - print information about environment.
   oref0 pebble
   oref0 ifttt-notify
@@ -29,7 +30,10 @@ Valid commands:
   oref0 calculate-iob
   oref0 meal
   oref0 determine-basal
-  oref0 export-loop  - Print a backup json representation of entire configuration.
+  oref0 export-loop [backup-loop.json] - Print a backup json representation of
+                                         entire configuration. Optionally, if a
+                                         filename is specified, listing is
+                                         saved in the file instead.
   oref0 help - this message
 EOF
 }

--- a/bin/oref0.sh
+++ b/bin/oref0.sh
@@ -18,9 +18,11 @@ $self <cmd>
     \_|__|_/ |_|  \_\ |_|____ |_|      
 
 Valid commands:
-  oref0 device-helper - <name> <spec>: create/template a device from bash commands easily
-  oref0 alias-helper - <name> <spec>: create/template a alias from bash commands easily
-  oref0 env - print information about environment.
+  oref0 device-helper - <name> <spec>  : create/template a device from bash commands easily
+  oref0 alias-helper  - <name> <spec>  : create/template a alias from bash commands easily
+  oref0 cron-5-minute-helper  - <cmds> - generate a cron template for commands
+                                         to run every 5 minutes:
+  oref0 env                            - print information about environment.
   oref0 pebble
   oref0 ifttt-notify
   oref0 get-profile
@@ -46,6 +48,18 @@ alias-helper)
   shift
   cat <<EOF
 {"type": "alias", "name": "$name", "$name": {"command": "! bash -c \"$*\" --"}}
+EOF
+  ;;
+cron-5-minute-helper)
+  name=${1-'openaps do-everything'}
+  shift
+  workdir=$(pwd)
+  cat <<EOF
+SHELL=/bin/bash
+PATH=$PATH
+
+*/5 * * * * (cd $workdir && time ${name} $*) 2>&1 | logger -t openaps-loop
+
 EOF
   ;;
 env)

--- a/bin/oref0.sh
+++ b/bin/oref0.sh
@@ -68,7 +68,8 @@ env)
   exit
   ;;
 export-loop)
-  openaps import -l | while read type ; do openaps $type show --json ; done | json -g
+  out=${1-/dev/stdout}
+  openaps import -l | while read type ; do openaps $type show --json ; done | json -g > $out
 
   exit
   ;;


### PR DESCRIPTION
Eg: `oref0 cron-5-minute-helper openaps do-everything`


```bash
$ oref0 cron-5-minute-helper openaps do-everything
SHELL=/bin/bash
PATH=/home/bewest/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/home/bewest/.cabal/bin:/home/bewest/.cabal/bin

*/5 * * * * (cd /home/bewest/Documents/foobar && time openaps do-everything) 2>&1 | logger -t openaps-loop

```

```bash
$ oref0 cron-5-minute-helper
SHELL=/bin/bash
PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games

*/5 * * * * (cd /home/edison/openaps && time openaps do-everything ) 2>&1 | logger -t openaps-loop


```

Can be used by piping into `crontab -`:


```bash
edison@ubilinux:~/openaps$ oref0 cron-5-minute-helper | crontab -
edison@ubilinux:~/openaps$ 
edison@ubilinux:~/openaps$ 
edison@ubilinux:~/openaps$ crontab -l
SHELL=/bin/bash
PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games

*/5 * * * * (cd /home/edison/openaps && time openaps do-everything ) 2>&1 | logger -t openaps-loop



```