### PR TITLE
Use 10m instead of 5m lookback for deviation

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -138,7 +138,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else {
         tick = glucose_status.delta;
     }
-    var minDelta = Math.min(glucose_status.delta, glucose_status.avgdelta);
+    var minDelta;
+    if (typeof glucose_status.twodelta !== 'undefined' ) {
+        minDelta = Math.min(glucose_status.twodelta, glucose_status.avgdelta);
+    } else {
+        minDelta = Math.min(glucose_status.delta, glucose_status.avgdelta);
+    }
 
     var sens = profile.sens;
     if (typeof autosens_data !== 'undefined' ) {
@@ -298,7 +303,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (glucose_status.delta > minDelta) {
             rT.reason += ", delta " + glucose_status.delta + ">0";
         } else {
-            rT.reason += ", avg delta " + minDelta.toFixed(2) + ">0";
+            rT.reason += ", min delta " + minDelta.toFixed(2) + ">0";
         }
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
@@ -316,7 +321,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if (glucose_status.delta > minDelta) {
                 rT.reason += ", but Delta " + tick + " > Exp. Delta " + expectedDelta;
             } else {
-                rT.reason += ", but Avg. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
+                rT.reason += ", but Min. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
             }
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
                 rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
@@ -376,7 +381,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (glucose_status.delta < minDelta) {
             rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Delta " + tick + " < Exp. Delta " + expectedDelta;
         } else {
-            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Avg. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
+            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Min. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
         }
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -13,7 +13,9 @@ var getLastGlucose = function (data) {
 
     //console.error(data);
     //TODO: calculate average using system_time instead of assuming 1 data point every 5m
-    if (typeof data[5] !== 'undefined' && data[5].glucose > 30) {
+    if (typeof data[6] !== 'undefined' && data[6].glucose > 30) {
+        then = data[6];
+    } else if (typeof data[5] !== 'undefined' && data[5].glucose > 30) {
         then = data[5];
     } else if (typeof data[4] !== 'undefined' && data[4].glucose > 30) {
         then = data[4];
@@ -23,6 +25,7 @@ var getLastGlucose = function (data) {
         then = data[2];
     } else if (typeof data[1] !== 'undefined' && data[1].glucose > 30) {
         then = data[1];
+        secondlast = data[1];
     } else {
         then = data[0];
     }
@@ -34,10 +37,26 @@ var getLastGlucose = function (data) {
         avg = change/minutes * 5;
     } else { console.error("Error: date field not found: cannot calculate avgdelta"); }
 
+    if (typeof data[2] !== 'undefined' && data[2].glucose > 30) {
+        secondtolast = data[2];
+    } else if (typeof data[1] !== 'undefined' && data[1].glucose > 30) {
+        secondtolast = data[1];
+    } else {
+        secondtolast = data[0];
+    }
+    twochange = now.glucose - secondtolast.glucose;
+    if (typeof secondtolast.date !== 'undefined' && typeof now.date !== 'undefined') {
+        minutes = Math.round( (now.date - secondtolast.date) / (1000 * 60) );
+        console.error("Two data point lookback", minutes, "minutes");
+        // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
+        twoavg = twochange/minutes * 5;
+    } else { console.error("Error: date field not found: cannot calculate twodelta"); }
+
     return {
         delta: now.glucose - last.glucose
         , glucose: now.glucose
         , avgdelta: Math.round( avg * 1000 ) / 1000
+        , twodelta: Math.round( twoavg * 1000 ) / 1000
     };
 };
 

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -165,7 +165,7 @@ describe('determine-basal', function ( ) {
         //output.duration.should.equal(0);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
-        output.reason.should.match(/BG 75<80, avg delta .*/);
+        output.reason.should.match(/BG 75<80, min delta .*/);
     });
 
     it('should cancel low-temp when eventualBG is higher then max_bg', function () {
@@ -176,7 +176,7 @@ describe('determine-basal', function ( ) {
         //console.log(output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
-        output.reason.should.match(/BG 75<80, avg delta .*/);
+        output.reason.should.match(/BG 75<80, min delta .*/);
     });
 
     it('should high-temp when > 80-ish and rising w/ lots of negative IOB', function () {
@@ -375,7 +375,7 @@ describe('determine-basal', function ( ) {
         //output.reason.should.match(/.*; cancel/);
         //output.rate.should.equal(0);
         //output.duration.should.equal(0);
-        output.reason.should.match(/Eventual BG.*>.*but Avg. Delta.*< Exp.*/);
+        output.reason.should.match(/Eventual BG.*>.*but Min. Delta.*< Exp.*/);
     });
 
     it('should cancel high-temp when high and delta falling faster than BGI', function () {


### PR DESCRIPTION
Per discussion in https://github.com/openaps/oref0/issues/164, it looks like it'd be better to smooth out our reaction to CGM variation by making many of our decisions on the 10m delta instead of the 5m delta.