### PR TITLE
Fixed wrong test for $NIGHTSCOUT_HOST echo

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -113,7 +113,7 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
     echo Are you using Nightscout? If not, press enter.
     read -p "If so, what is your Nightscout host? (i.e. https://mynightscout.azurewebsites.net)? " -r
     NIGHTSCOUT_HOST=$REPLY
-    if [[ -z "$ttyport" ]]; then
+    if [[ -z $NIGHTSCOUT_HOST ]]; then
         echo Ok, no Nightscout for you.
     else
         echo "Ok, $NIGHTSCOUT_HOST it is."


### PR DESCRIPTION
When running the setup script, entering a valid $NIGHTSCOUT_HOST resulted in
  "Ok, no Nightscout for you"
being printed if no TTY port was specified for mmeowlink