### PR TITLE
truncate git history at 2000 commits

### DIFF
--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -50,3 +50,6 @@ fi
 # if git repository is too corrupt to do anything, mv it to /tmp and start over.
 
 (git status && git diff) > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; openaps init . )
+
+#truncate git history to 1000 commits if it has grown past 1500
+oref0-truncate-git-history

--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -51,5 +51,3 @@ fi
 
 (git status && git diff && ! df | grep 100% && ! df -i | grep 100%) > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; rm -rf .git; openaps init . )
 
-#truncate git history to 1000 commits if it has grown past 1500
-oref0-truncate-git-history

--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -49,7 +49,7 @@ if [ $status -lt 128 ]; then
 fi
 # if git repository is too corrupt to do anything, mv it to /tmp and start over.
 
-(git status && git diff && ! df | grep 100%) > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; rm -rf .git; openaps init . )
+(git status && git diff && ! df | grep 100% && ! df -i | grep 100%) > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; rm -rf .git; openaps init . )
 
 #truncate git history to 1000 commits if it has grown past 1500
 oref0-truncate-git-history

--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -49,7 +49,7 @@ if [ $status -lt 128 ]; then
 fi
 # if git repository is too corrupt to do anything, mv it to /tmp and start over.
 
-(git status && git diff) > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; openaps init . )
+(git status && git diff && ! df | grep 100%) > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; rm -rf .git; openaps init . )
 
 #truncate git history to 1000 commits if it has grown past 1500
 oref0-truncate-git-history

--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -14,7 +14,6 @@
 # THE SOFTWARE.
 
 # must be run from within a git repo to do anything useful
