### PR TITLE
A new Nightscout helper to get glucose since some time ago

### DIFF
--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -124,6 +124,13 @@ openaps use ns shell upload treatments.json recently/combined-treatments.json
                                                  search query for Nightscout.
   oref0_glucose_without_zone [args]              Like oref0_glucose but without
                                                  rezoning.
+  oref0_glucose_since expr [tz]                  Get records matching oref0
+                                                 requirements filtered by a date calculated by expr
+                                                 from Nightscout.
+                                                 tz should be the name of the
+                                                 timezones device (default with
+                                                 no args is tz).
+                                                 expr is used with date -d, for example -6hours.
   upload endpoint file                           Upload a file to the Nightscout endpoint.
   latest-treatment-time                          - get latest treatment time from Nightscout
   format-recent-history-treatments history model - Formats medtronic pump
@@ -255,6 +262,13 @@ ns)
     params=${params-'count=10'}
     exec ns-get host $NIGHTSCOUT_HOST entries/sgv.json $params \
       | json -e "this.glucose = this.sgv"
+    ;;
+    oref0_glucose_since)
+    expr=$1
+    zone=${2-'tz'}
+    exec ns-get host $NIGHTSCOUT_HOST entries/sgv.json "find[date][\$gte]=$(date -d $expr +"%s%3N")&count=5000" \
+      | json -e "this.glucose = this.sgv" \
+      | openaps use $zone rezone --astimezone --date dateString -
     ;;
     *)
     echo "Unknown request:" $OP

--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -153,6 +153,10 @@ openaps use ns shell upload treatments.json recently/combined-treatments.json
   status                                         - ns-status
   get-status                                     - status - get NS status
   preflight                                      - NS preflight
+  temp_targets [expr]                            - Get temp target treatments from Nightscout
+                                                 expr is used with date -d, default is -24hours.
+  carb_history [expr]                            - Get treatments with carbs from Nightscout
+                                                 expr is used with date -d, default is -24hours.
 EOF
 extra_ns_help
 }
@@ -271,6 +275,14 @@ ns)
     exec ns-get host $NIGHTSCOUT_HOST entries/sgv.json "find[date][\$gte]=$(date -d $expr +"%s%3N")&count=$count" \
       | json -e "this.glucose = this.sgv" \
       | openaps use $zone rezone --astimezone --date dateString -
+    ;;
+    temp_targets)
+    expr=${1--24hours}
+    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes)&find[eventType]=Temporary+Target"
+    ;;
+    carb_history)
+    expr=${1--24hours}
+    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes)&find[carbs][\$exists]=true"
     ;;
     *)
     echo "Unknown request:" $OP

--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -124,13 +124,14 @@ openaps use ns shell upload treatments.json recently/combined-treatments.json
                                                  search query for Nightscout.
   oref0_glucose_without_zone [args]              Like oref0_glucose but without
                                                  rezoning.
-  oref0_glucose_since expr [tz]                  Get records matching oref0
+  oref0_glucose_since expr [tz] [count]          Get records matching oref0
                                                  requirements filtered by a date calculated by expr
                                                  from Nightscout.
+                                                 expr is used with date -d, for example -6hours.
                                                  tz should be the name of the
                                                  timezones device (default with
                                                  no args is tz).
-                                                 expr is used with date -d, for example -6hours.
+                                                 count is the max count (needed to overide NS default of 10).
   upload endpoint file                           Upload a file to the Nightscout endpoint.
   latest-treatment-time                          - get latest treatment time from Nightscout
   format-recent-history-treatments history model - Formats medtronic pump
@@ -266,7 +267,8 @@ ns)
     oref0_glucose_since)
     expr=$1
     zone=${2-'tz'}
-    exec ns-get host $NIGHTSCOUT_HOST entries/sgv.json "find[date][\$gte]=$(date -d $expr +"%s%3N")&count=5000" \
+    count=${3-1000}
+    exec ns-get host $NIGHTSCOUT_HOST entries/sgv.json "find[date][\$gte]=$(date -d $expr +"%s%3N")&count=$count" \
       | json -e "this.glucose = this.sgv" \
       | openaps use $zone rezone --astimezone --date dateString -
     ;;


### PR DESCRIPTION
$ `openaps use ns shell oref0_glucose_since -10hours | jq '. | length'`
123

$ `openaps use ns shell oref0_glucose_since -5hours | jq '. | length'`
60

$ `openaps use ns shell oref0_glucose_since -30minutes | jq '. | length'`
6

$ `openaps report add monitor/glucose-ns-recent.json JSON ns shell oref0_glucose_since -6hours tz`