### PR TITLE
Remove treatment data upload to NS entries

### DIFF
--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -189,20 +189,6 @@
     "name": "pebble"
   },
   {
-    "prep-pumphistory-entries": {
-      "command": "! bash -c \"cat monitor/pumphistory-zoned.json | json -e \\\"this.dateString = this.timestamp\\\" | json -e \\\"this.medtronic = this._type\\\" | json -e \\\"this.type = \\\\\\\"medtronic\\\\\\\"\\\" | json -e \\\"this.date = new Date(Date.parse(this.timestamp)).getTime( )\\\" > upload/pumphistory-entries.json\""
-    },
-    "type": "alias",
-    "name": "prep-pumphistory-entries"
-  },
-  {
-    "type": "alias",
-    "name": "upload-pumphistory-entries",
-    "upload-pumphistory-entries": {
-      "command": "! bash -c \"openaps prep-pumphistory-entries && ns-upload-entries upload/pumphistory-entries.json\""
-    }
-  },
-  {
     "type": "alias",
     "name": "latest-ns-treatment-time",
     "latest-ns-treatment-time": {

--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -123,7 +123,7 @@
     "type": "alias",
     "name": "upload",
     "upload": {
-      "command": "! bash -c \"echo -n Upload && ( openaps upload-bg; openaps upload-ns-status; openaps upload-pumphistory-entries; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed\""
+      "command": "! bash -c \"echo -n Upload && ( openaps upload-bg; openaps upload-ns-status; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed\""
     }
   },
   {"type": "alias", "first-upload": {"command": "! bash -c \"cat nightscout/glucose.json | json 1 > nightscout/recent-missing-entries.json && openaps report invoke nightscout/uploaded-entries.json\""}, "name": "first-upload"}

--- a/lib/templates/refresh-loops.json
+++ b/lib/templates/refresh-loops.json
@@ -677,20 +677,6 @@
     "name": "pebble"
   },
   {
-    "prep-pumphistory-entries": {
-      "command": "! bash -c \"cat monitor/pumphistory-zoned.json | json -e \\\"this.dateString = this.timestamp\\\" | json -e \\\"this.medtronic = this._type\\\" | json -e \\\"this.type = \\\\\\\"medtronic\\\\\\\"\\\" | json -e \\\"this.date = new Date(Date.parse(this.timestamp)).getTime( )\\\" > upload/pumphistory-entries.json\""
-    },
-    "type": "alias",
-    "name": "prep-pumphistory-entries"
-  },
-  {
-    "type": "alias",
-    "name": "upload-pumphistory-entries",
-    "upload-pumphistory-entries": {
-      "command": "! bash -c \"openaps prep-pumphistory-entries && ns-upload-entries upload/pumphistory-entries.json\""
-    }
-  },
-  {
     "type": "alias",
     "name": "latest-ns-treatment-time",
     "latest-ns-treatment-time": {


### PR DESCRIPTION
This change removes pump history upload to the Nightscout entries collection.

Reasons for the change:
1. Pump history is already uploaded to treatments. It belongs in that collection and not in entries.
2. It causes problems when backfilling sgv to the entries collection. The `recent-missing-entries` algorithm does not distinguish between sensor and pump history data in the entries collection. This causes the algorithm to think there are no sgv gaps if there is history data around the same time, event though those items are being uploaded independently of each other. This causes valid sgv entries to be removed from the NS upload incorrectly, resulting in gaps.

Relevant PRs:
https://github.com/openaps/decocare/pull/16
https://github.com/openaps/oref0/pull/287