### PR TITLE
Fix rounding error for small basal rates.

### DIFF
--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -27,13 +27,13 @@ var round_basal = require('./round-basal');
     else if (rate > maxSafeBasal) { 
         rate = maxSafeBasal; 
     }
-    
-    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > 20 && rate < currenttemp.rate + 0.1 && rate > currenttemp.rate - 0.1) {
-        rT.reason += ", but "+currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + rate + "U/hr: no action required";
+
+    var suggestedRate = round_basal(rate, profile);
+    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > 20 && suggestedRate == currenttemp.rate) {
+        rT.reason += ", but "+currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no action required";
         return rT;
     }
 
-    var suggestedRate = round_basal(rate, profile);
     if (suggestedRate === profile.current_basal) {
       if (profile.skip_neutral_temps) {
         if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && currenttemp.duration > 0) {

--- a/tests/set-temp-basal.test.js
+++ b/tests/set-temp-basal.test.js
@@ -80,11 +80,19 @@ describe('tempBasalFunctions.setTempBasal', function ( ) {
     });
 
     it('should allow small basal change when current temp is also small', function () {
-	var rt = {}
+        var rt = {}
         var profile = { "current_basal":0.075,"max_daily_basal":1.3,"max_basal":10.0, "current_basal_safety_multiplier": 5, "model": "523"};
-	var currentTemp = { "rate": 0.025, "duration": 24};
-        var requestedTemp = tempBasalFunctions.setTempBasal(0.05, 30, profile, rt, currentTemp);
-        requestedTemp.rate.should.equal(0.05);
+        var currentTemp = { "rate": 0.025, "duration": 24};
+        var requestedTemp = tempBasalFunctions.setTempBasal(0, 30, profile, rt, currentTemp);
+        requestedTemp.rate.should.equal(0);
         requestedTemp.duration.should.equal(30);
+    });
+
+    it('should not allow small basal change when current temp is large', function () {
+        var rt = {}
+        var profile = { "current_basal":10.075,"max_daily_basal":11.3,"max_basal":50.0, "current_basal_safety_multiplier": 5, "model": "523"};
+        var currentTemp = { "rate": 10.1, "duration": 24};
+        var requestedTemp = tempBasalFunctions.setTempBasal(10.125, 30, profile, rt, currentTemp);
+        requestedTemp.reason.should.equal("undefined, but 24m left and 10.1 ~ req 10.1U/hr: no action required");
     });
 });

--- a/tests/set-temp-basal.test.js
+++ b/tests/set-temp-basal.test.js
@@ -79,4 +79,12 @@ describe('tempBasalFunctions.setTempBasal', function ( ) {
         requestedTemp.duration.should.equal(30);
     });
 
+    it('should allow small basal change when current temp is also small', function () {
+	var rt = {}
+        var profile = { "current_basal":0.075,"max_daily_basal":1.3,"max_basal":10.0, "current_basal_safety_multiplier": 5, "model": "523"};
+	var currentTemp = { "rate": 0.025, "duration": 24};
+        var requestedTemp = tempBasalFunctions.setTempBasal(0.05, 30, profile, rt, currentTemp);
+        requestedTemp.rate.should.equal(0.05);
+        requestedTemp.duration.should.equal(30);
+    });
 });


### PR DESCRIPTION
Fix rounding error that was preventing small changes to small basal rates. Use round_basal instead. #164 