### PR TITLE
Support loading ISF and BG targets in mmol/L

### DIFF
--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -45,19 +45,24 @@ if (!module.parent) {
 
         var pumphistory_data = require(cwd + '/' + pumphistory_input);
         var profile = require(cwd + '/' + profile_input);
-        //console.log(profile);
-        //var glucose_status = detectsensitivity.getLastGlucose(glucose_data);
+
         var isf_data = require(cwd + '/' + isf_input);
         if (isf_data.units !== 'mg/dL') {
-            console.log('ISF is expected to be expressed in mg/dL.'
-                    , 'Found', isf_data.units, 'in', isf_input, '.');
-            process.exit(2);
+            if (isf_data.units == 'mmol/L') {
+                for (var i = 0, len = isf_data.sensitivities.length; i < len; i++) {
+                    isf_data.sensitivities[i].sensitivity = isf_data.sensitivities[i].sensitivity * 18;
+                }
+            } else {
+                console.log('ISF is expected to be expressed in mg/dL or mmol/L.'
+                        , 'Found', isf_data.units, 'in', isf_input, '.');
+                process.exit(2);
+            }
         }
         var basalprofile = require(cwd + '/' + basalprofile_input);
 
         var iob_inputs = {
             history: pumphistory_data
-        , profile: profile
+            , profile: profile
         //, clock: clock_data
         };
     } catch (e) {

--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -52,6 +52,7 @@ if (!module.parent) {
                 for (var i = 0, len = isf_data.sensitivities.length; i < len; i++) {
                     isf_data.sensitivities[i].sensitivity = isf_data.sensitivities[i].sensitivity * 18;
                 }
+               isf_data.units = 'mg/dL';
             } else {
                 console.log('ISF is expected to be expressed in mg/dL or mmol/L.'
                         , 'Found', isf_data.units, 'in', isf_input, '.');

--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -97,8 +97,8 @@ if (!module.parent) {
     if (bgtargets_data.units !== 'mg/dL') {
         if (bgtargets_data.units == 'mmol/L') {
             for (var i = 0, len = bgtargets_data.targets.length; i < len; i++) {
-                isf_data.targets[i].high = bgtargets_data.targets[i].high * 18;
-                isf_data.targets[i].low = bgtargets_data.targets[i].low * 18;
+                bgtargets_data.targets[i].high = bgtargets_data.targets[i].high * 18;
+                bgtargets_data.targets[i].low = bgtargets_data.targets[i].low * 18;
             }
             bgtargets_data.units = 'mg/dL';
         } else {

--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -95,15 +95,31 @@ if (!module.parent) {
     var pumpsettings_data = require(cwd + '/' + pumpsettings_input);
     var bgtargets_data = require(cwd + '/' + bgtargets_input);
     if (bgtargets_data.units !== 'mg/dL') {
-      console.log('BG Target data is expected to be expressed in mg/dL.'
+        if (bgtargets_data.units == 'mmol/L') {
+            for (var i = 0, len = bgtargets_data.sensitivities.length; i < len; i++) {
+                isf_data.targets[i].high = bgtargets_data.targets[i].high * 18;
+                isf_data.targets[i].low = bgtargets_data.targets[i].low * 18;
+            }
+            bgtargets_data.units = 'mg/dL';
+        } else {
+            console.log('BG Target data is expected to be expressed in mg/dL.'
                  , 'Found', bgtargets_data.units, 'in', bgtargets_input, '.');
-      process.exit(2);
+            process.exit(2);
+        }
     }
+    
     var isf_data = require(cwd + '/' + isf_input);
     if (isf_data.units !== 'mg/dL') {
-      console.log('ISF is expected to be expressed in mg/dL.'
-                 , 'Found', isf_data.units, 'in', isf_input, '.');
-      process.exit(2);
+        if (isf_data.units == 'mmol/L') {
+            for (var i = 0, len = isf_data.sensitivities.length; i < len; i++) {
+                isf_data.sensitivities[i].sensitivity = isf_data.sensitivities[i].sensitivity * 18;
+            }
+            isf_data.units = 'mg/dL';
+        } else {
+            console.log('ISF is expected to be expressed in mg/dL or mmol/L.'
+                    , 'Found', isf_data.units, 'in', isf_input, '.');
+            process.exit(2);
+        }
     }
     var basalprofile_data = require(cwd + '/' + basalprofile_input);
 

--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -96,13 +96,13 @@ if (!module.parent) {
     var bgtargets_data = require(cwd + '/' + bgtargets_input);
     if (bgtargets_data.units !== 'mg/dL') {
         if (bgtargets_data.units == 'mmol/L') {
-            for (var i = 0, len = bgtargets_data.sensitivities.length; i < len; i++) {
+            for (var i = 0, len = bgtargets_data.targets.length; i < len; i++) {
                 isf_data.targets[i].high = bgtargets_data.targets[i].high * 18;
                 isf_data.targets[i].low = bgtargets_data.targets[i].low * 18;
             }
             bgtargets_data.units = 'mg/dL';
         } else {
-            console.log('BG Target data is expected to be expressed in mg/dL.'
+            console.log('BG Target data is expected to be expressed in mg/dL or mmol/L.'
                  , 'Found', bgtargets_data.units, 'in', bgtargets_input, '.');
             process.exit(2);
         }


### PR DESCRIPTION
This will mean users with a pump in mmol mode don't need to add a conversion step to their loop script