### PR TITLE
Support floating point max-iob in setup. 

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -167,7 +167,7 @@ if [[ -z "$ttyport" ]]; then
 else
     echo -n TTY $ttyport
 fi
-if [[ "$max_iob" -ne 0 ]]; then echo -n ", max_iob $max_iob"; fi
+if [[ "$max_iob" != "0" ]]; then echo -n ", max_iob $max_iob"; fi
 if [[ ! -z "$ENABLE" ]]; then echo -n ", advanced features $ENABLE"; fi
 echo
 


### PR DESCRIPTION
The script was using the integer comparison operator -ne which gives a syntax error if the operand has a decimal point. Use string comparison instead.