### PR TITLE
Always display bg in mmol/L to one decimal point

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -39,11 +39,11 @@ function convert_bg(value, profile)
 {
     if (profile.out_units == "mmol/L")
     {
-        return round(value / 18, 1);
+        return round(value / 18, 1).toFixed(1);
     }
     else
     {
-        return value;
+        return value.toFixed(0);
     }
 }
 


### PR DESCRIPTION
If the numeral after the decimal point is zero it is dropped when concatenated in the 'reason' field, leading to nightscout feedback like "Eventual BG 0.2 < 6". This commit restores the decimal point. Also changed in mg/dl case for consistency, although this should have no effect.