### PR TITLE
Pass the "BG data out of date" message on to nightscout

### DIFF
--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -148,13 +148,6 @@ if (!module.parent) {
     } else { console.error("Could not determine last BG time"); }
     var minAgo = (systemTime - bgTime) / 60 / 1000;
 
-    if (minAgo > 10 || minAgo < -5) { // Dexcom data is too old, or way in the future
-        var reason = "BG data is too old, or clock set incorrectly.  Your CGM time is "+bgTime+" but your system time is "+systemTime;
-        console.error(reason);
-        var msg = {msg: reason }
-        errors.push(msg);
-        /// return 1;
-    }
     if (warnings.length) {
       console.error(JSON.stringify(warnings));
     }
@@ -163,6 +156,16 @@ if (!module.parent) {
       console.log(JSON.stringify(errors));
       process.exit(1);
     }
+
+    if (minAgo > 10 || minAgo < -5) { // Dexcom data is too old, or way in the future
+        var reason = "BG data is too old, or clock set incorrectly.  Your CGM time is "+bgTime+" but your system time is "+systemTime;
+        console.error(reason);
+        var msg = {reason: reason }
+	console.log(JSON.stringify(msg));
+//        errors.push(msg);
+        process.exit(1);
+    }
+
 
     if (typeof(iob_data.length) && iob_data.length > 1) {
         console.error(JSON.stringify(iob_data[0]));

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -27,12 +27,8 @@ var getLastGlucose = function (data) {
         then = data[0];
     }
     change = now.glucose - then.glucose;
-
-    var then_date = then.date || Date.parse(then.display_time);
-    var now_date = now.date || Date.parse(now.display_time);
-
-    if (typeof then_date !== 'undefined' && typeof now_date !== 'undefined') {
-        minutes = Math.round( (now_date - then_date) / (1000 * 60) );
+    if (typeof then.date !== 'undefined' && typeof now.date !== 'undefined') {
+        minutes = Math.round( (now.date - then.date) / (1000 * 60) );
         console.error("Avgdelta lookback", minutes, "minutes");
         // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
         avg = change/minutes * 5;


### PR DESCRIPTION
NS wasn't giving a reason for loop not running and it turned out to be the "BG data out of date" case that was causing it. This change allows the error message to be passed to Nightscout.