### PR TITLE
Fix rounding error when lowering rate to maxSafeBasal.

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -437,8 +437,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         var maxSafeBasal = tempBasalFunctions.getMaxSafeBasal(profile);
         
         if (rate > maxSafeBasal) {
-            rT.reason += "adj. req. rate: "+rate.toFixed(1) +" to maxSafeBasal: "+maxSafeBasal.toFixed(1)+", ";
-            rate = maxSafeBasal.toFixed(1);
+            rT.reason += "adj. req. rate: "+rate+" to maxSafeBasal: "+maxSafeBasal+", ";
+            rate = round_basal(maxSafeBasal, profile);
         }
 
         var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -688,6 +688,17 @@ describe('determine-basal', function ( ) {
         output.rate.should.equal(5);
         output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal:.*, no temp, setting/);
     });
+
+    it('should round appropriately for small basals when setting basal to maxSafeBasal ', function () {
+        var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
+	var profile2 = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.025,"max_daily_basal":1.3,"max_basal":.05,"max_bg":120,"min_bg":110,"sens":200,"target_bg":110,"model":"523"};
+	var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile2, undefined, meal_data, tempBasalFunctions);
+        output.rate.should.equal(0.05);
+	output.duration.should.equal(30);
+        output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal: 0.05, no temp, setting 0.05/);
+    });
+    
     it('should match the basal rate precision available on a 523', function () {
         //var currenttemp = {"duration":30,"rate":0,"temp":"absolute"};
         var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};


### PR DESCRIPTION
Fix another rounding error involving small basals. 

This would lead determine-basal to suggest a rate higher than maxSafeBasal by as much as 2x (e.g. .05 -> .1). Fortunately, setTempBasal enforces the maxSafeBasal constraint a second time, and there the rounding is done correctly. So the only impact was that the values shown in the reason were wrong. #164 