### PR TITLE
Setup should include the model in profile.json. 

### DIFF
--- a/lib/oref0-setup/report.json
+++ b/lib/oref0-setup/report.json
@@ -287,7 +287,7 @@
       "json_default": "True",
       "carb_ratios": "settings/carb_ratios.json",
       "device": "get-profile",
-      "remainder": "settings/temptargets.json",
+      "remainder": "settings/temptargets.json --model=settings/model.json",
       "isf": "settings/insulin_sensitivities.json"
     },
     "type": "report",


### PR DESCRIPTION
Among other things, this is needed so that small basal rates are rounded appropriately.