### PR TITLE
add new carbratio_adjustmentratio preference

### DIFF
--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -98,8 +98,8 @@ function detectSensitivityandCarbAbsorption(inputs) {
         // if bgTime is more recent than mealTime
         if(bgTime > mealTime) {
             // figure out how many carbs that represents
-            // but always assume at least 3mg/dL/5m absorption
-            ci = Math.max(deviation, 3);
+            // but always assume at least 3mg/dL/5m (default) absorption
+            ci = Math.max(deviation, profile.min_5m_carbimpact);
             absorbed = ci * profile.carb_ratio / profile.sens;
             // and add that to the running total carbsAbsorbed
             carbsAbsorbed += absorbed;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -210,9 +210,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // calculate current carb absorption rate, and how long to absorb all carbs
     // CI = current carb impact on BG in mg/dL/5m
     ci = Math.round((minDelta - bgi)*10)/10;
-    // set ci to a minimum of 3mg/dL/5m if less than half of carbs have absorbed
     if (meal_data.mealCOB * 2 > meal_data.carbs) {
-        ci = Math.max(3, ci);
+        // set ci to a minimum of 3mg/dL/5m (default) if less than half of carbs have absorbed
+        ci = Math.max(profile.min_5m_carbimpact, ci);
     }
     aci = 10;
     //5m data points = g * (1U/10g) * (40mg/dL/1U) / (mg/dL/5m)

--- a/lib/profile/carbs.js
+++ b/lib/profile/carbs.js
@@ -1,7 +1,7 @@
 
 var getTime = require('../medtronic-clock');
 
-function carbRatioLookup (inputs) {
+function carbRatioLookup (inputs, profile) {
     var now = new Date();
     var carbratio_data = inputs.carbratio;
     if (typeof(carbratio_data) != "undefined" && typeof(carbratio_data.schedule) != "undefined") {
@@ -19,7 +19,7 @@ function carbRatioLookup (inputs) {
             if (carbratio_data.units == "exchanges") {
                 carbRatio.ratio = 12 / carbRatio.ratio
             }
-        return carbRatio.ratio;
+            return carbRatio.ratio * profile.carbratio_adjustmentratio;
         } else {
             console.error("Error: Unsupported carb_ratio units " + carbratio_data.units);
             return;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -16,6 +16,7 @@ function defaults ( ) {
     , override_high_target_with_low: false
     , skip_neutral_temps: false
     , bolussnooze_dia_divisor: 2
+    , min_5m_carbimpact: 3 //mg/dL/5m
     , carbratio_adjustmentratio: 1 //if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
   };
   return profile;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -16,6 +16,7 @@ function defaults ( ) {
     , override_high_target_with_low: false
     , skip_neutral_temps: false
     , bolussnooze_dia_divisor: 2
+    , carbratio_adjustmentratio: 1 //if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
   };
   return profile;
 }
@@ -63,7 +64,7 @@ function generate (inputs, opts) {
     return -1;
   }
   if (typeof(inputs.carbratio) != "undefined") {
-    profile.carb_ratio = carb_ratios.carbRatioLookup(inputs);
+    profile.carb_ratio = carb_ratios.carbRatioLookup(inputs, profile);
   } else {
     console.error("Profile wasn't given carb ratio data, cannot calculate carb_ratio");
   }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {
+    "lodash": "^4.15.0",
     "share2nightscout-bridge": "^0.1.5",
     "timezone": "0.0.47",
     "yargs": "~4.3.2"

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+require('should');
+var _ = require('lodash');
+
+describe('Profile', function ( ) {
+
+    var baseInputs = {
+        settings: {
+            insulin_action_curve: 3
+        }
+        , basals: [
+            {minutes: 0, rate: 1}
+        ]
+        , targets: {
+            targets: [
+                { offset: 0, high: 120, low: 100 }
+            ]
+        }
+        , temptargets: [
+        ]
+        , isf: {
+            sensitivities: [
+                { offset: 0, i: 0, x: 0, start: '00:00:00', sensitivity: 100 }
+            ]
+        }
+        , carbratio: {
+            units: 'grams'
+            , schedule: [
+                { offset: 0, ratio: 20 }
+            ]
+        }
+    };
+
+    it('should should create a profile from inputs', function () {
+        var profile = require('../lib/profile')(baseInputs);
+        profile.max_iob.should.equal(0);
+        profile.dia.should.equal(3);
+        profile.sens.should.equal(100);
+        profile.current_basal.should.equal(1);
+        profile.max_bg.should.equal(120);
+        profile.min_bg.should.equal(100);
+        profile.carb_ratio.should.equal(20);
+    });
+
+    it('should adjust carbratio with carbratio_adjustmentratio', function () {
+
+        var profile = require('../lib/profile')(baseInputs);
+        profile.carb_ratio.should.equal(20);
+
+        var profileA = require('../lib/profile')(_.merge({}, baseInputs, {
+            carbratio_adjustmentratio: .8
+        }));
+        profileA.carb_ratio.should.equal(16);
+
+    });
+
+});


### PR DESCRIPTION
I'm using this so we can set higher than normal carb ratios on the pump, and cause the bolus wizard to calculate a partial bolus, but then correct the carb ratio used for AMA so we can catch up if/when there's a rise.

Might need to also adjust the min up CI from the current 3mg/dL/5m, but planning on experimenting without that first.