-# remove old lockfile if still present
 self=$(basename $0)
 BACKUP_AREA=${1-${BACKUP_AREA-/var/cache/openaps-ruination}}
 function usage ( ) {
@@ -34,7 +33,8 @@ esac
 test ! -d $BACKUP_AREA && BACKUP_AREA=/tmp
 BACKUP="$BACKUP_AREA/git-$(date +%s)"
 
-find .git/index.lock -mmin +5 -exec rm {} \; 2>/dev/null
+# remove old lockfile if still present
+find .git/index.lock -mmin +60 -exec rm {} \; 2>/dev/null
 # first, try oref0-fix-git-corruption.sh to preserve git history up to last good commit
 echo "Attempting to fix git corruption.  Please wait 15s."
 oref0-fix-git-corruption &

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -380,7 +380,10 @@ if [[ ${CGM,,} =~ "shareble" ]]; then
 fi
 (crontab -l; crontab -l | grep -q "sudo wpa_cli scan" || echo '* * * * * sudo wpa_cli scan') | crontab -
 (crontab -l; crontab -l | grep -q "killall -g --older-than" || echo '* * * * * killall -g --older-than 15m openaps') | crontab -
+# repair or reset git repository if it's corrupted or disk is full
 (crontab -l; crontab -l | grep -q "cd $directory && oref0-reset-git" || echo "* * * * * cd $directory && oref0-reset-git") | crontab -
+#truncate git history to 1000 commits if it has grown past 1500
+(crontab -l; crontab -l | grep -q "cd $directory && oref0-truncate-git-history" || echo "* * * * * cd $directory && oref0-truncate-git-history") | crontab -
 if ! [[ ${CGM,,} =~ "mdt" ]]; then
     (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
 fi

--- a/bin/oref0-truncate-git-history.sh
+++ b/bin/oref0-truncate-git-history.sh
@@ -37,7 +37,8 @@ find .git/index.lock -mmin +5 -exec rm {} \; 2>/dev/null
 commits=$(git log | grep -c commit)
 if (( $commits > 1500 )); then
     echo "Found $commits commits; truncating git history"
-    git commit -m"save unsaved changes" -a && du -sh .git && git rev-parse HEAD~1000 > .git/info/grafts && git filter-branch -- --all
+    git commit -m"save unsaved changes" -a 
+    du -sh .git && git rev-parse HEAD~1000 > .git/info/grafts && git filter-branch -- --all
     rm .git/info/grafts
     git update-ref -d refs/original/refs/heads/master && git reflog expire --expire=now --all && git gc --prune=now --aggressive 
 fi 

--- a/bin/oref0-truncate-git-history.sh
+++ b/bin/oref0-truncate-git-history.sh
@@ -20,7 +20,7 @@ function usage ( ) {
 
 cat <<EOF
 $self
-$self - Check if git commit history is longer than 1400 commits, and truncate to 1000 if so.
+$self - Check if git commit history is longer than 1500 commits, and truncate to 1000 if so.
 EOF
 }
 
@@ -35,7 +35,7 @@ esac
 find .git/index.lock -mmin +5 -exec rm {} \; 2>/dev/null
 
 commits=$(git log | grep -c commit)
-if [[ $commits > 1400 ]]; then
+if (( $commits > 1500 )); then
     echo "Found $commits commits; truncating git history"
     git commit -m"save unsaved changes" -a && du -sh .git && git rev-parse HEAD~1000 > .git/info/grafts && git filter-branch -- --all
     rm .git/info/grafts

--- a/bin/oref0-truncate-git-history.sh
+++ b/bin/oref0-truncate-git-history.sh
@@ -20,7 +20,7 @@ function usage ( ) {
 
 cat <<EOF
 $self
-$self - Check if git commit history is longer than 1500 commits, and truncate to 1000 if so.
+$self - Check if git commit history is longer than 5000 commits, and truncate to 2000 if so.
 EOF
 }
 
@@ -35,10 +35,10 @@ esac
 find .git/index.lock -mmin +60 -exec rm {} \; 2>/dev/null
 
 commits=$(git log | grep -c commit)
-if (( $commits > 1500 )); then
+if (( $commits > 5000 )); then
     echo "Found $commits commits; truncating git history"
     git commit -m"save unsaved changes" -a 
-    du -sh .git && git rev-parse HEAD~1000 > .git/info/grafts && git filter-branch -- --all
+    du -sh .git && git rev-parse HEAD~2000 > .git/info/grafts && git filter-branch -- --all
     rm .git/info/grafts
     git update-ref -d refs/original/refs/heads/master && git reflog expire --expire=now --all && git gc --prune=now --aggressive 
 fi 

--- a/bin/oref0-truncate-git-history.sh
+++ b/bin/oref0-truncate-git-history.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Delete git lock / history if necessary to recover from corrupted .git objects
+#
+# Released under MIT license. See the accompanying LICENSE.txt file for
+# full terms and conditions
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# must be run from within a git repo to do anything useful
+self=$(basename $0)
+#BACKUP_AREA=${1-${BACKUP_AREA-/var/cache/openaps-ruination}}
+function usage ( ) {
+
+cat <<EOF
+$self
+$self - Check if git commit history is longer than 1500 commits, and truncate to 1000 if so.
+EOF
+}
+
+case "$1" in
+  --help|help|-h)
+    usage
+    exit 0
+    ;;
+esac
+
+# remove old lockfile if still present
+find .git/index.lock -mmin +5 -exec rm {} \; 2>/dev/null
+
+commits=$(git log | grep -c commit)
+if [[ $commits > 1500 ]]; then
+    echo "Found $commits commits; truncating git history"
+    git commit -m"save unsaved changes" -a && du -sh .git && git rev-parse HEAD~1000 > .git/info/grafts && git filter-branch -- --all
+    rm .git/info/grafts
+    git update-ref -d refs/original/refs/heads/master && git reflog expire --expire=now --all && git gc --prune=now --aggressive 
+fi 
+commits=$(git log | grep -c commit)
+usage=$(du -sh .git)
+oldest=$(git log | grep Date | tail -1)
+echo "$commits git commits using $usage since $oldest"

--- a/bin/oref0-truncate-git-history.sh
+++ b/bin/oref0-truncate-git-history.sh
@@ -32,7 +32,7 @@ case "$1" in
 esac
 
 # remove old lockfile if still present
-find .git/index.lock -mmin +5 -exec rm {} \; 2>/dev/null
+find .git/index.lock -mmin +60 -exec rm {} \; 2>/dev/null
 
 commits=$(git log | grep -c commit)
 if (( $commits > 1500 )); then

--- a/bin/oref0-truncate-git-history.sh
+++ b/bin/oref0-truncate-git-history.sh
@@ -20,7 +20,7 @@ function usage ( ) {
 
 cat <<EOF
 $self
-$self - Check if git commit history is longer than 1500 commits, and truncate to 1000 if so.
+$self - Check if git commit history is longer than 1400 commits, and truncate to 1000 if so.
 EOF
 }
 
@@ -35,13 +35,13 @@ esac
 find .git/index.lock -mmin +5 -exec rm {} \; 2>/dev/null
 
 commits=$(git log | grep -c commit)
-if [[ $commits > 1500 ]]; then
+if [[ $commits > 1400 ]]; then
     echo "Found $commits commits; truncating git history"
     git commit -m"save unsaved changes" -a && du -sh .git && git rev-parse HEAD~1000 > .git/info/grafts && git filter-branch -- --all
     rm .git/info/grafts
     git update-ref -d refs/original/refs/heads/master && git reflog expire --expire=now --all && git gc --prune=now --aggressive 
 fi 
 commits=$(git log | grep -c commit)
-usage=$(du -sh .git)
+usage=$(du -sh .git | awk '{print $1}')
 oldest=$(git log | grep Date | tail -1)
 echo "$commits git commits using $usage since $oldest"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "oref0-raw": "./bin/oref0-raw.js",
     "oref0-reset-usb": "bin/oref0-reset-usb.sh",
     "oref0-reset-git": "bin/oref0-reset-git.sh",
+    "oref0-truncate-git-history": "bin/oref0-truncate-git-history.sh",
     "mm-format-ns-glucose": "./bin/mm-format-ns-glucose.sh",
     "mm-format-ns-profile": "./bin/mm-format-ns-profile.sh",
     "mm-format-ns-treatments": "./bin/mm-format-ns-treatments.sh",


### PR DESCRIPTION
This should prevent the .git directory from growing uncontrollably.  If garbage collection fails and it does grow to fill the disk, it should now go ahead and rm -rf .git and re-init.