### PR TITLE
JSON speedup, BG conversions

### DIFF
--- a/bin/mm-format-ns-glucose.sh
+++ b/bin/mm-format-ns-glucose.sh
@@ -29,11 +29,11 @@ OUTPUT=${2-/dev/fd/1}
 
 
 cat $HISTORY | \
-  json -e "this.medtronic = this._type;" | \
-  json -e "this.dateString = this.dateString ? this.dateString : (this.date + '$(date +%z)')" | \
-  json -e "this.date = new Date(this.dateString).getTime();" | \
-  json -e "this.type = (this.name == 'GlucoseSensorData') ? 'sgv' : 'pumpdata'" | \
-  json -e "this.device = 'openaps://medtronic/pump/cgm'" | (
-    json -e "$NSONLY"
+  json -E "this.medtronic = this._type;" | \
+  json -E "this.dateString = this.dateString ? this.dateString : (this.date + '$(date +%z)')" | \
+  json -E "this.date = new Date(this.dateString).getTime();" | \
+  json -E "this.type = (this.name == 'GlucoseSensorData') ? 'sgv' : 'pumpdata'" | \
+  json -E "this.device = 'openaps://medtronic/pump/cgm'" | (
+    json -E "$NSONLY"
   ) > $OUTPUT
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -288,7 +288,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     rT.COB=meal_data.mealCOB;
     rT.IOB=iob_data.iob;
-    rT.reason="COB: " + meal_data.mealCOB + ", Dev: " + deviation + ", BGI: " + bgi + ", ISF: " + sens + ", Target: " + target_bg + "; ";
+    rT.reason="COB: " + meal_data.mealCOB + ", Dev: " + deviation + ", BGI: " + bgi + ", ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(target_bg, profile) + "; ";
     if (bg < threshold) { // low glucose suspend mode: BG is < ~80
         rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile);
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {


### PR DESCRIPTION
Output formatting for determine-basal changed in ama, converting the new format to mmol/l

mm-format-ns-glucose was taking a *long* time on my PI. Switching to `json -E` fixed that

```
       Compatibility  note:  There is also a -e CODE option (lowercase "e") from earlier versions of json to do much the same thing (with slightly different semantics for the CODE). It is still supported for backward compatibility.
       However it is deprecated because it can cause processing to be 10x or more slower for large inputs. See the COMPATIBILITY section below.
```