### PR TITLE
support multiple receivers, and use all recent data points for avgdeltas

### DIFF
--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -51,6 +51,14 @@ if (!module.parent) {
       })
       .strict(true)
       .help('help')
+      .option('exportDefaults', {
+        describe: "Show default preference values",
+        default: false
+      })
+      .option('updatePreferences', {
+        describe: "Check for any keys missing from current prefs and add from defaults",
+        default: false
+      })
 
     var params = argv.argv;
     var pumpsettings_input = params._.slice(0, 1).pop()
@@ -58,6 +66,18 @@ if (!module.parent) {
       usage( );
       process.exit(0);
     }
+    if (params.exportDefaults) {
+        exportDefaults();
+        process.exit(0);
+    }
+    if (params.updatePreferences) {
+        var preferences = {};
+        var cwd = process.cwd()
+        preferences = require(cwd + '/' + params.updatePreferences);
+        updatePreferences(preferences);
+        process.exit(0);
+    }
+
     var bgtargets_input = params._.slice(1, 2).pop()
     var isf_input = params._.slice(2, 3).pop()
     var basalprofile_input = params._.slice(3, 4).pop()
@@ -170,4 +190,5 @@ if (!module.parent) {
     var profile = generate(inputs);
 
     console.log(JSON.stringify(profile));
+
 }

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -28,24 +28,28 @@ function detectSensitivityandCarbAbsorption(inputs) {
         var lastbgTime;
         if (glucose_data[i].display_time) {
             bgTime = new Date(glucose_data[i].display_time.replace('T', ' '));
-            lastbgTime = new Date(glucose_data[i-1].display_time.replace('T', ' '));
         } else if (glucose_data[i].dateString) {
             bgTime = new Date(glucose_data[i].dateString);
+        } else { console.error("Could not determine BG time"); }
+        if (glucose_data[i-1].display_time) {
+            lastbgTime = new Date(glucose_data[i-1].display_time.replace('T', ' '));
+        } else if (glucose_data[i-1].dateString) {
             lastbgTime = new Date(glucose_data[i-1].dateString);
         } else { console.error("Could not determine last BG time"); }
         var elapsed_minutes = (bgTime - lastbgTime)/(60*1000);
-        console.log(elapsed_minutes);
-        if(elapsed_minutes > 2) {
+        console.error(elapsed_minutes);
+        if(Math.abs(elapsed_minutes) > 2) {
             j++;
             bucketed_data[j]=glucose_data[i];
-            bucketed_data[j].bgTime = bgTime;
+            bucketed_data[j].date = bgTime.getTime();
         } else {
             bucketed_data[j].glucose = (bucketed_data[j].glucose + glucose_data[i].glucose)/2;
         }
     }
+    console.error(bucketed_data);
     for (var i=0; i < bucketed_data.length-3; ++i) {
         //console.log(bucketed_data[i]);
-        var bgTime = bucketed_data.bgTime;
+        var bgTime = new Date(bucketed_data.date);
         //console.log(bgTime);
         var bg;
         var avgDelta;

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -37,7 +37,6 @@ function detectSensitivityandCarbAbsorption(inputs) {
             lastbgTime = new Date(glucose_data[i-1].dateString);
         } else { console.error("Could not determine last BG time"); }
         var elapsed_minutes = (bgTime - lastbgTime)/(60*1000);
-        console.error(elapsed_minutes);
         if(Math.abs(elapsed_minutes) > 2) {
             j++;
             bucketed_data[j]=glucose_data[i];
@@ -46,7 +45,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
             bucketed_data[j].glucose = (bucketed_data[j].glucose + glucose_data[i].glucose)/2;
         }
     }
-    console.error(bucketed_data);
+    //console.error(bucketed_data);
     for (var i=0; i < bucketed_data.length-3; ++i) {
         //console.log(bucketed_data[i]);
         var bgTime = new Date(bucketed_data.date);

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -3,7 +3,11 @@ var get_iob = require('oref0/lib/iob');
 
 function detectSensitivityandCarbAbsorption(inputs) {
 
-    glucose_data = inputs.glucose_data;
+    glucose_data = inputs.glucose_data.map(function prepGlucose (obj) {
+        //Support the NS sgv field to avoid having to convert in a custom way
+        obj.glucose = obj.glucose || obj.sgv;
+        return obj;
+    });
     iob_inputs = inputs.iob_inputs;
     basalprofile = inputs.basalprofile;
     profile = inputs.iob_inputs.profile;
@@ -28,16 +32,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
         var bg;
         var avgDelta;
         var delta;
-        //console.error(typeof(glucose_data[i].sgv));
-        if ( typeof(glucose_data[i].sgv) != 'undefined' ) {
-            bg = glucose_data[i].sgv;
-            if ( bg < 40 || glucose_data[i+3].sgv < 40) {
-                process.stderr.write("!");
-                continue;
-            }
-            avgDelta = (bg - glucose_data[i+3].sgv)/3;
-            delta = (bg - glucose_data[i+1].sgv);
-        } else if (typeof(glucose_data[i].glucose) != 'undefined') {
+        if (typeof(glucose_data[i].glucose) != 'undefined') {
             bg = glucose_data[i].glucose;
             if ( bg < 40 || glucose_data[i+3].glucose < 40) {
                 process.stderr.write("!");

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -48,7 +48,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
     //console.error(bucketed_data);
     for (var i=0; i < bucketed_data.length-3; ++i) {
         //console.log(bucketed_data[i]);
-        var bgTime = new Date(bucketed_data.date);
+        var bgTime = new Date(bucketed_data[i].date);
         //console.log(bgTime);
         var bg;
         var avgDelta;
@@ -113,6 +113,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
     bgis.sort(function(a, b){return a-b});
     deviations.sort(function(a, b){return a-b});
     for (var i=0.9; i > 0.1; i = i - 0.02) {
+        //console.error("p="+i.toFixed(2)+": "+percentile(avgDeltas, i).toFixed(2)+", "+percentile(bgis, i).toFixed(2)+", "+percentile(deviations, i).toFixed(2));
         if ( percentile(deviations, (i+0.02)) >= 0 && percentile(deviations, i) < 0 ) {
             //console.error("p="+i.toFixed(2)+": "+percentile(avgDeltas, i).toFixed(2)+", "+percentile(bgis, i).toFixed(2)+", "+percentile(deviations, i).toFixed(2));
             console.error(Math.round(100*i)+"% of non-meal deviations negative (target 45%-50%)");

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -20,26 +20,44 @@ function detectSensitivityandCarbAbsorption(inputs) {
     var deviations = [];
     var deviationSum = 0;
     var carbsAbsorbed = 0;
-    for (var i=0; i < glucose_data.length-3; ++i) {
-        //console.log(glucose_data[i]);
+    var bucketed_data = [];
+    bucketed_data[0] = glucose_data[0];
+    j=0;
+    for (var i=1; i < glucose_data.length; ++i) {
         var bgTime;
+        var lastbgTime;
         if (glucose_data[i].display_time) {
             bgTime = new Date(glucose_data[i].display_time.replace('T', ' '));
+            lastbgTime = new Date(glucose_data[i-1].display_time.replace('T', ' '));
         } else if (glucose_data[i].dateString) {
             bgTime = new Date(glucose_data[i].dateString);
+            lastbgTime = new Date(glucose_data[i-1].dateString);
         } else { console.error("Could not determine last BG time"); }
+        var elapsed_minutes = (bgTime - lastbgTime)/(60*1000);
+        console.log(elapsed_minutes);
+        if(elapsed_minutes > 2) {
+            j++;
+            bucketed_data[j]=glucose_data[i];
+            bucketed_data[j].bgTime = bgTime;
+        } else {
+            bucketed_data[j].glucose = (bucketed_data[j].glucose + glucose_data[i].glucose)/2;
+        }
+    }
+    for (var i=0; i < bucketed_data.length-3; ++i) {
+        //console.log(bucketed_data[i]);
+        var bgTime = bucketed_data.bgTime;
         //console.log(bgTime);
         var bg;
         var avgDelta;
         var delta;
-        if (typeof(glucose_data[i].glucose) != 'undefined') {
-            bg = glucose_data[i].glucose;
-            if ( bg < 40 || glucose_data[i+3].glucose < 40) {
+        if (typeof(bucketed_data[i].glucose) != 'undefined') {
+            bg = bucketed_data[i].glucose;
+            if ( bg < 40 || bucketed_data[i+3].glucose < 40) {
                 process.stderr.write("!");
                 continue;
             }
-            avgDelta = (bg - glucose_data[i+3].glucose)/3;
-            delta = (bg - glucose_data[i+1].glucose);
+            avgDelta = (bg - bucketed_data[i+3].glucose)/3;
+            delta = (bg - bucketed_data[i+1].glucose);
         } else { console.error("Could not find glucose data"); }
 
         avgDelta = avgDelta.toFixed(2);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -437,8 +437,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         var maxSafeBasal = tempBasalFunctions.getMaxSafeBasal(profile);
         
         if (rate > maxSafeBasal) {
-            rT.reason += "adj. req. rate: "+rate.toFixed(1) +" to maxSafeBasal: "+maxSafeBasal.toFixed(1)+", ";
-            rate = maxSafeBasal.toFixed(1);
+            rT.reason += "adj. req. rate: "+rate+" to maxSafeBasal: "+maxSafeBasal+", ";
+            rate = round_basal(maxSafeBasal, profile);
         }
 
         var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -134,9 +134,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var tick;
 
     if (glucose_status.delta >= 0) {
-        tick = "+" + round(glucose_status.delta,1);
+        tick = "+" + round(glucose_status.delta,0);
     } else {
-        tick = round(glucose_status.delta,1);
+        tick = round(glucose_status.delta,0);
     }
     var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
     var minAvgDelta = Math.min(glucose_status.short_avgdelta, glucose_status.long_avgdelta);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -133,7 +133,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     var tick;
 
-    if (glucose_status.delta >= 0) {
+    if (glucose_status.delta > -0.5) {
         tick = "+" + round(glucose_status.delta,0);
     } else {
         tick = round(glucose_status.delta,0);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -134,9 +134,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var tick;
 
     if (glucose_status.delta >= 0) {
-        tick = "+" + glucose_status.delta;
+        tick = "+" + round(glucose_status.delta,1);
     } else {
-        tick = glucose_status.delta;
+        tick = round(glucose_status.delta,1);
     }
     var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
     var minAvgDelta = Math.min(glucose_status.short_avgdelta, glucose_status.long_avgdelta);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -356,8 +356,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 rate = round_basal(rate, profile);
                 // if required temp < existing temp basal
                 var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
-                if (insulinScheduled < insulinReq - 0.2) { // if current temp would deliver >0.2U less than the required insulin, raise the rate
-                    rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate - basal).toFixed(3) + " = " + insulinScheduled.toFixed(3) + " < req " + insulinReq + "-0.2U";
+                if (insulinScheduled < insulinReq - basal*0.3) { // if current temp would deliver a lot (30% of basal) less than the required insulin, raise the rate
+                    rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate - basal).toFixed(3) + " = " + insulinScheduled.toFixed(3) + " < req " + insulinReq + "-" + basal*0.3;
                     return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
                 }
                 if (typeof currenttemp.rate !== 'undefined' && (currenttemp.duration > 5 && rate >= currenttemp.rate * 0.8)) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -138,7 +138,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else {
         tick = glucose_status.delta;
     }
-    var minDelta = Math.min(glucose_status.delta, glucose_status.avgdelta);
+    var minDelta;
+    if (typeof glucose_status.twodelta !== 'undefined' ) {
+        minDelta = Math.min(glucose_status.twodelta, glucose_status.avgdelta);
+    } else {
+        minDelta = Math.min(glucose_status.delta, glucose_status.avgdelta);
+    }
 
     var sens = profile.sens;
     if (typeof autosens_data !== 'undefined' ) {
@@ -298,7 +303,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (glucose_status.delta > minDelta) {
             rT.reason += ", delta " + glucose_status.delta + ">0";
         } else {
-            rT.reason += ", avg delta " + minDelta.toFixed(2) + ">0";
+            rT.reason += ", min delta " + minDelta.toFixed(2) + ">0";
         }
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
@@ -316,7 +321,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if (glucose_status.delta > minDelta) {
                 rT.reason += ", but Delta " + tick + " > Exp. Delta " + expectedDelta;
             } else {
-                rT.reason += ", but Avg. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
+                rT.reason += ", but Min. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
             }
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
                 rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
@@ -376,7 +381,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (glucose_status.delta < minDelta) {
             rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Delta " + tick + " < Exp. Delta " + expectedDelta;
         } else {
-            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Avg. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
+            rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Min. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
         }
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
             rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -138,12 +138,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else {
         tick = glucose_status.delta;
     }
-    var minDelta;
-    if (typeof glucose_status.twodelta !== 'undefined' ) {
-        minDelta = Math.min(glucose_status.twodelta, glucose_status.avgdelta);
-    } else {
-        minDelta = Math.min(glucose_status.delta, glucose_status.avgdelta);
-    }
+    var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
+    var minAvgDelta = Math.min(glucose_status.short_avgdelta, glucose_status.long_avgdelta);
 
     var sens = profile.sens;
     if (typeof autosens_data !== 'undefined' ) {
@@ -158,9 +154,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var bgi = round(( -iob_data.activity * sens * 5 ), 2);
     // project deviations for 30 minutes
     var deviation = Math.round( 30 / 5 * ( minDelta - bgi ) );
-    // don't overreact to a big negative delta: use avgdelta if deviation is negative
+    // don't overreact to a big negative delta: use minAvgDelta if deviation is negative
     if (deviation < 0) {
-        deviation = Math.round( (30 / 5) * ( glucose_status.avgdelta - bgi ) );
+        deviation = Math.round( (30 / 5) * ( minAvgDelta - bgi ) );
     }
 
     // calculate the naive (bolus calculator math) eventual BG based on net IOB and sensitivity

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -6,7 +6,7 @@ var getLastGlucose = function (data) {
     });
 
     var now = data[0];
-    var now_date = now.date || Date.parse(now.display_time);
+    var now_date = now.date || Date.parse(now.display_time) || Date.parse(then.dateString);
     var change;
     var last_deltas = [];
     var short_deltas = [];
@@ -15,7 +15,7 @@ var getLastGlucose = function (data) {
     for (i=1; i < data.length; i++) {
         if (typeof data[i] !== 'undefined' && data[i].glucose > 30) {
             var then = data[i];
-            var then_date = then.date || Date.parse(then.display_time);
+            var then_date = then.date || Date.parse(then.display_time) || Date.parse(then.dateString);
             var avgdelta = 0;
             var minutesago;
             if (typeof then_date !== 'undefined' && typeof now_date !== 'undefined') {

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -55,10 +55,10 @@ var getLastGlucose = function (data) {
     }
 
     return {
-        delta: Math.round( last_delta * 1000 ) / 1000
-        , glucose: Math.round( now.glucose * 1000 ) / 1000
-        , short_avgdelta: Math.round( short_avgdelta * 1000 ) / 1000
-        , long_avgdelta: Math.round( long_avgdelta * 1000 ) / 1000
+        delta: Math.round( last_delta * 100 ) / 100
+        , glucose: Math.round( now.glucose * 100 ) / 100
+        , short_avgdelta: Math.round( short_avgdelta * 100 ) / 100
+        , long_avgdelta: Math.round( long_avgdelta * 100 ) / 100
     };
 };
 

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -13,7 +13,9 @@ var getLastGlucose = function (data) {
 
     //console.error(data);
     //TODO: calculate average using system_time instead of assuming 1 data point every 5m
-    if (typeof data[5] !== 'undefined' && data[5].glucose > 30) {
+    if (typeof data[6] !== 'undefined' && data[6].glucose > 30) {
+        then = data[6];
+    } else if (typeof data[5] !== 'undefined' && data[5].glucose > 30) {
         then = data[5];
     } else if (typeof data[4] !== 'undefined' && data[4].glucose > 30) {
         then = data[4];
@@ -23,6 +25,7 @@ var getLastGlucose = function (data) {
         then = data[2];
     } else if (typeof data[1] !== 'undefined' && data[1].glucose > 30) {
         then = data[1];
+        secondlast = data[1];
     } else {
         then = data[0];
     }
@@ -34,10 +37,26 @@ var getLastGlucose = function (data) {
         avg = change/minutes * 5;
     } else { console.error("Error: date field not found: cannot calculate avgdelta"); }
 
+    if (typeof data[2] !== 'undefined' && data[2].glucose > 30) {
+        secondtolast = data[2];
+    } else if (typeof data[1] !== 'undefined' && data[1].glucose > 30) {
+        secondtolast = data[1];
+    } else {
+        secondtolast = data[0];
+    }
+    twochange = now.glucose - secondtolast.glucose;
+    if (typeof secondtolast.date !== 'undefined' && typeof now.date !== 'undefined') {
+        minutes = Math.round( (now.date - secondtolast.date) / (1000 * 60) );
+        console.error("Two data point lookback", minutes, "minutes");
+        // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
+        twoavg = twochange/minutes * 5;
+    } else { console.error("Error: date field not found: cannot calculate twodelta"); }
+
     return {
         delta: now.glucose - last.glucose
         , glucose: now.glucose
         , avgdelta: Math.round( avg * 1000 ) / 1000
+        , twodelta: Math.round( twoavg * 1000 ) / 1000
     };
 };
 

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -7,56 +7,58 @@ var getLastGlucose = function (data) {
 
     var now = data[0];
     var last = data[1];
-    var minutes;
     var change;
-    var avg = 0;
+    var last_deltas = [];
+    var short_deltas = [];
+    var long_deltas = [];
 
-    //console.error(data);
-    //TODO: calculate average using system_time instead of assuming 1 data point every 5m
-    if (typeof data[6] !== 'undefined' && data[6].glucose > 30) {
-        then = data[6];
-    } else if (typeof data[5] !== 'undefined' && data[5].glucose > 30) {
-        then = data[5];
-    } else if (typeof data[4] !== 'undefined' && data[4].glucose > 30) {
-        then = data[4];
-    } else if (typeof data[3] !== 'undefined' && data[3].glucose > 30) {
-        then = data[3];
-    } else if (typeof data[2] !== 'undefined' && data[2].glucose > 30) {
-        then = data[2];
-    } else if (typeof data[1] !== 'undefined' && data[1].glucose > 30) {
-        then = data[1];
-        secondlast = data[1];
-    } else {
-        then = data[0];
+    for (i=1; i < data.length; i++) {
+        if (typeof data[i] !== 'undefined' && data[i].glucose > 30) {
+            var then = data[i];
+            var avgdelta = 0;
+            var minutesago;
+            if (typeof then.date !== 'undefined' && typeof now.date !== 'undefined') {
+                minutesago = Math.round( (now.date - then.date) / (1000 * 60) );
+                // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
+                change = now.glucose - then.glucose;
+                avgdelta = change/minutesago * 5;
+            } else { console.error("Error: date field not found: cannot calculate avgdelta"); }
+            // use the average of all data points in the last 2.5m for all further "now" calculations
+            if (0 < minutesago && minutesago < 2.5) {
+                now.glucose = ( now.glucose + then.glucose ) / 2;
+                now.date = ( now.date + then.date ) / 2;
+            // short_deltas are calculated from everything ~5-15 minutes ago
+            } else if (2.5 < minutesago && minutesago < 17.5) {
+                //console.error(minutesago, avgdelta);
+                short_deltas.push(avgdelta);
+                // last_deltas are calculated from everything ~5 minutes ago
+                if (2.5 < minutesago && minutesago < 7.5) {
+                    last_deltas.push(avgdelta);
+                }
+            // long_deltas are calculated from everything ~20-40 minutes ago
+            } else if (17.5 < minutesago && minutesago < 42.5) {
+                long_deltas.push(avgdelta);
+            }
+        }
     }
-    change = now.glucose - then.glucose;
-    if (typeof then.date !== 'undefined' && typeof now.date !== 'undefined') {
-        minutes = Math.round( (now.date - then.date) / (1000 * 60) );
-        console.error("Avgdelta lookback", minutes, "minutes");
-        // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
-        avg = change/minutes * 5;
-    } else { console.error("Error: date field not found: cannot calculate avgdelta"); }
-
-    if (typeof data[2] !== 'undefined' && data[2].glucose > 30) {
-        secondtolast = data[2];
-    } else if (typeof data[1] !== 'undefined' && data[1].glucose > 30) {
-        secondtolast = data[1];
-    } else {
-        secondtolast = data[0];
+    var last_delta = 0;
+    var short_avgdelta = 0;
+    var long_avgdelta = 0;
+    if (last_deltas.length > 0) {
+        last_delta = last_deltas.reduce(function(a, b) { return a + b; }) / last_deltas.length;
     }
-    twochange = now.glucose - secondtolast.glucose;
-    if (typeof secondtolast.date !== 'undefined' && typeof now.date !== 'undefined') {
-        minutes = Math.round( (now.date - secondtolast.date) / (1000 * 60) );
-        console.error("Two data point lookback", minutes, "minutes");
-        // multiply by 5 to get the same units as delta, i.e. mg/dL/5m
-        twoavg = twochange/minutes * 5;
-    } else { console.error("Error: date field not found: cannot calculate twodelta"); }
+    if (short_deltas.length > 0) {
+        short_avgdelta = short_deltas.reduce(function(a, b) { return a + b; }) / short_deltas.length;
+    }
+    if (long_deltas.length > 0) {
+        long_avgdelta = long_deltas.reduce(function(a, b) { return a + b; }) / long_deltas.length;
+    }
 
     return {
-        delta: now.glucose - last.glucose
-        , glucose: now.glucose
-        , avgdelta: Math.round( avg * 1000 ) / 1000
-        , twodelta: Math.round( twoavg * 1000 ) / 1000
+        delta: Math.round( last_delta * 1000 ) / 1000
+        , glucose: Math.round( now.glucose * 1000 ) / 1000
+        , short_avgdelta: Math.round( short_avgdelta * 1000 ) / 1000
+        , long_avgdelta: Math.round( long_avgdelta * 1000 ) / 1000
     };
 };
 

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -78,7 +78,7 @@ describe('determine-basal', function ( ) {
    //function determine_basal(glucose_status, currenttemp, iob_data, profile)
 
     // standard initial conditions for all determine-basal test cases unless overridden
-    var glucose_status = {"delta":0,"glucose":115,"avgdelta":0};
+    var glucose_status = {"delta":0,"glucose":115,"long_avgdelta":0,"short_avgdelta":0};
     var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
     var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
     var profile = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.9,"max_daily_basal":1.3,"max_basal":3.5,"max_bg":120,"min_bg":110,"sens":40,"target_bg":110,"carb_ratio":10};
@@ -97,7 +97,7 @@ describe('determine-basal', function ( ) {
 
     // low glucose suspend test cases
     it('should temp to 0 when low w/o IOB', function () {
-        var glucose_status = {"delta":-5,"glucose":75,"avgdelta":-5};
+        var glucose_status = {"delta":-5,"glucose":75,"long_avgdelta":-5,"short_avgdelta":-5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
         output.duration.should.equal(30);
@@ -106,7 +106,7 @@ describe('determine-basal', function ( ) {
 
     it('should not extend temp to 0 when >20m left', function () {
         var currenttemp = {"duration":27,"rate":0,"temp":"absolute"};
-        var glucose_status = {"delta":-5,"glucose":75,"avgdelta":-5};
+        var glucose_status = {"delta":-5,"glucose":75,"long_avgdelta":-5,"short_avgdelta":-5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         (typeof output.rate).should.equal('undefined');
@@ -114,7 +114,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should do nothing when low and rising w/o IOB', function () {
-        var glucose_status = {"delta":5,"glucose":75,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":75,"long_avgdelta":5,"short_avgdelta":5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
@@ -122,7 +122,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should do nothing when low and rising w/ negative IOB', function () {
-        var glucose_status = {"delta":5,"glucose":75,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":75,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
@@ -131,7 +131,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should do nothing on large uptick even if avgdelta is still negative', function () {
-        var glucose_status = {"delta":4,"glucose":75,"avgdelta":-2};
+        var glucose_status = {"delta":4,"glucose":75,"long_avgdelta":-2,"short_avgdelta":-2};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
@@ -139,7 +139,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when rising slower than BGI', function () {
-        var glucose_status = {"delta":1,"glucose":75,"avgdelta":1};
+        var glucose_status = {"delta":1,"glucose":75,"long_avgdelta":1,"short_avgdelta":1};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
@@ -148,7 +148,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when low and falling, regardless of BGI', function () {
-        var glucose_status = {"delta":-1,"glucose":75,"avgdelta":-1};
+        var glucose_status = {"delta":-1,"glucose":75,"long_avgdelta":-1,"short_avgdelta":-1};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
@@ -158,7 +158,7 @@ describe('determine-basal', function ( ) {
 
     it('should cancel high-temp when low and rising faster than BGI', function () {
         var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
-        var glucose_status = {"delta":5,"glucose":75,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":75,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //output.rate.should.equal(0);
@@ -170,7 +170,7 @@ describe('determine-basal', function ( ) {
 
     it('should cancel low-temp when eventualBG is higher then max_bg', function () {
         var currenttemp = {"duration":20,"rate":0,"temp":"absolute"};
-        var glucose_status = {"delta":5,"glucose":75,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":75,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
@@ -180,7 +180,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should high-temp when > 80-ish and rising w/ lots of negative IOB', function () {
-        var glucose_status = {"delta":5,"glucose":85,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":85,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":-1,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
@@ -189,14 +189,14 @@ describe('determine-basal', function ( ) {
     });
 
     it('should high-temp when > 180-ish and rising but not more then maxSafeBasal', function () {
-        var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":185,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal:.*, no temp, setting/);
     });
 
     it('should reduce high-temp when schedule would be above max', function () {
-        var glucose_status = {"delta":5,"glucose":145,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":145,"long_avgdelta":5,"short_avgdelta":5};
         var currenttemp = {"duration":160,"rate":1.9,"temp":"absolute"};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
@@ -205,7 +205,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should continue high-temp when required ~= temp running', function () {
-        var glucose_status = {"delta":5,"glucose":145,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":145,"long_avgdelta":5,"short_avgdelta":5};
         var currenttemp = {"duration":30,"rate":3.5,"temp":"absolute"};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
@@ -216,7 +216,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should set high-temp when required running temp is low', function () {
-        var glucose_status = {"delta":5,"glucose":145,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":145,"long_avgdelta":5,"short_avgdelta":5};
         var currenttemp = {"duration":30,"rate":1.1,"temp":"absolute"};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
@@ -225,7 +225,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should stop high-temp when iob is near max_iob.', function () {
-        var glucose_status = {"delta":5,"glucose":485,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":485,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":3.5,"activity":0.05,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
@@ -234,7 +234,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when LOW w/ positive IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0,"short_avgdelta":0};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
@@ -243,7 +243,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when LOW w/ negative IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0,"short_avgdelta":0};
         var iob_data = {"iob":-2.5,"activity":-0.03,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
@@ -252,7 +252,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when LOW w/ no IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0,"short_avgdelta":0};
         var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
@@ -265,7 +265,7 @@ describe('determine-basal', function ( ) {
     // low eventualBG
 
     it('should low-temp when eventualBG < min_bg', function () {
-        var glucose_status = {"delta":-3,"glucose":110,"avgdelta":-1};
+        var glucose_status = {"delta":-3,"glucose":110,"long_avgdelta":-1,"short_avgdelta":-1};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.be.below(0.8);
@@ -274,7 +274,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
-        var glucose_status = {"delta":-5,"glucose":115,"avgdelta":-6};
+        var glucose_status = {"delta":-5,"glucose":115,"long_avgdelta":-6,"short_avgdelta":-6};
         var iob_data = {"iob":2,"activity":0.05,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
@@ -284,7 +284,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
-        var glucose_status = {"delta":-2,"glucose":156,"avgdelta":-1.33};
+        var glucose_status = {"delta":-2,"glucose":156,"long_avgdelta":-1.33,"short_avgdelta":-1.33};
         var iob_data = {"iob":3.51,"activity":0.06,"bolussnooze":0.08};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
@@ -294,7 +294,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should low-temp much less when eventualBG < min_bg with delta barely negative', function () {
-        var glucose_status = {"delta":-1,"glucose":115,"avgdelta":-1};
+        var glucose_status = {"delta":-1,"glucose":115,"long_avgdelta":-1,"short_avgdelta":-1};
         var iob_data = {"iob":2,"activity":0.05,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(0.3);
@@ -304,7 +304,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should do nothing when eventualBG < min_bg but appropriate low temp in progress', function () {
-        var glucose_status = {"delta":-1,"glucose":110,"avgdelta":-1};
+        var glucose_status = {"delta":-1,"glucose":110,"long_avgdelta":-1,"short_avgdelta":-1};
         var currenttemp = {"duration":20,"rate":0.25,"temp":"absolute"};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         (typeof output.rate).should.equal('undefined');
@@ -314,7 +314,7 @@ describe('determine-basal', function ( ) {
 
     it('should cancel low-temp when lowish and avg.delta rising faster than BGI', function () {
         var currenttemp = {"duration":20,"rate":0.5,"temp":"absolute"};
-        var glucose_status = {"delta":3,"glucose":85,"avgdelta":3};
+        var glucose_status = {"delta":3,"glucose":85,"long_avgdelta":3,"short_avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
@@ -326,7 +326,7 @@ describe('determine-basal', function ( ) {
 
     it('should cancel low-temp when lowish and delta rising faster than BGI', function () {
         var currenttemp = {"duration":20,"rate":0.5,"temp":"absolute"};
-        var glucose_status = {"delta":3,"glucose":85,"avgdelta":3};
+        var glucose_status = {"delta":3,"glucose":85,"long_avgdelta":3,"short_avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
@@ -335,7 +335,7 @@ describe('determine-basal', function ( ) {
 
     it('should set current basal as temp when lowish and delta rising faster than BGI', function () {
         var currenttemp = {"duration":0,"rate":0.5,"temp":"absolute"};
-        var glucose_status = {"delta":3,"glucose":85,"avgdelta":3};
+        var glucose_status = {"delta":3,"glucose":85,"long_avgdelta":3,"short_avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //(typeof output.rate).should.equal('undefined');
@@ -347,7 +347,7 @@ describe('determine-basal', function ( ) {
 
 
     it('should low-temp when low and rising slower than BGI', function () {
-        var glucose_status = {"delta":1,"glucose":85,"avgdelta":1};
+        var glucose_status = {"delta":1,"glucose":85,"long_avgdelta":1,"short_avgdelta":1};
         var iob_data = {"iob":-0.5,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.below(0.8);
@@ -358,7 +358,7 @@ describe('determine-basal', function ( ) {
     // high eventualBG
 
     it('should high-temp when eventualBG > max_bg', function () {
-        var glucose_status = {"delta":+3,"glucose":120,"avgdelta":+1};
+        var glucose_status = {"delta":+3,"glucose":120,"long_avgdelta":0,"short_avgdelta":+1};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
         output.duration.should.equal(30);
@@ -367,7 +367,7 @@ describe('determine-basal', function ( ) {
 
     it('should cancel high-temp when high and avg. delta falling faster than BGI', function () {
         var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
-        var glucose_status = {"delta":-5,"glucose":175,"avgdelta":-5};
+        var glucose_status = {"delta":-5,"glucose":175,"long_avgdelta":-5,"short_avgdelta":-5};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
@@ -380,7 +380,7 @@ describe('determine-basal', function ( ) {
 
     it('should cancel high-temp when high and delta falling faster than BGI', function () {
         var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
-        var glucose_status = {"delta":-5,"glucose":175,"avgdelta":-4};
+        var glucose_status = {"delta":-5,"glucose":175,"long_avgdelta":-4,"short_avgdelta":-4};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.9);
@@ -390,7 +390,7 @@ describe('determine-basal', function ( ) {
 
     it('should do nothing when no temp and high and delta falling faster than BGI', function () {
         var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
-        var glucose_status = {"delta":-5,"glucose":175,"avgdelta":-4};
+        var glucose_status = {"delta":-5,"glucose":175,"long_avgdelta":-4,"short_avgdelta":-4};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //(typeof output.rate).should.equal('undefined');
@@ -401,7 +401,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should high-temp when high and falling slower than BGI', function () {
-        var glucose_status = {"delta":-1,"glucose":175,"avgdelta":-1};
+        var glucose_status = {"delta":-1,"glucose":175,"long_avgdelta":-1,"short_avgdelta":-1};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
@@ -410,7 +410,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should high-temp when high and falling slowly with low insulin activity', function () {
-        var glucose_status = {"delta":-1,"glucose":300,"avgdelta":-1};
+        var glucose_status = {"delta":-1,"glucose":300,"long_avgdelta":-1,"short_avgdelta":-1};
         var iob_data = {"iob":0.5,"activity":0.005,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(2.5);
@@ -419,7 +419,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should set lower high-temp when high and falling almost fast enough with low insulin activity', function () {
-        var glucose_status = {"delta":-8,"glucose":300,"avgdelta":-5};
+        var glucose_status = {"delta":-8,"glucose":300,"long_avgdelta":-5,"short_avgdelta":-5};
         var iob_data = {"iob":0.5,"activity":0.005,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.above(1);
@@ -429,7 +429,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should reduce high-temp when high and falling almost fast enough with low insulin activity', function () {
-        var glucose_status = {"delta":-8,"glucose":300,"avgdelta":-5};
+        var glucose_status = {"delta":-8,"glucose":300,"long_avgdelta":-5,"short_avgdelta":-5};
         var iob_data = {"iob":0.5,"activity":0.005,"bolussnooze":0};
         var currenttemp = {"duration":30,"rate":2.5,"temp":"absolute"};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
@@ -485,7 +485,7 @@ describe('determine-basal', function ( ) {
     // meal assist / bolus snooze
     // right after 20g 1U meal bolus
     it('should set current basal as temp when low and rising after meal bolus', function () {
-        var glucose_status = {"delta":1,"glucose":80,"avgdelta":1};
+        var glucose_status = {"delta":1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
         var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
         var meal_data = {"carbs":20,"boluses":1, "mealCOB":20};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
@@ -494,7 +494,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should do nothing when requested temp already running with >15m left', function () {
-        var glucose_status = {"delta":-2,"glucose":121,"avgdelta":-1.333};
+        var glucose_status = {"delta":-2,"glucose":121,"long_avgdelta":-1.333,"short_avgdelta":-1.333};
         var iob_data = {"iob":3.983,"activity":0.0255,"bolussnooze":2.58,"basaliob":0.384,"netbasalinsulin":0.3,"hightempinsulin":0.7};
         var meal_data = {"carbs":65,"boluses":4, "mealCOB":65};
         var currenttemp = {"duration":29,"rate":1.3,"temp":"absolute"};
@@ -506,7 +506,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should cancel high temp when low and dropping after meal bolus', function () {
-        var glucose_status = {"delta":-1,"glucose":80,"avgdelta":1};
+        var glucose_status = {"delta":-1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
         var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
         var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
@@ -518,7 +518,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should cancel low temp when low and rising after meal bolus', function () {
-        var glucose_status = {"delta":1,"glucose":80,"avgdelta":1};
+        var glucose_status = {"delta":1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
         var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
         var currenttemp = {"duration":20,"rate":0,"temp":"absolute"};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
@@ -660,7 +660,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('maxSafeBasal current_basal_safety_multiplier of 1 should cause the current rate to be set, even if higher is needed', function () {
-        var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":185,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
         profile.current_basal_safety_multiplier = 1;
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
@@ -669,7 +669,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('maxSafeBasal max_daily_safety_multiplier of 1 should cause the max daily rate to be set, even if higher is needed', function () {
-        var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":185,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
         profile.current_basal_safety_multiplier = null;
         profile.max_daily_safety_multiplier = 1;
@@ -679,7 +679,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('overriding maxSafeBasal multipliers to 10 should increase temp', function () {
-        var glucose_status = {"delta":5,"glucose":285,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":285,"long_avgdelta":5,"short_avgdelta":5};
         var iob_data = {"iob":0,"activity":-0.01,"bolussnooze":0};
         profile.max_basal = 5;
         profile.current_basal_safety_multiplier = 10;
@@ -690,7 +690,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should round appropriately for small basals when setting basal to maxSafeBasal ', function () {
-        var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
+        var glucose_status = {"delta":5,"glucose":185,"long_avgdelta":5,"short_avgdelta":5};
 	var profile2 = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.025,"max_daily_basal":1.3,"max_basal":.05,"max_bg":120,"min_bg":110,"sens":200,"target_bg":110,"model":"523"};
 	var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile2, undefined, meal_data, tempBasalFunctions);

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -688,6 +688,17 @@ describe('determine-basal', function ( ) {
         output.rate.should.equal(5);
         output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal:.*, no temp, setting/);
     });
+
+    it('should round appropriately for small basals when setting basal to maxSafeBasal ', function () {
+        var glucose_status = {"delta":5,"glucose":185,"avgdelta":5};
+	var profile2 = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.025,"max_daily_basal":1.3,"max_basal":.05,"max_bg":120,"min_bg":110,"sens":200,"target_bg":110,"model":"523"};
+	var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile2, undefined, meal_data, tempBasalFunctions);
+        output.rate.should.equal(0.05);
+	output.duration.should.equal(30);
+        output.reason.should.match(/.*, adj. req. rate:.* to maxSafeBasal: 0.05, no temp, setting 0.05/);
+    });
+    
     it('should match the basal rate precision available on a 523', function () {
         //var currenttemp = {"duration":30,"rate":0,"temp":"absolute"};
         var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -165,7 +165,7 @@ describe('determine-basal', function ( ) {
         //output.duration.should.equal(0);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
-        output.reason.should.match(/BG 75<80, avg delta .*/);
+        output.reason.should.match(/BG 75<80, min delta .*/);
     });
 
     it('should cancel low-temp when eventualBG is higher then max_bg', function () {
@@ -176,7 +176,7 @@ describe('determine-basal', function ( ) {
         //console.log(output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
-        output.reason.should.match(/BG 75<80, avg delta .*/);
+        output.reason.should.match(/BG 75<80, min delta .*/);
     });
 
     it('should high-temp when > 80-ish and rising w/ lots of negative IOB', function () {
@@ -375,7 +375,7 @@ describe('determine-basal', function ( ) {
         //output.reason.should.match(/.*; cancel/);
         //output.rate.should.equal(0);
         //output.duration.should.equal(0);
-        output.reason.should.match(/Eventual BG.*>.*but Avg. Delta.*< Exp.*/);
+        output.reason.should.match(/Eventual BG.*>.*but Min. Delta.*< Exp.*/);
     });
 
     it('should cancel high-temp when high and delta falling faster than BGI', function () {

--- a/tests/get-last-glucose.test.js
+++ b/tests/get-last-glucose.test.js
@@ -7,9 +7,27 @@ describe('getLastGlucose', function ( ) {
     var getLastGlucose = require('../lib/glucose-get-last.js');
     
     it('should handle NS sgv fields', function () {
-      var glucose_status = getLastGlucose([{date: 1467942845000, sgv: 100}, {date: 1467942845000, sgv: 95}, {date: 1467942244000, sgv: 90}, {date: 1467941944000, sgv: 70}]);
+      var glucose_status = getLastGlucose([{date: 1467942845000, sgv: 100}, {date: 1467942544500, sgv: 95}, {date: 1467942244000, sgv: 85}, {date: 1467941944000, sgv: 70}]);
+      //console.log(glucose_status);
       glucose_status.delta.should.equal(5);
       glucose_status.glucose.should.equal(100);
-      glucose_status.avgdelta.should.equal(10);
+      glucose_status.short_avgdelta.should.equal(7.5);
+      glucose_status.long_avgdelta.should.equal(0);
+    });
+    it('should handle two receivers 30s and 3 mg/dL offset', function () {
+      var glucose_status = getLastGlucose([{date: 1467942875000, sgv: 103}, {date: 1467942845000, sgv: 100}, {date: 1467942574500, sgv: 98}, {date: 1467942544500, sgv: 95}, {date: 1467942274000, sgv: 88}, {date: 1467942244000, sgv: 85}, {date: 1467941974000, sgv: 73}, {date: 1467941944000, sgv: 70}]);
+      //console.log(glucose_status);
+      glucose_status.delta.should.equal(5);
+      glucose_status.glucose.should.equal(101.5);
+      glucose_status.short_avgdelta.should.equal(7.5);
+      glucose_status.long_avgdelta.should.equal(0);
+    });
+    it('should handle fields named glucose and calculate long_avgdelta', function () {
+      var glucose_status = getLastGlucose([{"date": 1469509700000, "glucose": 97}, {"date": 1469509400000, "glucose": 94}, {"date": 1469509100000, "glucose": 87}, {"date": 1469508800000, "glucose": 81}, {"date": 1469508500000, "glucose": 78}, {"date": 1469508200000, "glucose": 78}, {"date": 1469507900000, "glucose": 81}, {"date": 1469507600000, "glucose": 84}, {"date": 1469507300000, "glucose": 87}, {"date": 1469507000000, "glucose": 93}, {"date": 1469506700000, "glucose": 102}, {"date": 1469506400000, "glucose": 104}, {"date": 1469506100000, "glucose": 99}, {"date": 1469505800000, "glucose": 81}, {"date": 1469505500000, "glucose": 76}, {date: 1469509700000, glucose: 97}]);
+      //console.log(glucose_status);
+      glucose_status.delta.should.equal(3);
+      glucose_status.glucose.should.equal(97);
+      glucose_status.short_avgdelta.should.equal(4.444);
+      glucose_status.long_avgdelta.should.equal(2.865);
     });
 });


### PR DESCRIPTION
calculate and use new short_avgdelta (using avg of deltas from all data points 5-15m ago) and long_avgdelta (using avg of deltas from all data points 20-40m ago) vs. "now" (avg of all data points within last 2.5m)

This should mean we can have multiple rigs uploading BGs from multiple receivers and it won't affect our deltas.  It should also mean that our deltas are less jumpy, as we'll be using the average of several deltas in each case rather than just picking one arbitrarily.

Before merge, need to actually test this in production to verify we get expected behavior with a single rig, and then add uploads from a second receiver and verify everything stays happy.