### PR TITLE
Better check for whether model is present

### DIFF
--- a/lib/round-basal.js
+++ b/lib/round-basal.js
@@ -16,7 +16,7 @@ var round_basal = function round_basal(basal, profile) {
     if (typeof profile !== 'undefined')
     {
         // Make sure optional model has been set
-        if (typeof profile.model !== 'undefined') 
+        if (typeof profile.model == 'string') 
         {
             if (endsWith(profile.model, "54") || endsWith(profile.model, "23"))
             {


### PR DESCRIPTION
Saw a report of determine-basal crashing because `typeof profile.model` was `Object` - profile.json contained `'model':{}`. Moved to a stricter check.