### PR TITLE
Don't wait for 15 seconds if the oref0-fix-git-corruption completed

### DIFF
--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -38,7 +38,15 @@ find .git/index.lock -mmin +5 -exec rm {} \; 2>/dev/null
 # first, try oref0-fix-git-corruption.sh to preserve git history up to last good commit
 echo "Attempting to fix git corruption.  Please wait 15s."
 oref0-fix-git-corruption &
-sleep 15 && killall oref0-fix-git-corruption
+pid=$!
+(sleep 15; killall oref0-fix-git-corruption) &
+sleep_pid=$!
+wait $pid
+
+status=$?
+if [ $status -lt 128 ]; then
+	kill $sleep_pid 2> /dev/null
+fi
 # if git repository is too corrupt to do anything, mv it to /tmp and start over.
 
 git status > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; openaps init . )

--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -45,7 +45,7 @@ wait $pid
 
 status=$?
 if [ $status -lt 128 ]; then
-	kill $sleep_pid 2> /dev/null
+	kill $sleep_pid
 fi
 # if git repository is too corrupt to do anything, mv it to /tmp and start over.
 


### PR DESCRIPTION
Tested by inserting a 30 second sleep at the start of fix-git-corruption, which gets killed after 15 seconds as expected.