### PR TITLE
oref0-pebble.js fails if enact cannot be parsed

### DIFF
--- a/bin/oref0-calculate-iob.js
+++ b/bin/oref0-calculate-iob.js
@@ -20,7 +20,7 @@
 
 var generate = require('oref0/lib/iob');
 function usage ( ) {
-    console.log('usage: ', process.argv.slice(0, 2), '<pumphistory.json> <profile.json> <clock.json>');
+    console.log('usage: ', process.argv.slice(0, 2), '<pumphistory-zoned.json> <profile.json> <clock-zoned.json>');
 
 }
 

--- a/bin/oref0-pebble.js
+++ b/bin/oref0-pebble.js
@@ -114,16 +114,23 @@ if (!module.parent) {
     } else { 
         reqtempstring = requestedtemp.duration + "m@" + requestedtemp.rate.toFixed(1) + "U";
     }
-    var enactedtemp = require(cwd + '/' + enactedtemp_input);
-    if (enactedtemp.duration < 1) {
-        enactedstring = "Cancel";
-    } else { 
-        enactedstring = enactedtemp.duration + "m@" + enactedtemp.rate.toFixed(1) + "U";
-    }
-    tz = new Date().toString().match(/([-\+][0-9]+)\s/)[1]
-    enactedDate = new Date(enactedtemp.timestamp.concat(tz));
-    enactedHMS = enactedDate.toLocaleTimeString().split(":")
-    enactedat = enactedHMS[0].concat(":", enactedHMS[1]);
+	try {
+		var enactedtemp = require(cwd + '/' + enactedtemp_input);
+		if (enactedtemp.duration < 1) {
+			enactedstring = "Cancel";
+		} else { 
+			enactedstring = enactedtemp.duration + "m@" + enactedtemp.rate.toFixed(1) + "U";
+		}
+	    tz = new Date().toString().match(/([-\+][0-9]+)\s/)[1]
+		enactedDate = new Date(enactedtemp.timestamp.concat(tz));
+		enactedHMS = enactedDate.toLocaleTimeString().split(":")
+		enactedat = enactedHMS[0].concat(":", enactedHMS[1]);
+
+	} catch (e) {
+		console.error("error parsing enact");
+		enactedstring = "X";
+		enactedat="?";
+	}
 
     var mealCOB = "???";
     if (typeof meal_input != 'undefined') {

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -327,7 +327,7 @@ if ! [[ ${CGM,,} =~ "mdt" ]]; then
 fi
 (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
 if [[ $ENABLE =~ autosens ]]; then
-    (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens-loop' || openaps autosens-loop | tee -a /var/log/openaps/autosens-loop.log") | crontab -
+    (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens' || openaps autosens | tee -a /var/log/openaps/autosens-loop.log") | crontab -
 fi
 (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -321,6 +321,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 (crontab -l; crontab -l | grep -q "cd $directory && oref0-reset-git" || echo "* * * * * cd $directory && oref0-reset-git") | crontab -
 (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
 (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
+if [[ $ENABLE =~ autosens ]]; then
+    (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens-loop' || openaps autosens-loop | tee -a /var/log/openaps/autosens-loop.log") | crontab -
+fi
 (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l
 fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -297,7 +297,7 @@ read -p "Schedule openaps in cron? y/[N] " -r
 if [[ $REPLY =~ ^[Yy]$ ]]; then
 # add crontab entries
 (crontab -l; crontab -l | grep -q $NIGHTSCOUT_HOST || echo NIGHTSCOUT_HOST=$NIGHTSCOUT_HOST) | crontab -
-(crontab -l; crontab -l | grep -q $API_SECRET || echo API_SECRET=`nightscout hash-api-secret $API_SECRET`) | crontab -
+(crontab -l; crontab -l | grep -q "API_SECRET=" || echo API_SECRET=`nightscout hash-api-secret $API_SECRET`) | crontab -
 (crontab -l; crontab -l | grep -q PATH || echo "PATH=$PATH" ) | crontab -
 (crontab -l; crontab -l | grep -q wpa_cli || echo '* * * * * sudo wpa_cli scan') | crontab -
 (crontab -l; crontab -l | grep -q "killall -g --older-than 10m openaps" || echo '* * * * * killall -g --older-than 10m openaps') | crontab -

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -319,7 +319,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 (crontab -l; crontab -l | grep -q "sudo wpa_cli scan" || echo '* * * * * sudo wpa_cli scan') | crontab -
 (crontab -l; crontab -l | grep -q "killall -g --older-than 10m openaps" || echo '* * * * * killall -g --older-than 10m openaps') | crontab -
 (crontab -l; crontab -l | grep -q "cd $directory && oref0-reset-git" || echo "* * * * * cd $directory && oref0-reset-git") | crontab -
-(crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
+if ! [[ ${CGM,,} =~ "mdt" ]]; then
+    (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
+fi
 (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
 if [[ $ENABLE =~ autosens ]]; then
     (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens-loop' || openaps autosens-loop | tee -a /var/log/openaps/autosens-loop.log") | crontab -

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -313,15 +313,15 @@ openaps report add enact/suggested.json text determine-basal shell monitor/iob.j
 read -p "Schedule openaps in cron? y/[N] " -r
 if [[ $REPLY =~ ^[Yy]$ ]]; then
 # add crontab entries
-(crontab -l; crontab -l | grep -q $NIGHTSCOUT_HOST || echo NIGHTSCOUT_HOST=$NIGHTSCOUT_HOST) | crontab -
+(crontab -l; crontab -l | grep -q "$NIGHTSCOUT_HOST" || echo NIGHTSCOUT_HOST=$NIGHTSCOUT_HOST) | crontab -
 (crontab -l; crontab -l | grep -q "API_SECRET=" || echo API_SECRET=`nightscout hash-api-secret $API_SECRET`) | crontab -
-(crontab -l; crontab -l | grep -q PATH || echo "PATH=$PATH" ) | crontab -
-(crontab -l; crontab -l | grep -q wpa_cli || echo '* * * * * sudo wpa_cli scan') | crontab -
+(crontab -l; crontab -l | grep -q "PATH=" || echo "PATH=$PATH" ) | crontab -
+(crontab -l; crontab -l | grep -q "sudo wpa_cli scan" || echo '* * * * * sudo wpa_cli scan') | crontab -
 (crontab -l; crontab -l | grep -q "killall -g --older-than 10m openaps" || echo '* * * * * killall -g --older-than 10m openaps') | crontab -
-(crontab -l; crontab -l | grep -q "reset-git" || echo "* * * * * cd $directory && oref0-reset-git") | crontab -
-(crontab -l; crontab -l | grep -q get-bg || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
-(crontab -l; crontab -l | grep -q ns-loop || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
-(crontab -l; crontab -l | grep -q pump-loop || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
+(crontab -l; crontab -l | grep -q "cd $directory && oref0-reset-git" || echo "* * * * * cd $directory && oref0-reset-git") | crontab -
+(crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
+(crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
+(crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -279,7 +279,7 @@ fi
 
 # Medtronic CGM
 if [[ ${CGM,,} =~ "mdt" ]]; then
-    pip install -U openapscontrib.glucosetools || die "Couldn't install glucosetools"
+    sudo pip install -U openapscontrib.glucosetools || die "Couldn't install glucosetools"
     openaps device remove cgm 2>/dev/null
     if [[ -z "$ttyport" ]]; then
         openaps device add cgm medtronic $serial || die "Can't add cgm"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -113,7 +113,7 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
     echo Are you using Nightscout? If not, press enter.
     read -p "If so, what is your Nightscout host? (i.e. https://mynightscout.azurewebsites.net)? " -r
     NIGHTSCOUT_HOST=$REPLY
-    if [[ -z "$ttyport" ]]; then
+    if [[ -z $NIGHTSCOUT_HOST ]]; then
         echo Ok, no Nightscout for you.
     else
         echo "Ok, $NIGHTSCOUT_HOST it is."

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -60,6 +60,11 @@ case $i in
     API_SECRET="${i#*=}"
     shift # past argument=value
     ;;
+    -r=*|--radio-locale=*)
+    radio_locale="${i#*=}"
+    shift # past argument=value
+
+    ;;
     -e=*|--enable=*)
     ENABLE="${i#*=}"
     shift # past argument=value
@@ -70,6 +75,10 @@ case $i in
     ;;
 esac
 done
+if [[ -z $TTY && radio_locale != "US" ]]; then
+    echo "World wide radio locale is only supported with TI stick currently"
+    echo "If you'd like to help add World Wide radio locale support, please contact @pietergit on Gitter"
+fi
 
 if ! [[ ${CGM,,} =~ "g4" || ${CGM,,} =~ "g5" || ${CGM,,} =~ "mdt" ]]; then
     echo "Unsupported CGM.  Please select (Dexcom) G4 (default), G5, or MDT."
@@ -88,7 +97,7 @@ if ! ( git config -l | grep -q user.name ); then
     git config --global user.name $NAME
 fi
 if [[ -z "$DIR" || -z "$serial" ]]; then
-    echo "Usage: oref0-setup.sh <--dir=directory> <--serial=pump_serial_#> [--tty=/dev/ttySOMETHING] [--max_iob=0] [--ns-host=https://mynightscout.azurewebsites.net] [--api-secret=myplaintextsecret] [--cgm=(G4|G5|MDT)] [--enable='autosens meal']"
+    echo "Usage: oref0-setup.sh <--dir=directory> <--serial=pump_serial_#> [--tty=/dev/ttySOMETHING] [--max_iob=0] [--ns-host=https://mynightscout.azurewebsites.net] [--api-secret=myplaintextsecret] [--cgm=(G4|G5|MDT)] [--radio-locale=(US|WW)] [--enable='autosens meal']"
     read -p "Start interactive setup? [Y]/n " -r
     if [[ $REPLY =~ ^[Nn]$ ]]; then
         exit
@@ -113,6 +122,17 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
         echo -n TTY $ttyport
     fi
     echo " it is."
+	# 
+	if [[ -n "$ttyport" ]]; then
+		read -p "Are you using a USA (US) or world wide (WW) Medtronic pump? If US, press enter, otherwise enter WW. " -r
+		radio_locale=$REPLY
+		if [[ $radio_locale =~ ^[Ww][Ww]$ ]]; then
+			radio_locale="WW"
+		else
+			radio_locale="US"
+		fi
+	fi
+
     echo Are you using Nightscout? If not, press enter.
     read -p "If so, what is your Nightscout host? (i.e. https://mynightscout.azurewebsites.net)? " -r
     NIGHTSCOUT_HOST=$REPLY
@@ -194,6 +214,10 @@ if openaps vendor add --path . mmeowlink.vendors.mmeowlink 2>&1 | grep "No modul
         echo -n "Cloning mmeowlink dev: "
         (cd ~/src && git clone -b dev git://github.com/oskarpearson/mmeowlink.git) || die "Couldn't clone mmeowlink dev"
     fi
+	if [[ "$radio_locale" -eq "WW" ]]; then
+		echo -n "Patching mmtune.py for WW frequencies. " # temporary fix for https://github.com/oskarpearson/mmeowlink/issues/16
+		sed -i "s/def __init__(self, link, pumpserial, radio_locale='US'):/def __init__(self, link, pumpserial, radio_locale='WW'):/g" ~/src/mmeowlink/mmeowlink/mmtune.py || die "Couldn't patch mmtune.py"
+	fi
     echo Installing latest mmeowlink dev && cd $HOME/src/mmeowlink/ && sudo pip install -e . || die "Couldn't install mmeowlink"
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -101,6 +101,9 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
     read -p "What is your pump serial number? " -r
     serial=$REPLY
     echo "Ok, $serial it is."
+    read -p "What Kind of CGM are you using? (i.e. G4, G5, MDT) " -r
+    CGM=$REPLY
+    echo "Ok, $CGM it is."
     read -p "Are you using mmeowlink? If not, press enter. If so, what TTY port (i.e. /dev/ttySOMETHING)? " -r
     ttyport=$REPLY
     echo -n "Ok, "

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -16,7 +16,7 @@ function generate (inputs) {
 
     var iobArray = [];
     console.error(inputs.clock);
-    if (! /(Z|[+-][0-2][0-9]:[03]0)+/.test(inputs.clock) ) {
+    if (! /(Z|[+-][0-2][0-9]:[034][05])+/.test(inputs.clock) ) {
         console.error("Warning: clock input is unzoned; please pass clock-zoned.json instead");
     }
     var clock = new Date(tz(inputs.clock));

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -15,6 +15,10 @@ function generate (inputs) {
     };
 
     var iobArray = [];
+    console.error(inputs.clock);
+    if (! /(Z|[+-][0-2][0-9]:[03]0)+/.test(inputs.clock) ) {
+        console.error("Warning: clock input is unzoned; please pass clock-zoned.json instead");
+    }
     var clock = new Date(tz(inputs.clock));
 
     // predict IOB out to DIA plus 30m to account for any running temp basals

--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -171,7 +171,7 @@
     "type": "alias",
     "name": "ns-loop",
     "ns-loop": {
-      "command": "! bash -c \"echo Starting ns-loop at `date`: && openaps get-ns-bg; openaps autosens; openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload\""
+      "command": "! bash -c \"echo Starting ns-loop at `date`: && openaps get-ns-bg; openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload\""
     }
   },
   {

--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -47,5 +47,12 @@
     "monitor-cgm": {
       "command": "report invoke monitor/cgm-mm-glucosedirty.json cgm/cgm-glucose.json"
     }
+  },
+  {
+    "pump-loop": {
+      "command": "! bash -c \"sleep $[ ( $RANDOM / 2048 ) ]s; until(echo Starting pump-loop at `date`: && openaps wait-for-silence && openaps get-bg && openaps refresh-old-pumphistory && openaps refresh-old-pumphistory-24h && openaps refresh-old-profile && openaps refresh-temp-and-enact && openaps refresh-pumphistory-and-enact && openaps refresh-profile && openaps refresh-pumphistory-24h && echo Completed pump-loop at `date` && echo); do echo Error, retrying && [[ $RANDOM > 30000 ]] && openaps wait-for-long-silence && openaps mmtune; sleep 5; done\""
+    },
+    "type": "alias",
+    "name": "pump-loop"
   }
 ]

--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -1,0 +1,51 @@
+[
+  {
+    "type": "vendor",
+    "name": "openapscontrib.glucosetools",
+    "openapscontrib.glucosetools": {
+      "path": ".",
+      "module": "openapscontrib.glucosetools"
+    }
+  },
+  {
+    "extra": {},
+    "type": "device",
+    "name": "glucose",
+    "glucose": {
+      "vendor": "openapscontrib.glucosetools",
+      "extra": "glucose.ini"
+    }
+  },
+  {
+    "monitor/cgm-mm-glucosedirty.json": {
+      "hours": "24.0",
+      "device": "cgm",
+      "use": "iter_glucose_hours",
+      "reporter": "JSON"
+    },
+    "type": "report",
+    "name": "monitor/cgm-mm-glucosedirty.json"
+  },
+  {
+    "type": "report",
+    "name": "cgm/cgm-glucose.json",
+    "cgm/cgm-glucose.json": {
+      "use": "clean",
+      "reporter": "JSON",
+      "astimezone": "False",
+      "date": "display_time dateString",
+      "adjust": "missing",
+      "input": "raw-cgm/raw-entries.json",
+      "device": "glucose",
+      "timezone": "",
+      "infile": "monitor/cgm-mm-glucosedirty.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "monitor-cgm",
+    "monitor-cgm": {
+      "command": "report invoke monitor/cgm-mm-glucosedirty.json cgm/cgm-glucose.json"
+    }
+  }
+]


### PR DESCRIPTION
the oref0-pebble.js currently fails if the enact details are not available. The enact information is currently commented out and is not available for users that have a pump that does not support micro bolusses.

I implemented a fix to make the oref0-pebble.js not fail and set enactedstring to "X" (similar as in Nightscout). 

Other fix is to rip these lines out, because they are commented out in the pebble string at the end of the file, but then also the dependency on enacted json file should be removed.
