### PR TITLE
Handle xDrip errorstate 38

### DIFF
--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -37,7 +37,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
         } else if (glucose_data[i-1].dateString) {
             lastbgTime = new Date(glucose_data[i-1].dateString);
         } else { console.error("Could not determine last BG time"); }
-        if (glucose_data[i].glucose < 38 || glucose_data[i-1].glucose < 38) {
+        if (glucose_data[i].glucose < 39 || glucose_data[i-1].glucose < 39) {
             continue;
         }
         var elapsed_minutes = (bgTime - lastbgTime)/(60*1000);

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -37,7 +37,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
         } else if (glucose_data[i-1].dateString) {
             lastbgTime = new Date(glucose_data[i-1].dateString);
         } else { console.error("Could not determine last BG time"); }
-        if (glucose_data[i].glucose < 30 || glucose_data[i-1].glucose < 30) {
+        if (glucose_data[i].glucose < 38 || glucose_data[i-1].glucose < 38) {
             continue;
         }
         var elapsed_minutes = (bgTime - lastbgTime)/(60*1000);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -66,7 +66,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     var bg = glucose_status.glucose;
     // TODO: figure out how to use raw isig data to estimate BG
-    if (bg < 38) {  //Dexcom is in ??? mode or calibrating
+    if (bg < 39) {  //Dexcom is in ??? mode or calibrating
         rT.reason = "CGM is calibrating or in ??? state";
         if (basal <= currenttemp.rate * 1.2) { // high temp is running
             rT.reason += "; setting current basal of " + basal + " as temp";

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -66,7 +66,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     var bg = glucose_status.glucose;
     // TODO: figure out how to use raw isig data to estimate BG
-    if (bg < 30) {  //Dexcom is in ??? mode or calibrating
+    if (bg < 38) {  //Dexcom is in ??? mode or calibrating
         rT.reason = "CGM is calibrating or in ??? state";
         if (basal <= currenttemp.rate * 1.2) { // high temp is running
             rT.reason += "; setting current basal of " + basal + " as temp";

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -13,7 +13,7 @@ var getLastGlucose = function (data) {
     var long_deltas = [];
 
     for (i=1; i < data.length; i++) {
-        if (typeof data[i] !== 'undefined' && data[i].glucose > 30) {
+        if (typeof data[i] !== 'undefined' && data[i].glucose > 38) {
             var then = data[i];
             var then_date = then.date || Date.parse(then.display_time) || Date.parse(then.dateString);
             var avgdelta = 0;

--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -73,7 +73,7 @@
     "type": "alias",
     "name": "bg-fresh-check",
     "bg-fresh-check": {
-      "command": "! bash -c \"cat cgm/glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 6 && minAgo > 0 && this.glucose > 30\\\" | grep -q glucose\""
+      "command": "! bash -c \"cat cgm/glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 6 && minAgo > 0 && this.glucose > 38\\\" | grep -q glucose\""
     }
   },
   {
@@ -87,7 +87,7 @@
     "type": "alias",
     "name": "get-ns-bg",
     "get-ns-bg": {
-      "command": "! bash -c \"openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 30\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json\""
+      "command": "! bash -c \"openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json\""
     }
   },
   {

--- a/lib/templates/refresh-loops.json
+++ b/lib/templates/refresh-loops.json
@@ -561,7 +561,7 @@
     "type": "alias",
     "name": "bg-fresh-check",
     "bg-fresh-check": {
-      "command": "! bash -c \"cat cgm/glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 6 && minAgo > 0 && this.glucose > 30\\\" | grep -q glucose\""
+      "command": "! bash -c \"cat cgm/glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 6 && minAgo > 0 && this.glucose > 38\\\" | grep -q glucose\""
     }
   },
   {
@@ -575,7 +575,7 @@
     "type": "alias",
     "name": "get-ns-bg",
     "get-ns-bg": {
-      "command": "! bash -c \"openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 30\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json\""
+      "command": "! bash -c \"openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json\""
     }
   },
   {


### PR DESCRIPTION
While Dexcom uses values at 30 and below as error states, xDrip uses the values at 31 to 38 as additional error states (only 38 used/propagated) so far.
Those values are not used by Dexcom as they map LOW to 39 and the normal range it shows values starts with 40.
NightScout shows it as error "38?? ✖︎".

I don't use Oref0 but AndroidAPS, but I hope I have found all cutoffs. I've looked at all ocurrences of "30" in the sourcecode and checked if it was a cutoff or not.