### PR TITLE
Round basal

### DIFF
--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -183,7 +183,7 @@ function init() {
     };
     
     determinebasal.getLastGlucose = require('oref0/lib/glucose-get-last');
-    determinebasal.determine_basal = require('oref0/lib/determine-basal/determine-basal').determine_basal;
+    determinebasal.determine_basal = require('oref0/lib/determine-basal/determine-basal');
     return determinebasal;
 
 }

--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -18,7 +18,7 @@
 
 var generate = require('oref0/lib/profile/');
 function usage ( ) {
-        console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <insulin_sensitivities.json> <basal_profile.json> [<preferences.json>] [<carb_ratios.json>]');
+        console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <insulin_sensitivities.json> <basal_profile.json> [<preferences.json>] [model.json] [<carb_ratios.json>]');
 }
 
 if (!module.parent) {
@@ -32,8 +32,9 @@ if (!module.parent) {
     var isf_input = process.argv.slice(4, 5).pop()
     var basalprofile_input = process.argv.slice(5, 6).pop()
     var preferences_input = process.argv.slice(6, 7).pop()
-    var carbratio_input = process.argv.slice(7, 8).pop()
-    
+    var model_input = process.argv.slice(7, 8).pop()
+    var carbratio_input = process.argv.slice(8, 9).pop()
+
     if (!pumpsettings_input || !bgtargets_input || !isf_input || !basalprofile_input) {
         usage( );
         process.exit(1);
@@ -60,6 +61,20 @@ if (!module.parent) {
         preferences = require(cwd + '/' + preferences_input);
     }
     var fs = require('fs');
+
+    var model_data = { }
+    if (typeof model_input != 'undefined') {
+	try {
+	    model_string = fs.readFileSync(model_input, 'utf8');
+	    model_data = model_string.replace(/\"/gi, '');
+	} catch (e) {
+		var msg = { error: e, msg: "Could not parse model_data", file: model_input};
+		console.error(msg.msg);
+		console.log(JSON.stringify(msg));
+		process.exit(1);
+	}
+    }
+
     var carbratio_data = { };
     //console.log("carbratio_input",carbratio_input);
     if (typeof carbratio_input != 'undefined') {
@@ -99,6 +114,7 @@ if (!module.parent) {
     , max_iob: preferences.max_iob || 0
     , skip_neutral_temps: preferences.skip_neutral_temps || false
     , carbratio: carbratio_data
+    , model: model_data
     };
 
     var profile = generate(inputs);

--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -18,28 +18,44 @@
 
 var generate = require('oref0/lib/profile/');
 function usage ( ) {
-        console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <insulin_sensitivities.json> <basal_profile.json> [<preferences.json>] [model.json] [<carb_ratios.json>]');
+        console.log('usage: ', process.argv.slice(0, 2), '<pump_settings.json> <bg_targets.json> <insulin_sensitivities.json> <basal_profile.json> [<preferences.json>] [--model model.json] [<carb_ratios.json>] ');
 }
 
 if (!module.parent) {
     
-    var pumpsettings_input = process.argv.slice(2, 3).pop()
+    var argv = require('yargs')
+      .usage("$0 pump_settings.json bg_targets.json insulin_sensitivities.json basal_profile.json [preferences.json] [--model model.json] [<carb_ratios.json>]")
+      .option('model', {
+        alias: 'm',
+        describe: "Pump model response",
+        default: false
+      })
+      .strict(true)
+      .help('help')
+
+    var params = argv.argv;
+    var pumpsettings_input = params._.slice(0, 1).pop()
     if ([null, '--help', '-h', 'help'].indexOf(pumpsettings_input) > 0) {
       usage( );
       process.exit(0)
     }
-    var bgtargets_input = process.argv.slice(3, 4).pop()
-    var isf_input = process.argv.slice(4, 5).pop()
-    var basalprofile_input = process.argv.slice(5, 6).pop()
-    var preferences_input = process.argv.slice(6, 7).pop()
-    var model_input = process.argv.slice(7, 8).pop()
-    var carbratio_input = process.argv.slice(8, 9).pop()
+    var bgtargets_input = params._.slice(1, 2).pop()
+    var isf_input = params._.slice(2, 3).pop()
+    var basalprofile_input = params._.slice(3, 4).pop()
+    var preferences_input = params._.slice(4, 5).pop()
+    var carbratio_input = params._.slice(5, 6).pop()
+    var model_input = params.model;
+    if (params._.length > 6)
+    {
+      model_input = params.model ? params.params._.slice(5, 6).pop() : false;
+      var carbratio_input = params._.slice(6, 7).pop()
+    }
 
     if (!pumpsettings_input || !bgtargets_input || !isf_input || !basalprofile_input) {
         usage( );
         process.exit(1);
     }
-    
+
     var cwd = process.cwd()
     var pumpsettings_data = require(cwd + '/' + pumpsettings_input);
     var bgtargets_data = require(cwd + '/' + bgtargets_input);
@@ -63,16 +79,16 @@ if (!module.parent) {
     var fs = require('fs');
 
     var model_data = { }
-    if (typeof model_input != 'undefined') {
-	try {
-	    model_string = fs.readFileSync(model_input, 'utf8');
-	    model_data = model_string.replace(/\"/gi, '');
-	} catch (e) {
-		var msg = { error: e, msg: "Could not parse model_data", file: model_input};
-		console.error(msg.msg);
-		console.log(JSON.stringify(msg));
-		process.exit(1);
-	}
+    if (params.model) {
+      try {
+        model_string = fs.readFileSync(model_input, 'utf8');
+        model_data = model_string.replace(/\"/gi, '');
+      } catch (e) {
+        var msg = { error: e, msg: "Could not parse model_data", file: model_input};
+        console.error(msg.msg);
+        console.log(JSON.stringify(msg));
+        process.exit(1);
+      }
     }
 
     var carbratio_data = { };

--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -1,3 +1,5 @@
+var round_basal = require('./round-basal');
+
 var setTempBasal = function (rate, duration, profile, rT, currenttemp) {
     var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * profile.current_basal);
     
@@ -13,7 +15,8 @@ var setTempBasal = function (rate, duration, profile, rT, currenttemp) {
         return rT;
     }
 
-    var suggestedRate = Math.round((Math.round(rate / 0.05) * 0.05)*100)/100;
+    var suggestedRate = round_basal(rate, profile);
+    //var suggestedRate = Math.round((Math.round(rate / 0.05) * 0.05)*100)/100;
     if (suggestedRate === profile.current_basal) {
       if (profile.skip_neutral_temps) {
         if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && currenttemp.duration > 0) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -14,31 +14,7 @@
 */
 
 
-var round_basal = function round_basal(basal) {
-    
-    /* x23 and x54 pumps change basal increment depending on how much basal is being delivered:
-            0.025u for 0.025 < x < 0.975
-            0.05u for 1 < x < 9.95
-            0.1u for 10 < x
-      To round numbers nicely for the pump, use a scale factor of (1 / increment). */
-    
-    var rounded_result = basal; 
-    // Shouldn't need to check against 0 as pumps can't deliver negative basal anyway?
-    if (basal < 1)
-    {
-        rounded_basal = Math.round(basal * 40) / 40;        
-    }
-    else if (basal < 10)
-    {
-        rounded_basal = Math.round(basal * 20) / 20;        
-    }
-    else
-    {
-        rounded_basal = Math.round(basal * 10) / 10;        
-    }
-
-    return rounded_basal;
-}
+var round_basal = require('../round-basal')
 
 // Rounds value to 'digits' decimal places
 function round(value, digits)
@@ -79,7 +55,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var basal = profile.current_basal;
     if (typeof autosens_data !== 'undefined' ) {
         basal = profile.current_basal * autosens_data.ratio;
-        basal = round_basal(basal);
+        basal = round_basal(basal, profile);
         if (basal != profile.current_basal) {
             console.error("Adjusting basal from "+profile.current_basal+" to "+basal);
         }
@@ -249,7 +225,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         } else {
             rT.reason += ", avg delta " + minDelta.toFixed(2) + ">0";
         }
-        if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
+        if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
         } else {
@@ -284,7 +260,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += remainingMealBolus+"U meal bolus remaining, ";
         // by rebasing everything off an adjusted basal rate
         basal += basalAdj;
-        basal = round_basal(basal);
+        basal = round_basal(basal, profile);
 
         //rT.reason += ", setting " + rate + "U/hr";
         //var rate = basal + (2 * insulinReq);
@@ -305,7 +281,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 } else {
                     rT.reason += ", but Avg. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
                 }
-                if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
+                if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
                     rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
                     return rT;
                 } else {
@@ -320,7 +296,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if (snoozeBG > min_bg) { // if adding back in the bolus contribution BG would be above min
                 rT.reason += ", bolus snooze: eventual BG range " + convert_bg(eventualBG, profile) + "-" + convert_bg(snoozeBG, profile);
                 //console.log(currenttemp, basal );
-                if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
+                if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
                     rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
                     return rT;
                 } else {
@@ -341,7 +317,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 }
                 // rate required to deliver insulinReq less insulin over 30m:
                 var rate = basal + (2 * insulinReq);
-                rate = round_basal(rate);
+                rate = round_basal(rate, profile);
                 // if required temp < existing temp basal
                 var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
                 if (insulinScheduled < insulinReq - 0.2) { // if current temp would deliver >0.2U less than the required insulin, raise the rate
@@ -366,7 +342,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         } else {
             rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Avg. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
         }
-        if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
+        if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
         } else {
@@ -377,7 +353,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     
     if (eventualBG < profile.max_bg || snoozeBG < profile.max_bg) {
         rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(snoozeBG, profile)+" in range: no temp required";
-        if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
+        if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
         } else {
@@ -394,7 +370,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " >= " +  convert_bg(profile.max_bg, profile) + ", ";
     if (basaliob > max_iob) {
         rT.reason += "basaliob " + basaliob + " > max_iob " + max_iob;
-        if (currenttemp.duration > 15 && (round_basal(basal) === round_basal(currenttemp.rate))) {
+        if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
             return rT;
         } else {
@@ -419,7 +395,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
         // rate required to deliver insulinReq more insulin over 30m:
         var rate = basal + (2 * insulinReq);
-        rate = round_basal(rate);
+        rate = round_basal(rate, profile);
 
             var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * basal);
         if (rate > maxSafeBasal) {
@@ -438,7 +414,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return setTempBasal(rate, 30, profile, rT, currenttemp);
         }
         
-        if (currenttemp.duration > 5 && (round_basal(rate) <= round_basal(currenttemp.rate))) { // if required temp <~ existing temp basal
+        if (currenttemp.duration > 5 && (round_basal(rate, profile) <= round_basal(currenttemp.rate, profile))) { // if required temp <~ existing temp basal
             rT.reason += "temp " + currenttemp.rate + " >~ req " + rate + "U/hr";
             return rT;
         } 
@@ -450,5 +426,5 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     
 };
 
-module.exports.determine_basal = determine_basal;
-module.exports.round_basal = round_basal;
+module.exports = determine_basal;
+

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -27,6 +27,11 @@ function generate (inputs, opts) {
   if (inputs.max_iob) {
     profile.max_iob = inputs.max_iob;
   }
+
+  if (inputs.model)
+  {
+	profile.model = inputs.model;
+  }
   profile.skip_neutral_temps = inputs.skip_neutral_temps;
 
   profile.current_basal = basal.basalLookup(inputs.basals);

--- a/lib/round-basal.js
+++ b/lib/round-basal.js
@@ -1,0 +1,46 @@
+var endsWith = function endsWith(text, val) {
+	return text.indexOf(val, text.length - val.length) !== -1;
+}
+
+var round_basal = function round_basal(basal, profile) {
+    
+    /* x23 and x54 pumps change basal increment depending on how much basal is being delivered:
+            0.025u for 0.025 < x < 0.975
+            0.05u for 1 < x < 9.95
+            0.1u for 10 < x
+      To round numbers nicely for the pump, use a scale factor of (1 / increment). */
+    
+    var lowest_rate_scale = 20;
+
+    // Has profile even been passed in?
+    if (typeof profile !== 'undefined')
+    {
+        // Make sure optional model has been set
+        if (typeof profile.model !== 'undefined') 
+        {
+            if (endsWith(profile.model, "54") || endsWith(profile.model, "23"))
+            {
+                lowest_rate_scale = 40;
+            }
+        }
+    }
+
+    var rounded_result = basal; 
+    // Shouldn't need to check against 0 as pumps can't deliver negative basal anyway?
+    if (basal < 1)
+    {
+        rounded_basal = Math.round(basal * lowest_rate_scale) / lowest_rate_scale;        
+    }
+    else if (basal < 10)
+    {
+        rounded_basal = Math.round(basal * 20) / 20;        
+    }
+    else
+    {
+        rounded_basal = Math.round(basal * 10) / 10;        
+    }
+
+    return rounded_basal;
+}
+
+exports = module.exports = round_basal

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -3,11 +3,41 @@
 var should = require('should');
 
 describe('round_basal', function ( ) {
-    var round_basal = require('../lib/determine-basal/determine-basal').round_basal;
+    var round_basal = require('../lib/round-basal');
+
+    it('should round correctly without profile being passed in', function() {
+        var basal = 0.025;
+        var output = round_basal(basal);
+        output.should.equal(0.05);
+    });
+
+    var profile = {model: "522"};
+    it('should round correctly with an old pump model', function() {
+        var basal = 0.025;
+        var output = round_basal(basal, profile);
+        output.should.equal(0.05);
+    });
+
+    
+    it('should round correctly with a new pump model', function() {
+        var basal = 0.025;
+        profile.model = "554";
+        var output = round_basal(basal, profile);
+        output.should.equal(0.025);
+        console.error(output);
+    });
+
+    it('should round correctly with an invalid pump model', function() {
+        var basal = 0.025;
+        profile.model = "HelloThisIsntAPumpModel";
+        var output = round_basal(basal, profile);
+        output.should.equal(0.05);
+    });
+
     it('should round basal rates properly (0.83 -> 0.825)', function() {
         var basal = 0.83;
         var output = round_basal(basal);
-        output.should.equal(0.825);
+        output.should.equal(0.85);
     });
 
     it('should round basal rates properly (0.86 -> 0.85)', function() {
@@ -42,7 +72,7 @@ describe('round_basal', function ( ) {
 });
 
 describe('determine-basal', function ( ) {
-    var determine_basal = require('../lib/determine-basal/determine-basal').determine_basal;
+    var determine_basal = require('../lib/determine-basal/determine-basal');
     var setTempBasal = require('../lib/basal-set-temp');
 
    //function determine_basal(glucose_status, currenttemp, iob_data, profile)
@@ -614,4 +644,31 @@ describe('determine-basal', function ( ) {
         output.rate.should.equal(0);
         output.duration.should.equal(30);
     });
+
+    it('should match the basal rate precision available on a 523', function () {
+        //var currenttemp = {"duration":30,"rate":0,"temp":"absolute"};
+        var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
+        profile.current_basal = 0.825;
+        profile.model = "523";
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        //output.rate.should.equal(0);
+        //output.duration.should.equal(0);
+        output.rate.should.equal(0.825);
+        output.duration.should.equal(30);
+        output.reason.should.match(/in range.*/);
+    });
+
+    it('should match the basal rate precision available on a 522', function () {
+        //var currenttemp = {"duration":30,"rate":0,"temp":"absolute"};
+        var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
+        profile.current_basal = 0.875;
+        profile.model = "522";
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, setTempBasal);
+        //output.rate.should.equal(0);
+        //output.duration.should.equal(0);
+        output.rate.should.equal(0.9);
+        output.duration.should.equal(30);
+        output.reason.should.match(/in range.*/);
+    });    
+
 });


### PR DESCRIPTION
Previous attempts at rounding basal were thwarted by another set of rounding in SetTempBasal. Pull the round basal function out in to a separate file to make it easier to call in multiple places.

Add model.json to the profile produced by get-profile. This model is now used by round_basal to choose an appropriate precision for doses in the sub-1u region. 

Undo previous changes to how determine-basal is require()'d by other files - they are no longer needed with round_basal in another file.