### PR TITLE
Uploader battery status

### DIFF
--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -38,19 +38,48 @@ function mmtuneStatus (status) {
     }
 }
 
+function uploaderStatus (status) {
+    if (uploader_input ) {
+	var uploader = require(cwd + '/' + uploader_input);
+	if (uploader) {
+	    status.uploader =  {};
+	    status.uploader.battery = uploader;
+	}
+    }
+}
+
 if (!module.parent) {
 
-    var clock_input = process.argv.slice(2, 3).pop();
-    var iob_input = process.argv.slice(3, 4).pop();
-    var suggested_input = process.argv.slice(4, 5).pop();
-    var enacted_input = process.argv.slice(5, 6).pop();
-    var battery_input = process.argv.slice(6, 7).pop();
-    var reservoir_input = process.argv.slice(7, 8).pop();
-    var status_input = process.argv.slice(8, 9).pop();
-    var mmtune_input = process.argv.slice(9, 10).pop();
+    var argv = require('yargs')
+	.usage("$0 <clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [--uploader uploader.json] [mmtune.json]")
+	.option('uploader', {
+	    alias: 'u',
+	    describe: "Uploader battery status",
+	    default: false
+	})
+	.strict(true)
+	.help('help')
+
+    var params = argv.argv;
+
+
+    var clock_input = params._.slice(0, 1).pop();
+    var iob_input = params._.slice(1, 2).pop();
+    var suggested_input = params._.slice(2, 3).pop();
+    var enacted_input = params._.slice(3, 4).pop();
+    var battery_input = params._.slice(4, 5).pop();
+    var reservoir_input = params._.slice(5, 6).pop();
+    var status_input = params._.slice(6, 7).pop();
+    var mmtune_input = params._.slice(7, 8).pop();
+    var uploader_input = params.uploader;
+
+    if (params._.length > 8) {
+	uploader_input = params.uploader ? params._.slice(7, 8).pop() : false;
+	mmtune_input = params._.slice(8, 9).pop();
+    }
 
     if (!clock_input || !iob_input || !suggested_input || !enacted_input || !battery_input || !reservoir_input || !status_input) {
-        console.log('usage: ', process.argv.slice(0, 2), '<clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [mmtune.json]');
+        console.log('usage: ', process.argv.slice(0, 2), '<clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [--uploader uploader.json] [mmtune.json]');
         process.exit(1);
     }
 
@@ -80,6 +109,7 @@ if (!module.parent) {
         };
 
         mmtuneStatus(status);
+	uploaderStatus(status);
     } catch (e) {
         return console.error("Could not parse input data: ", e);
     }


### PR DESCRIPTION
Puts a battery percentage in the upbat pill of Nightscout. Expects a file that contains a single number, the battery percentage.

uploader.json could be generated with the following `root` cronjob (`sudo crontab -e`)

`*/5 * * * /path/to/EdisonVoltage/voltage 3 > /path/to/openaps/uploader.json`

I've tested the various combinations of --uploader uploader.json / mmtune.json and they all seem to work.