### PR TITLE
clean up meal date logging

### DIFF
--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -28,18 +28,19 @@ function diaCarbs(opts, time) {
     var mealCOB = 0;
 
     treatments.forEach(function(treatment) {
-        now = time.getTime();
+        var now = time.getTime();
         var dia_ago = now - 1.5*profile_data.dia*60*60*1000;
-        t = new Date(tz(treatment.timestamp)).getTime();
-        if(t > dia_ago && t <= now) {
+        var treatmentDate = new Date(tz(treatment.timestamp));
+        var treatmentTime = treatmentDate.getTime();
+        if (treatmentTime > dia_ago && treatmentTime <= now) {
             if (treatment.carbs >= 1) {
-                console.error(treatment.carbs, maxCarbs, treatment.timestamp);
+                console.error(treatment.carbs, maxCarbs, treatmentDate);
                 carbs += parseFloat(treatment.carbs);
-                COB_inputs.mealTime = t;
+                COB_inputs.mealTime = treatmentTime;
                 var myCarbsAbsorbed = calcMealCOB(COB_inputs).carbsAbsorbed;
                 var myMealCOB = Math.max(0, carbs - myCarbsAbsorbed);
                 mealCOB = Math.max(mealCOB, myMealCOB);
-    console.error(mealCOB);
+                console.error(mealCOB);
             }
             if (treatment.bolus >= 0.1) {
                 boluses += parseFloat(treatment.bolus);


### PR DESCRIPTION
Since we get carbs from multiple sources, use the parsed date in logging instead of the raw `treatment.timestamp`