### PR TITLE
path problem running script with sudo and calling cat

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -316,7 +316,7 @@ elif [[ ${CGM,,} =~ "shareble" ]]; then
     # import cgm-loop stuff
     for type in cgm-loop; do
         echo importing $type file
-        cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
+        cat ../src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
     done
 
     if [[ -z "$BLE_MAC" ]]; then


### PR DESCRIPTION
I don't know why the 'cat' command decides to define $HOME as "root" but I assume it has to do the the fact that I'm calling the script with sudo. (because of the explorer board). Don't feel like you have to bring in this PR, but this small change fixed it for me.  I did not replace $HOME in other places that this also might be a problem but my permutations of the setting caused the script to skip. 