### PR TITLE
Remove get-ns-bg from ns-loop for MDT cgm

### DIFF
--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -48,6 +48,13 @@
       "command": "report invoke monitor/cgm-mm-glucosedirty.json cgm/cgm-glucose.json"
     }
   },
+    {
+    "type": "alias",
+    "name": "ns-loop",
+    "ns-loop": {
+      "command": "! bash -c \"echo Starting ns-loop at $(date): && openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload\""
+    }
+  },
   {
     "pump-loop": {
       "command": "! bash -c \"sleep $[ ( $RANDOM / 2048 ) ]s; until(echo Starting pump-loop at $(date): && openaps wait-for-silence && openaps get-bg && openaps refresh-old-pumphistory && openaps refresh-old-pumphistory-24h && openaps refresh-old-profile && openaps refresh-temp-and-enact && openaps refresh-pumphistory-and-enact && openaps refresh-profile && openaps refresh-pumphistory-24h && echo Completed pump-loop at $(date) && echo); do echo Error, retrying && [[ $RANDOM > 30000 ]] && openaps wait-for-long-silence && openaps mmtune; sleep 5; done\""


### PR DESCRIPTION
oref0-setup provides a mechanism to fetch NS cgm in addition to device cgm so that the newer of the two can be used in the loop. This change removes that Nightscout entries fetch when using `MDT` cgm.

Reasons for the change:
1. NS fetch is unnecessary with MDT cgm. There is a very low likelihood that NS will have newer sgvs than the pump device when using `MDT` as the cgm source for oref0. 
2. Reliability of NS entries upload. The NS fetch has been observed to cause a problem with the `recent-missing-entries` report which causes duplicate entries and inconsistency in the NS uploaded entries.

Related PRs:
https://github.com/openaps/oref0/pull/288
https://github.com/openaps/decocare/pull/16