### PR TITLE
Round basaliob, was outputting very long floats

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -393,7 +393,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     else { basaliob = iob_data.iob - iob_data.bolussnooze; }
     rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " >= " +  convert_bg(profile.max_bg, profile) + ", ";
     if (basaliob > max_iob) {
-        rT.reason += "basaliob " + basaliob + " > max_iob " + max_iob;
+        rT.reason += "basaliob " + round(basaliob,2) + " > max_iob " + max_iob;
         if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;


### PR DESCRIPTION
In some cases, due to floating point error, this was outputting strings like 2.00000000000001. Rounding should prevent that.