### PR TITLE
fix oref0 version check in oref0-setup

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -206,7 +206,7 @@ else
     (cd ~/src && git clone git://github.com/openaps/oref0.git) || die "Couldn't clone oref0"
 fi
 echo Checking oref0 installation
-npm list -g oref0 | egrep ^0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
+npm list -g oref0 | egrep oref0@0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
 #(echo Installing latest oref0 dev && cd $HOME/src/oref0/ && npm run global-install)
 
 echo Checking mmeowlink installation

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -206,7 +206,7 @@ else
     (cd ~/src && git clone git://github.com/openaps/oref0.git) || die "Couldn't clone oref0"
 fi
 echo Checking oref0 installation
-npm view oref0 version | egrep ^0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
+npm list -g oref0 | egrep ^0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
 #(echo Installing latest oref0 dev && cd $HOME/src/oref0/ && npm run global-install)
 
 echo Checking mmeowlink installation


### PR DESCRIPTION
Turns out `npm view` shows what's in npm, not installed locally. We actually want `npm list`

Thanks @dougtakeuti @Bender1061 @logichammer @C-Ville for helping me find and fix this.