### PR TITLE
Change > /dev/stderr to >&2 for portability and weird file truncation

### DIFF
--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -230,11 +230,11 @@ ns)
     upload-non-empty-type)
       TYPE=${1-entries.json}
       FILE=$2
-      test $(cat $FILE | json -a | wc -l) -lt 1 && echo "Nothing to upload." > /dev/stderr && cat $FILE && exit 0
+      test $(cat $FILE | json -a | wc -l) -lt 1 && echo "Nothing to upload." >&2 && cat $FILE && exit 0
       exec ns-upload $NIGHTSCOUT_HOST $API_SECRET $TYPE $FILE
     ;;
     upload-non-empty-treatments)
-      test $(cat $1 | json -a | wc -l) -lt 1 && echo "Nothing to upload." > /dev/stderr && cat $1 && exit 0
+      test $(cat $1 | json -a | wc -l) -lt 1 && echo "Nothing to upload." >&2 && cat $1 && exit 0
     exec ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json $1
 
     ;;


### PR DESCRIPTION
I run openaps with all output being appended to a log file. I was getting repeated truncation of the logfile whenever nightscout.sh was writing to /dev/stderr. Changing to >&2 seems to fix the problem, and should be more portable.