### PR TITLE
Various determine-basal changes

### DIFF
--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -183,7 +183,7 @@ function init() {
     };
     
     determinebasal.getLastGlucose = require('oref0/lib/glucose-get-last');
-    determinebasal.determine_basal = require('oref0/lib/determine-basal/determine-basal');
+    determinebasal.determine_basal = require('oref0/lib/determine-basal/determine-basal').determine_basal;
     return determinebasal;
 
 }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -12,14 +12,41 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
+
+function round_basal(basal) {
+	
+	/* x23 and x54 pumps change basal increment depending on how much basal is being delivered:
+			0.025u for 0.025 < x < 0.975
+			0.05u for 1 < x < 9.95
+			0.1u for 10 < x
+	  To round numbers nicely for the pump, use a scale factor of (1 / increment). */
+	
+    var rounded_result = basal;	 
+	if (basal <= 0.975)
+	{
+		rounded_basal = Math.round(basal * 40) / 40;		
+	}
+	else if (basal <= 9.95)
+	{
+		rounded_basal = Math.round(basal * 20) / 20;		
+	}
+	else
+	{
+		rounded_basal = Math.round(basal * 10) / 10;		
+	}
+
+	return rounded_basal;
+}
+
+function truncate(value, digits)
+{
+    var scale = Math.pow(10, digits);
+    return Math.round(value * scale) / scale;
+}
+
 var determine_basal = function determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, setTempBasal) {
     var rT = { //short for requestedTemp
     };
-
-    //40 gives basal rates that match a 0.025u scroll rate.
-    //80 would match 0.05, 10 would match 0.1u
-    //Was 1000 before this change (round to 2 dp)
-    var basal_scale = 40;
 
     if (typeof profile === 'undefined' || typeof profile.current_basal === 'undefined') {
         rT.error ='Error: could not get current basal rate';
@@ -28,7 +55,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var basal = profile.current_basal;
     if (typeof autosens_data !== 'undefined' ) {
         basal = profile.current_basal * autosens_data.ratio;
-        basal = Math.round(basal * basal_scale) / basal_scale;
+        basal = round_basal(basal);
         if (basal != profile.current_basal) {
             console.error("Adjusting basal from "+profile.current_basal+" to "+basal);
         }
@@ -90,9 +117,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     //calculate BG impact: the amount BG "should" be rising or falling based on insulin activity alone
-    var bgi = Math.round(( -iob_data.activity * sens * 5 )*100)/100;
+    var bgi = truncate(( -iob_data.activity * sens * 5 ), 2);
     // project positive deviations for 15 minutes
-    var deviation = Math.round( 15 / 5 * ( minDelta - bgi ) );
+    var deviation = Math.round( 15 / 5 * (minDelta - bgi ) ) ;
     // project negative deviations for 30 minutes
     if (deviation < 0) {
         deviation = Math.round( 30 / 5 * ( glucose_status.avgdelta - bgi ) );
@@ -113,8 +140,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // adjust that for deviation like we did eventualBG
     var snoozeBG = naive_snoozeBG + deviation;
     
-
-    var expectedDelta = Math.round(( bgi + ( target_bg - eventualBG ) / ( profile.dia * 60 / 5 ) )*10)/10;
+    var dia_in_5min_blocks = (profile.dia * 60) / 5;
+    var target_delta = target_bg - eventualBG;
+    var expectedDelta = truncate(bgi + (target_delta / dia_in_5min_blocks), 1);
 
     if (typeof eventualBG === 'undefined' || isNaN(eventualBG)) { 
         rT.error ='Error: could not calculate eventualBG';
@@ -156,9 +184,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         mealAssist=1;
     } else {
         // phase in mealAssist, as a fraction
-        mealAssist = Math.max(0, Math.round( Math.min(deviation/wtfDeviation,minDelta/wtfDelta)*100)/100 );
+        mealAssist = Math.max(0, truncate(Math.min(deviation/wtfDeviation, minDelta/wtfDelta), 2));
     }
-    var remainingMealBolus = Math.round( (1.1 * meal_data.carbs/profile.carb_ratio - ( meal_data.boluses + Math.max(0,hightempinsulin) ) )*10)/10;
+    var remainingMealBolus = truncate( (1.1 * (meal_data.carbs/profile.carb_ratio) - ( meal_data.boluses + Math.max(0,hightempinsulin) ) ), 1);
         // if minDelta is >3 and >BGI, and there are uncovered carbs, meal-assist
     if ( minDelta > Math.max(3, bgi) && meal_data.carbs > 0 && remainingMealBolus > 0 ) {
         mealAssist=1;
@@ -176,11 +204,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //console.error("eventualBG: "+eventualBG+", mAeventualBG: "+mAeventualBG+", rT.eventualBG: "+rT.eventualBG);
     }
     // lower target for meal-assist or wtf-assist (high and rising)
-    wtfAssist = Math.round( Math.max(wtfAssist, mealAssist) *100)/100;
+    wtfAssist = truncate( Math.max(wtfAssist, mealAssist), 2);
     if (wtfAssist > 0) {
         min_bg = wtfAssist*80 + (1-wtfAssist)*min_bg;
         target_bg = (min_bg + profile.max_bg) / 2;
-        expectedDelta = Math.round(( bgi + ( target_bg - eventualBG ) / ( profile.dia * 60 / 5 ) )*10)/10;
+        expectedDelta = truncate(( bgi + ( target_bg - eventualBG ) / ( profile.dia * 60 / 5 ) ), 1);
         mealAssistPct = Math.round(mealAssist*100);
         wtfAssistPct = Math.round(wtfAssist*100);
         rT.mealAssist = "On: "+mealAssistPct+"%, "+wtfAssistPct+"%, Carbs: " + meal_data.carbs + " Boluses: " + meal_data.boluses + " ISF: " + sens + ", Target: " + Math.round(target_bg) + " Deviation: " + deviation + " BGI: " + bgi;
@@ -226,16 +254,16 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // simulate an extended bolus to deliver the remainder over DIA (so 30m is 0.5x remainder/dia)
 
         //var insulinReq = Math.round( (0.5 * remainingMealBolus / profile.dia)*100)/100;
-        var basalAdj = Math.round( (remainingMealBolus / profile.dia)*100)/100;
+        var basalAdj = truncate( (remainingMealBolus / profile.dia), 2);
         if (minDelta < 0 && minDelta > expectedDelta) {
-            var newbasalAdj = Math.round(( basalAdj * (1 - (minDelta / expectedDelta)) ) * 100)/100;
+            var newbasalAdj = truncate(( basalAdj * (1 - (minDelta / expectedDelta))), 2);
             console.error("Reducing basalAdj from " + basalAdj + " to " + newbasalAdj);
             basalAdj = newbasalAdj;
         }
         rT.reason += remainingMealBolus+"U meal bolus remaining, ";
         // by rebasing everything off an adjusted basal rate
         basal += basalAdj;
-        basal = Math.round( basal*basal_scale ) / basal_scale;
+        basal = round_basal(basal); //Math.round( basal*basal_scale ) / basal_scale;
         //rT.reason += ", setting " + rate + "U/hr";
         //var rate = basal + (2 * insulinReq);
         //rate = Math.round( rate * 1000 ) / 1000;
@@ -285,13 +313,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 if (minDelta < 0 && minDelta > expectedDelta) {
                     // if we're barely falling, newinsulinReq should be barely negative
                     rT.reason += ", Snooze BG " + snoozeBG;
-                    var newinsulinReq = Math.round(( insulinReq * (minDelta / expectedDelta) ) * 100)/100;
+                    var newinsulinReq = truncate(( insulinReq * (minDelta / expectedDelta) ), 2);
                     //console.log("Increasing insulinReq from " + insulinReq + " to " + newinsulinReq);
                     insulinReq = newinsulinReq;
                 }
                 // rate required to deliver insulinReq less insulin over 30m:
                 var rate = basal + (2 * insulinReq);
-                rate = Math.round( rate * basal_scale ) / basal_scale;
+                rate = round_basal(rate); //Math.round( rate * basal_scale ) / basal_scale;
                 // if required temp < existing temp basal
                 var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
                 if (insulinScheduled < insulinReq - 0.2) { // if current temp would deliver >0.2U less than the required insulin, raise the rate
@@ -357,7 +385,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // if in meal assist mode, check if snoozeBG is lower, as eventualBG is not dependent on IOB
         var insulinReq = (Math.min(snoozeBG,eventualBG) - target_bg) / sens;
         if (minDelta < 0 && minDelta > expectedDelta) {
-            var newinsulinReq = Math.round(( insulinReq * (1 - (minDelta / expectedDelta)) ) * 100)/100;
+            var newinsulinReq = truncate(( insulinReq * (1 - (minDelta / expectedDelta)) ), 2);
             //console.log("Reducing insulinReq from " + insulinReq + " to " + newinsulinReq);
             insulinReq = newinsulinReq;
         }
@@ -369,7 +397,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
         // rate required to deliver insulinReq more insulin over 30m:
         var rate = basal + (2 * insulinReq);
-        rate = Math.round( rate * basal_scale ) / basal_scale;
+        rate = round_basal(rate); //Math.round( rate * basal_scale ) / basal_scale;
 
             var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * basal);
         if (rate > maxSafeBasal) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -423,7 +423,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return setTempBasal(rate, 30, profile, rT, currenttemp);
         }
         
-        if (currenttemp.duration > 5 && (round_basal(rate) === round_basal(currenttemp.rate))) { // if required temp <~ existing temp basal
+        if (currenttemp.duration > 5 && (round_basal(rate) <= round_basal(currenttemp.rate))) { // if required temp <~ existing temp basal
             rT.reason += "temp " + currenttemp.rate + " >~ req " + rate + "U/hr";
             return rT;
         } 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -24,11 +24,11 @@ var round_basal = function round_basal(basal) {
     
     var rounded_result = basal; 
     // Shouldn't need to check against 0 as pumps can't deliver negative basal anyway?
-    if (basal <= 0.975)
+    if (basal < 1)
     {
         rounded_basal = Math.round(basal * 40) / 40;        
     }
-    else if (basal <= 9.95)
+    else if (basal < 10)
     {
         rounded_basal = Math.round(basal * 20) / 20;        
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -16,6 +16,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var rT = { //short for requestedTemp
     };
 
+    //40 gives basal rates that match a 0.025u scroll rate.
+    //80 would match 0.05, 10 would match 0.1u
+    //Was 1000 before this change (round to 2 dp)
+    var basal_scale = 40;
+
     if (typeof profile === 'undefined' || typeof profile.current_basal === 'undefined') {
         rT.error ='Error: could not get current basal rate';
         return rT;
@@ -23,7 +28,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var basal = profile.current_basal;
     if (typeof autosens_data !== 'undefined' ) {
         basal = profile.current_basal * autosens_data.ratio;
-        basal = Math.round(basal*100)/100;
+        basal = Math.round(basal * basal_scale) / basal_scale;
         if (basal != profile.current_basal) {
             console.error("Adjusting basal from "+profile.current_basal+" to "+basal);
         }
@@ -230,7 +235,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += remainingMealBolus+"U meal bolus remaining, ";
         // by rebasing everything off an adjusted basal rate
         basal += basalAdj;
-        basal = Math.round( basal*100 )/100;
+        basal = Math.round( basal*basal_scale ) / basal_scale;
         //rT.reason += ", setting " + rate + "U/hr";
         //var rate = basal + (2 * insulinReq);
         //rate = Math.round( rate * 1000 ) / 1000;
@@ -286,7 +291,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 }
                 // rate required to deliver insulinReq less insulin over 30m:
                 var rate = basal + (2 * insulinReq);
-                rate = Math.round( rate * 1000 ) / 1000;
+                rate = Math.round( rate * basal_scale ) / basal_scale;
                 // if required temp < existing temp basal
                 var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
                 if (insulinScheduled < insulinReq - 0.2) { // if current temp would deliver >0.2U less than the required insulin, raise the rate
@@ -364,7 +369,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
         // rate required to deliver insulinReq more insulin over 30m:
         var rate = basal + (2 * insulinReq);
-        rate = Math.round( rate * 1000 ) / 1000;
+        rate = Math.round( rate * basal_scale ) / basal_scale;
 
             var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * basal);
         if (rate > maxSafeBasal) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -13,32 +13,35 @@
   THE SOFTWARE.
 */
 
-function round_basal(basal) {
-	
-	/* x23 and x54 pumps change basal increment depending on how much basal is being delivered:
-			0.025u for 0.025 < x < 0.975
-			0.05u for 1 < x < 9.95
-			0.1u for 10 < x
-	  To round numbers nicely for the pump, use a scale factor of (1 / increment). */
-	
-    var rounded_result = basal;	 
-	if (basal <= 0.975)
-	{
-		rounded_basal = Math.round(basal * 40) / 40;		
-	}
-	else if (basal <= 9.95)
-	{
-		rounded_basal = Math.round(basal * 20) / 20;		
-	}
-	else
-	{
-		rounded_basal = Math.round(basal * 10) / 10;		
-	}
 
-	return rounded_basal;
+var round_basal = function round_basal(basal) {
+    
+    /* x23 and x54 pumps change basal increment depending on how much basal is being delivered:
+            0.025u for 0.025 < x < 0.975
+            0.05u for 1 < x < 9.95
+            0.1u for 10 < x
+      To round numbers nicely for the pump, use a scale factor of (1 / increment). */
+    
+    var rounded_result = basal; 
+    // Shouldn't need to check against 0 as pumps can't deliver negative basal anyway?
+    if (basal <= 0.975)
+    {
+        rounded_basal = Math.round(basal * 40) / 40;        
+    }
+    else if (basal <= 9.95)
+    {
+        rounded_basal = Math.round(basal * 20) / 20;        
+    }
+    else
+    {
+        rounded_basal = Math.round(basal * 10) / 10;        
+    }
+
+    return rounded_basal;
 }
 
-function truncate(value, digits)
+// Rounds value to 'digits' decimal places
+function round(value, digits)
 {
     var scale = Math.pow(10, digits);
     return Math.round(value * scale) / scale;
@@ -48,9 +51,21 @@ function calculate_expected_delta(dia, target_bg, eventual_bg, bgi) {
     // (hours * mins_per_hour) / 5 = how many 5 minute periods in dia
     var dia_in_5min_blocks = (dia * 60) / 5;
     var target_delta = target_bg - eventual_bg;
-    var expectedDelta = truncate(bgi + (target_delta / dia_in_5min_blocks), 1);
-
+    var expectedDelta = round(bgi + (target_delta / dia_in_5min_blocks), 1);
     return expectedDelta;
+}
+
+
+function convert_bg(value, profile)
+{
+    if (profile.out_units == "mmol/L")
+    {
+        return round(value / 18, 1);
+    }
+    else
+    {
+        return value;
+    }
 }
 
 var determine_basal = function determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, setTempBasal) {
@@ -119,19 +134,19 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var sens = profile.sens;
     if (typeof autosens_data !== 'undefined' ) {
         sens = profile.sens / autosens_data.ratio;
-        sens = truncate(sens, 1);
+        sens = round(sens, 1);
         if (sens != profile.sens) {
             console.error("Adjusting sens from "+profile.sens+" to "+sens);
         }
     }
 
     //calculate BG impact: the amount BG "should" be rising or falling based on insulin activity alone
-    var bgi = truncate(( -iob_data.activity * sens * 5 ), 2);
+    var bgi = round(( -iob_data.activity * sens * 5 ), 2);
     // project positive deviations for 15 minutes
-    var deviation = Math.round( 15 / 5 * (minDelta - bgi ) ) ;
+    var deviation = Math.round( (15 / 5) * (minDelta - bgi ) ) ;
     // project negative deviations for 30 minutes
     if (deviation < 0) {
-        deviation = Math.round( 30 / 5 * ( glucose_status.avgdelta - bgi ) );
+        deviation = Math.round( (30 / 5) * ( glucose_status.avgdelta - bgi ) );
     }
     
     // calculate the naive (bolus calculator math) eventual BG based on net IOB and sensitivity
@@ -190,9 +205,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         mealAssist=1;
     } else {
         // phase in mealAssist, as a fraction
-        mealAssist = Math.max(0, truncate(Math.min(deviation/wtfDeviation, minDelta/wtfDelta), 2));
+        mealAssist = Math.max(0, round(Math.min(deviation/wtfDeviation, minDelta/wtfDelta), 2));
     }
-    var remainingMealBolus = truncate( (1.1 * (meal_data.carbs/profile.carb_ratio) - ( meal_data.boluses + Math.max(0,hightempinsulin) ) ), 1);
+    var remainingMealBolus = round( (1.1 * (meal_data.carbs/profile.carb_ratio) - ( meal_data.boluses + Math.max(0,hightempinsulin) ) ), 1);
         // if minDelta is >3 and >BGI, and there are uncovered carbs, meal-assist
     if ( minDelta > Math.max(3, bgi) && meal_data.carbs > 0 && remainingMealBolus > 0 ) {
         mealAssist=1;
@@ -210,21 +225,21 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //console.error("eventualBG: "+eventualBG+", mAeventualBG: "+mAeventualBG+", rT.eventualBG: "+rT.eventualBG);
     }
     // lower target for meal-assist or wtf-assist (high and rising)
-    wtfAssist = truncate( Math.max(wtfAssist, mealAssist), 2);
+    wtfAssist = round( Math.max(wtfAssist, mealAssist), 2);
     if (wtfAssist > 0) {
         min_bg = wtfAssist*80 + (1-wtfAssist)*min_bg;
         target_bg = (min_bg + profile.max_bg) / 2;
         expectedDelta = calculate_expected_delta(profile.dia, target_bg, eventualBG, bgi);
         mealAssistPct = Math.round(mealAssist*100);
         wtfAssistPct = Math.round(wtfAssist*100);
-        rT.mealAssist = "On: "+mealAssistPct+"%, "+wtfAssistPct+"%, Carbs: " + meal_data.carbs + " Boluses: " + meal_data.boluses + " ISF: " + sens + ", Target: " + Math.round(target_bg) + " Deviation: " + deviation + " BGI: " + bgi;
+        rT.mealAssist = "On: "+mealAssistPct+"%, "+wtfAssistPct+"%, Carbs: " + meal_data.carbs + " Boluses: " + meal_data.boluses + " ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(Math.round(target_bg), profile)  + " Deviation: " + convert_bg(deviation, profile) + " BGI: " + bgi;
     } else {
-        rT.mealAssist = "Off: Carbs: " + meal_data.carbs + " Boluses: " + meal_data.boluses + " ISF: " + sens + ", Target: " + Math.round(target_bg) + " Deviation: " + deviation + " BGI: " + bgi;
+        rT.mealAssist = "Off: Carbs: " + meal_data.carbs + " Boluses: " + meal_data.boluses + " ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(Math.round(target_bg), profile) + " Deviation: " + convert_bg(deviation, profile) + " BGI: " + bgi;
     }
 
     rT.reason="";
     if (bg < threshold) { // low glucose suspend mode: BG is < ~80
-        rT.reason += "BG " + bg + "<" + threshold;
+        rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile);
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted
             return setTempBasal(0, 30, profile, rT, currenttemp);
@@ -260,9 +275,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // simulate an extended bolus to deliver the remainder over DIA (so 30m is 0.5x remainder/dia)
 
         //var insulinReq = Math.round( (0.5 * remainingMealBolus / profile.dia)*100)/100;
-        var basalAdj = truncate( (remainingMealBolus / profile.dia), 2);
+        var basalAdj = round( (remainingMealBolus / profile.dia), 2);
         if (minDelta < 0 && minDelta > expectedDelta) {
-            var newbasalAdj = truncate(( basalAdj * (1 - (minDelta / expectedDelta))), 2);
+            var newbasalAdj = round(( basalAdj * (1 - (minDelta / expectedDelta))), 2);
             console.error("Reducing basalAdj from " + basalAdj + " to " + newbasalAdj);
             basalAdj = newbasalAdj;
         }
@@ -282,7 +297,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //if (mealAssist === true) {
             rT.reason += "Meal assist: " + meal_data.carbs + "g, " + meal_data.boluses + "U";
         } else {
-            rT.reason += "Eventual BG " + eventualBG + "<" + min_bg;
+            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " < " + convert_bg(min_bg, profile);
             // if 5m or 15m avg BG is rising faster than expected delta
             if (minDelta > expectedDelta && minDelta > 0) {
                 if (glucose_status.delta > minDelta) {
@@ -303,7 +318,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (eventualBG < min_bg) {
             // if we've bolused recently, we can snooze until the bolus IOB decays (at double speed)
             if (snoozeBG > min_bg) { // if adding back in the bolus contribution BG would be above min
-                rT.reason += ", bolus snooze: eventual BG range " + eventualBG + "-" + snoozeBG;
+                rT.reason += ", bolus snooze: eventual BG range " + convert_bg(eventualBG, profile) + "-" + convert_bg(snoozeBG, profile);
                 //console.log(currenttemp, basal );
                 if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
                     rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
@@ -319,8 +334,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 var insulinReq = 2 * Math.min(0, (snoozeBG - target_bg) / sens);
                 if (minDelta < 0 && minDelta > expectedDelta) {
                     // if we're barely falling, newinsulinReq should be barely negative
-                    rT.reason += ", Snooze BG " + snoozeBG;
-                    var newinsulinReq = truncate(( insulinReq * (minDelta / expectedDelta) ), 2);
+                    rT.reason += ", Snooze BG " + convert_bg(snoozeBG, profile);
+                    var newinsulinReq = round(( insulinReq * (minDelta / expectedDelta) ), 2);
                     //console.log("Increasing insulinReq from " + insulinReq + " to " + newinsulinReq);
                     insulinReq = newinsulinReq;
                 }
@@ -347,9 +362,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // if eventual BG is above min but BG is falling faster than expected Delta
     if (minDelta < expectedDelta) {
         if (glucose_status.delta < minDelta) {
-            rT.reason += "Eventual BG " + eventualBG + ">" + min_bg + " but Delta " + tick + " < Exp. Delta " + expectedDelta;
+            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + ">" + convert_bg(min_bg, profile) + " but Delta " + tick + " < Exp. Delta " + expectedDelta;
         } else {
-            rT.reason += "Eventual BG " + eventualBG + ">" + min_bg + " but Avg. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
+            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + ">" + convert_bg(min_bg, profile) + " but Avg. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
         }
         if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
@@ -376,7 +391,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var basaliob;
     if (iob_data.basaliob) { basaliob = iob_data.basaliob; }
     else { basaliob = iob_data.iob - iob_data.bolussnooze; }
-    rT.reason += "Eventual BG " + eventualBG + ">=" + profile.max_bg + ", ";
+    rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + ">=" +  convert_bg(profile.max_bg, profile) + ", ";
     if (basaliob > max_iob) {
         rT.reason += "basaliob " + basaliob + " > max_iob " + max_iob;
         if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
@@ -392,7 +407,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // if in meal assist mode, check if snoozeBG is lower, as eventualBG is not dependent on IOB
         var insulinReq = (Math.min(snoozeBG,eventualBG) - target_bg) / sens;
         if (minDelta < 0 && minDelta > expectedDelta) {
-            var newinsulinReq = truncate(( insulinReq * (1 - (minDelta / expectedDelta)) ), 2);
+            var newinsulinReq = round(( insulinReq * (1 - (minDelta / expectedDelta)) ), 2);
             //console.log("Reducing insulinReq from " + insulinReq + " to " + newinsulinReq);
             insulinReq = newinsulinReq;
         }
@@ -435,4 +450,5 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     
 };
 
-module.exports = determine_basal;
+module.exports.determine_basal = determine_basal;
+module.exports.round_basal = round_basal;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -362,9 +362,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // if eventual BG is above min but BG is falling faster than expected Delta
     if (minDelta < expectedDelta) {
         if (glucose_status.delta < minDelta) {
-            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + ">" + convert_bg(min_bg, profile) + " but Delta " + tick + " < Exp. Delta " + expectedDelta;
+            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Delta " + tick + " < Exp. Delta " + expectedDelta;
         } else {
-            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + ">" + convert_bg(min_bg, profile) + " but Avg. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
+            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Avg. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
         }
         if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
@@ -376,7 +376,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
     
     if (eventualBG < profile.max_bg || snoozeBG < profile.max_bg) {
-        rT.reason += eventualBG+"-"+snoozeBG+" in range: no temp required";
+        rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(snoozeBG, profile)+" in range: no temp required";
         if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
@@ -391,7 +391,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var basaliob;
     if (iob_data.basaliob) { basaliob = iob_data.basaliob; }
     else { basaliob = iob_data.iob - iob_data.bolussnooze; }
-    rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + ">=" +  convert_bg(profile.max_bg, profile) + ", ";
+    rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " >= " +  convert_bg(profile.max_bg, profile) + ", ";
     if (basaliob > max_iob) {
         rT.reason += "basaliob " + basaliob + " > max_iob " + max_iob;
         if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
@@ -423,7 +423,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
             var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * basal);
         if (rate > maxSafeBasal) {
-            rT.reason += "adj. req. rate:"+rate.toFixed(1) +" to maxSafeBasal:"+maxSafeBasal.toFixed(1)+", ";
+            rT.reason += "adj. req. rate: "+rate.toFixed(1) +" to maxSafeBasal: "+maxSafeBasal.toFixed(1)+", ";
             rate = maxSafeBasal.toFixed(1);
         }
         

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -44,14 +44,18 @@ function truncate(value, digits)
     return Math.round(value * scale) / scale;
 }
 
+function calculate_expected_delta(dia, target_bg, eventual_bg, bgi) {
+    // (hours * mins_per_hour) / 5 = how many 5 minute periods in dia
+    var dia_in_5min_blocks = (dia * 60) / 5;
+    var target_delta = target_bg - eventual_bg;
+    var expectedDelta = truncate(bgi + (target_delta / dia_in_5min_blocks), 1);
+
+    return expectedDelta;
+}
+
 var determine_basal = function determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, setTempBasal) {
     var rT = { //short for requestedTemp
     };
-
-    //40 gives basal rates that match a 0.025u scroll rate.
-    //80 would match 0.05, 10 would match 0.1u
-    //Was 1000 before this change (round to 2 dp)
-    var basal_scale = 40;
 
     if (typeof profile === 'undefined' || typeof profile.current_basal === 'undefined') {
         rT.error ='Error: could not get current basal rate';
@@ -115,7 +119,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var sens = profile.sens;
     if (typeof autosens_data !== 'undefined' ) {
         sens = profile.sens / autosens_data.ratio;
-        sens = Math.round(sens*10)/10;
+        sens = truncate(sens, 1);
         if (sens != profile.sens) {
             console.error("Adjusting sens from "+profile.sens+" to "+sens);
         }
@@ -145,10 +149,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // adjust that for deviation like we did eventualBG
     var snoozeBG = naive_snoozeBG + deviation;
     
-    var dia_in_5min_blocks = (profile.dia * 60) / 5;
-    var target_delta = target_bg - eventualBG;
-    var expectedDelta = truncate(bgi + (target_delta / dia_in_5min_blocks), 1);
-
+    var expectedDelta = calculate_expected_delta(profile.dia, target_bg, eventualBG, bgi);
     if (typeof eventualBG === 'undefined' || isNaN(eventualBG)) { 
         rT.error ='Error: could not calculate eventualBG';
         return rT;
@@ -213,7 +214,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (wtfAssist > 0) {
         min_bg = wtfAssist*80 + (1-wtfAssist)*min_bg;
         target_bg = (min_bg + profile.max_bg) / 2;
-        expectedDelta = truncate(( bgi + ( target_bg - eventualBG ) / ( profile.dia * 60 / 5 ) ), 1);
+        expectedDelta = calculate_expected_delta(profile.dia, target_bg, eventualBG, bgi);
         mealAssistPct = Math.round(mealAssist*100);
         wtfAssistPct = Math.round(wtfAssist*100);
         rT.mealAssist = "On: "+mealAssistPct+"%, "+wtfAssistPct+"%, Carbs: " + meal_data.carbs + " Boluses: " + meal_data.boluses + " ISF: " + sens + ", Target: " + Math.round(target_bg) + " Deviation: " + deviation + " BGI: " + bgi;
@@ -233,7 +234,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         } else {
             rT.reason += ", avg delta " + minDelta.toFixed(2) + ">0";
         }
-        if (currenttemp.duration > 15 && basal < currenttemp.rate + 0.1 && basal > currenttemp.rate - 0.1) {
+        if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
         } else {
@@ -289,7 +290,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 } else {
                     rT.reason += ", but Avg. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
                 }
-                if (currenttemp.duration > 15 && basal < currenttemp.rate + 0.1 && basal > currenttemp.rate - 0.1) {
+                if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
                     rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
                     return rT;
                 } else {
@@ -304,7 +305,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if (snoozeBG > min_bg) { // if adding back in the bolus contribution BG would be above min
                 rT.reason += ", bolus snooze: eventual BG range " + eventualBG + "-" + snoozeBG;
                 //console.log(currenttemp, basal );
-                if (currenttemp.duration > 15 && basal < currenttemp.rate + 0.1 && basal > currenttemp.rate - 0.1) {
+                if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
                     rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
                     return rT;
                 } else {
@@ -350,7 +351,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         } else {
             rT.reason += "Eventual BG " + eventualBG + ">" + min_bg + " but Avg. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
         }
-        if (currenttemp.duration > 15 && basal < currenttemp.rate + 0.1 && basal > currenttemp.rate - 0.1) {
+        if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
         } else {
@@ -361,7 +362,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     
     if (eventualBG < profile.max_bg || snoozeBG < profile.max_bg) {
         rT.reason += eventualBG+"-"+snoozeBG+" in range: no temp required";
-        if (currenttemp.duration > 15 && basal < currenttemp.rate + 0.1 && basal > currenttemp.rate - 0.1) {
+        if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
         } else {
@@ -378,7 +379,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     rT.reason += "Eventual BG " + eventualBG + ">=" + profile.max_bg + ", ";
     if (basaliob > max_iob) {
         rT.reason += "basaliob " + basaliob + " > max_iob " + max_iob;
-        if (currenttemp.duration > 15 && basal < currenttemp.rate + 0.1 && basal > currenttemp.rate - 0.1) {
+        if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
         } else {
@@ -422,7 +423,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return setTempBasal(rate, 30, profile, rT, currenttemp);
         }
         
-        if (currenttemp.duration > 5 && rate < currenttemp.rate + 0.1) { // if required temp <~ existing temp basal
+        if (currenttemp.duration > 5 && (round_basal(rate) === round_basal(currenttemp.rate))) { // if required temp <~ existing temp basal
             rT.reason += "temp " + currenttemp.rate + " >~ req " + rate + "U/hr";
             return rT;
         } 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -38,6 +38,7 @@ function generate (inputs, opts) {
   }
 
   var range = targets.bgTargetsLookup(inputs);
+  profile.out_units = inputs.targets.user_preferred_units;
   profile.min_bg = range.min_bg;
   profile.max_bg = range.max_bg;
   profile.sens = isf.isfLookup(inputs);

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -239,7 +239,7 @@ describe('determine-basal', function ( ) {
         //console.log(output);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
-        output.reason.should.match(/Eventual BG .*<110.*setting .*/);
+        output.reason.should.match(/Eventual BG .*< 110.*setting .*/);
     });
     
     it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
@@ -249,7 +249,7 @@ describe('determine-basal', function ( ) {
         //console.log(output);
         output.rate.should.be.below(0.2);
         output.duration.should.equal(30);
-        output.reason.should.match(/Eventual BG .*<110.*setting .*/);
+        output.reason.should.match(/Eventual BG .*< 110.*setting .*/);
     });
     
     it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
@@ -259,7 +259,7 @@ describe('determine-basal', function ( ) {
         //console.log(output);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
-        output.reason.should.match(/Eventual BG .*<110.*setting .*/);
+        output.reason.should.match(/Eventual BG .*< 110.*setting .*/);
     });
 
     it('should low-temp much less when eventualBG < min_bg with delta barely negative', function () {
@@ -269,7 +269,7 @@ describe('determine-basal', function ( ) {
         output.rate.should.be.above(0.3);
         output.rate.should.be.below(0.8);
         output.duration.should.equal(30);
-        output.reason.should.match(/Eventual BG .*<110.*setting .*/);
+        output.reason.should.match(/Eventual BG .*< 110.*setting .*/);
     });
 
     it('should do nothing when eventualBG < min_bg but appropriate low temp in progress', function () {
@@ -278,7 +278,7 @@ describe('determine-basal', function ( ) {
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
         (typeof output.rate).should.equal('undefined');
         (typeof output.duration).should.equal('undefined');
-        output.reason.should.match(/Eventual BG .*<110, temp .*/);
+        output.reason.should.match(/Eventual BG .*< 110, temp .*/);
     });
 
     it('should cancel low-temp when lowish and avg.delta rising faster than BGI', function () {

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -2,10 +2,47 @@
 
 var should = require('should');
 
+describe('round_basal', function ( ) {
+    var round_basal = require('../lib/determine-basal/determine-basal').round_basal;
+    it('should round basal rates properly (0.83 -> 0.825)', function() {
+        var basal = 0.83;
+        var output = round_basal(basal);
+        output.should.equal(0.825);
+    });
 
+    it('should round basal rates properly (0.86 -> 0.85)', function() {
+        var basal = 0.86;
+        var output = round_basal(basal);
+        output.should.equal(0.85);
+    });    
+
+    it('should round basal rates properly: (1.83 -> 1.85)', function() {
+        var basal = 1.83;
+        var output = round_basal(basal);
+        output.should.equal(1.85);
+    });
+
+    it('should round basal rates properly: (1.86 -> 1.85)', function() {
+        var basal = 1.86;
+        var output = round_basal(basal);
+        output.should.equal(1.85);
+    });
+
+    it('should round basal rates properly: (10.83 -> 10.8)', function() {
+        var basal = 10.83;
+        var output = round_basal(basal);
+        output.should.equal(10.8);
+    });
+
+    it('should round basal rates properly: (10.86 -> 10.9)', function() {
+        var basal = 10.86;
+        var output = round_basal(basal);
+        output.should.equal(10.9);
+    }); 
+});
 
 describe('determine-basal', function ( ) {
-    var determine_basal = require('../lib/determine-basal/determine-basal');
+    var determine_basal = require('../lib/determine-basal/determine-basal').determine_basal;
     var setTempBasal = require('../lib/basal-set-temp');
 
    //function determine_basal(glucose_status, currenttemp, iob_data, profile)
@@ -577,5 +614,4 @@ describe('determine-basal', function ( ) {
         output.rate.should.equal(0);
         output.duration.should.equal(30);
     });
-
 });

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -331,7 +331,7 @@ describe('determine-basal', function ( ) {
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
         output.rate.should.be.above(1);
         output.duration.should.equal(30);
-        output.reason.should.match(/Eventual BG .*>=120/);
+        output.reason.should.match(/Eventual BG .*>= 120/);
     });
 
     it('should cancel high-temp when high and avg. delta falling faster than BGI', function () {


### PR DESCRIPTION
- Round to doses the pump can provide - accurate for x23 and x54. For doses < 1u it will produce values between ones x22 pumps can provide, but this shouldn't be any worse than the current behaviour.
- As a result of rounding basal doses better, it should be possible to replace most of the checks that ballpark within 0.1u/hr.
- Convert some of the output numbers to mmol/l. This is mostly where actual blood glucose values are displayed, not delta or BGI values (because of the loss of resolution when rounding)
- Add tests for basal rounding
- get-profile now includes the pumps preferred unit setting
- Alter the require structure to allow access to round_basal outside of the .js file for tests.