### PR TITLE
Print max_bg, not profile.max_bg

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -402,7 +402,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var basaliob;
     if (iob_data.basaliob) { basaliob = iob_data.basaliob; }
     else { basaliob = iob_data.iob - iob_data.bolussnooze; }
-    rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " >= " +  convert_bg(profile.max_bg, profile) + ", ";
+    rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " >= " +  convert_bg(max_bg, profile) + ", ";
     if (basaliob > max_iob) {
         rT.reason += "basaliob " + round(basaliob,2) + " > max_iob " + max_iob;
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {


### PR DESCRIPTION
Outputting the wrong target value when eventualBG > target.