### PR TITLE
Support display_time in getLastGlucose

### DIFF
--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -27,8 +27,12 @@ var getLastGlucose = function (data) {
         then = data[0];
     }
     change = now.glucose - then.glucose;
-    if (typeof then.date !== 'undefined' && typeof now.date !== 'undefined') {
-        minutes = Math.round( (now.date - then.date) / (1000 * 60) );
+
+    var then_date = then.date || Date.parse(then.display_time);
+    var now_date = now.date || Date.parse(now.display_time);
+
+    if (typeof then_date !== 'undefined' && typeof now_date !== 'undefined') {
+        minutes = Math.round( (now_date - then_date) / (1000 * 60) );
         console.error("Avgdelta lookback", minutes, "minutes");
         // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
         avg = change/minutes * 5;


### PR DESCRIPTION
This needs to be tested with non-MDT cgm. MDT CGM output has the date in a different format, this will choose `date` if it is present, otherwise it will look for `display_time`.