### PR TITLE
Install from source if the oref0 git clone is there. Use (updated) oref0 standard published package if there is no git oref0 directory

### DIFF
--- a/bin/oref0-dexusb-cgm-loop.py
+++ b/bin/oref0-dexusb-cgm-loop.py
@@ -37,7 +37,6 @@ import sys
 # Step 3. Disable the default cgm loop in crontab, because this script will invoke openaps get-bg
 #
 # Step 4. Reboot
-
 HOURS=24
 CMD_GET_GLUCOSE="openaps use cgm oref0_glucose --hours %d --threshold 100"
 CMD_DESCRIBE_CLOCKS="openaps use cgm DescribeClocks"
@@ -48,7 +47,7 @@ WAIT=5*60+1 # wait 5 minutes and 1 second
 CGMPER24H=288*2 # 24 hours = 288 * 5 minutes. For raw values multiply by 2
 
 # Redirect stdin file descriptor. Otherwise it will not start without a terminal
-sys.stdin = open('/dev/null', 'r')
+#sys.stdin = open('/dev/null', 'r')
 
 # limit list to maxlen items
 def limitlist(l,maxlen):

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -248,13 +248,16 @@ mkdir -p $HOME/src/
 if [ -d "$HOME/src/oref0/" ]; then
     echo "$HOME/src/oref0/ already exists; pulling latest"
     (cd ~/src/oref0 && git fetch && git pull) || die "Couldn't pull latest oref0"
+    echo (Re)installing oref0 installation from ~/src/oref0
+    cd $HOME/src/oref0/ && npm run global-install
 else
     echo -n "Cloning oref0: "
     (cd ~/src && git clone git://github.com/openaps/oref0.git) || die "Couldn't clone oref0"
+    echo Checking oref0 installation
+    npm list -g oref0 | egrep oref0@0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
 fi
-echo Checking oref0 installation
-npm list -g oref0 | egrep oref0@0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
-#(echo Installing latest oref0 dev && cd $HOME/src/oref0/ && npm run global-install)
+
+#(echo Installing latest oref0 dev && 
 
 echo Checking mmeowlink installation
 if openaps vendor add --path . mmeowlink.vendors.mmeowlink 2>&1 | grep "No module"; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -241,7 +241,7 @@ mkdir -p settings || die "Can't mkdir settings"
 mkdir -p enact || die "Can't mkdir enact"
 mkdir -p upload || die "Can't mkdir upload"
 if [[ ${CGM,,} =~ "xdrip" ]]; then
-	mkdir -p xdrip || die "Can't mkdir xdrip"
+    mkdir -p xdrip || die "Can't mkdir xdrip"
 fi
 
 mkdir -p $HOME/src/
@@ -251,17 +251,18 @@ if [ -d "$HOME/src/oref0/" ]; then
     OLD_HEAD=$(git rev-parse HEAD)
     (git fetch && git pull) || die "Couldn't pull latest oref0"
     NEW_HEAD=$(git rev-parse HEAD)
-    if [ "$OLD_HEAD" == "$NEW_HEAD" ];  then
+    if [ "$OLD_HEAD" != "$NEW_HEAD" ];  then
        echo "(Re)installing oref0 installation from ~/src/oref0. version=$NEW_HEAD"
-       npm run global-install
+       sudo npm install -g .
+       #npm run global-install
     else 
        echo "Not need to reinstall. version=$NEW_HEAD is still current"
     fi
 else
    echo -n "Cloning oref0: "
-    (cd ~/src && git clone git://github.com/openaps/oref0.git) || die "Couldn't clone oref0"
-    echo Checking oref0 installation
-    npm list -g oref0 | egrep oref0@0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
+   (cd ~/src && git clone git://github.com/openaps/oref0.git) || die "Couldn't clone oref0"
+   echo Checking oref0 installation
+   npm list -g oref0 | egrep oref0@0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
 fi
 
 echo Checking mmeowlink installation
@@ -280,9 +281,10 @@ fi
 cat preferences.json
 git add preferences.json
 
-# enable log rotation
-sudo cp $HOME/src/oref0/logrotate.openaps /etc/logrotate.d/openaps || die "Could not cp /etc/logrotate.d/openaps"
-sudo cp $HOME/src/oref0/logrotate.rsyslog /etc/logrotate.d/rsyslog || die "Could not cp /etc/logrotate.d/rsyslog"
+#enable log rotation
+#DEPRECATED: See https://github.com/openaps/oref0/pull/302
+#sudo cp $HOME/src/oref0/logrotate.openaps /etc/logrotate.d/openaps || die "Could not cp /etc/logrotate.d/openaps"
+#sudo cp $HOME/src/oref0/logrotate.rsyslog /etc/logrotate.d/rsyslog || die "Could not cp /etc/logrotate.d/rsyslog"
 
 test -d /var/log/openaps || sudo mkdir /var/log/openaps && sudo chown $USER /var/log/openaps || die "Could not create /var/log/openaps"
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -251,7 +251,7 @@ if [ -d "$HOME/src/oref0/" ]; then
     OLD_HEAD=$(git rev-parse HEAD)
     (git fetch && git pull) || die "Couldn't pull latest oref0"
     NEW_HEAD=$(git rev-parse HEAD)
-    if [ $OLD_HEAD -eq $NEW_HEAD ];  then
+    if [["$OLD_HEAD" == "$NEW_HEAD"]];  then
        echo "(Re)installing oref0 installation from ~/src/oref0. version=$NEW_HEAD"
        npm run global-install
     else 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -554,7 +554,7 @@ elif [[ ${CGM,,} =~ "xdrip" ]]; then
     (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps monitor-xdrip'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps monitor-xdrip' || ( date; openaps monitor-xdrip) | tee -a /var/log/openaps/xdrip-loop.log; cp -up $directory/xdrip/glucose.json $directory/monitor/glucose.json") | crontab -
     (crontab -l; crontab -l | grep -q "xDripAPS.py" || echo "@reboot python $HOME/.xDripAPS/xDripAPS.py") | crontab -
 elif [[ $ENABLE =~ dexusb ]]; then
-    (crontab -l; crontab -l | grep -q "@reboot	/usr/bin/python" || echo "@reboot	/usr/bin/python /usr/local/bin/oref0-dexusb-cgm-loop.py >> /var/log/openaps/cgm-dexusb-loop.log 2>&1" ) | crontab -
+    (crontab -l; crontab -l | grep -q "@reboot.*/usr/bin/python" || echo "@reboot cd $directory && /usr/bin/python /usr/local/bin/oref0-dexusb-cgm-loop.py >> /var/log/openaps/cgm-dexusb-loop.log 2>&1" ) | crontab -
 elif ! [[ ${CGM,,} =~ "mdt" ]]; then # use nightscout for cgm
     (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
 fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -247,17 +247,19 @@ fi
 mkdir -p $HOME/src/
 if [ -d "$HOME/src/oref0/" ]; then
     echo "$HOME/src/oref0/ already exists; pulling latest"
-    (cd ~/src/oref0 && git fetch && git pull) || die "Couldn't pull latest oref0"
-    echo (Re)installing oref0 installation from ~/src/oref0
-    cd $HOME/src/oref0/ && npm run global-install
+    cd ~/src/oref0
+    (git fetch && git pull) || die "Couldn't pull latest oref0"
+    #  only reinstall if repository has changed
+    if [[ ! -f .oref0_version_installed || `cat .oref0_version_installed` eq `git show | head -n 1 `]]; 
+       echo "(Re)installing oref0 installation from ~/src/oref0"
+       npm run global-install && (git show | head -n 1 > .oref0_version_installed)
+    fi
 else
-    echo -n "Cloning oref0: "
+   echo -n "Cloning oref0: "
     (cd ~/src && git clone git://github.com/openaps/oref0.git) || die "Couldn't clone oref0"
     echo Checking oref0 installation
     npm list -g oref0 | egrep oref0@0.3. || (echo Installing latest oref0 && sudo npm install -g oref0)
 fi
-
-#(echo Installing latest oref0 dev && 
 
 echo Checking mmeowlink installation
 if openaps vendor add --path . mmeowlink.vendors.mmeowlink 2>&1 | grep "No module"; then
@@ -455,7 +457,7 @@ else
 
        # Hack to check if radio_locale has been set in pump.ini. This is a temporary workaround for https://github.com/oskarpearson/mmeowlink/issues/55
        # It will remove empty line at the end of pump.ini and then append radio_locale if it's not there yet
-       grep -q radio_locale pump.ini &&  echo "$(< pump.ini)" > pump.ini ; echo "radio_locale=$radio_locale" >> pump.ini
+       grep -q radio_locale pump.ini || (echo "$(< pump.ini)" > pump.ini ; echo "radio_locale=$radio_locale" >> pump.ini)
     fi
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -251,7 +251,7 @@ if [ -d "$HOME/src/oref0/" ]; then
     OLD_HEAD=$(git rev-parse HEAD)
     (git fetch && git pull) || die "Couldn't pull latest oref0"
     NEW_HEAD=$(git rev-parse HEAD)
-    if [["$OLD_HEAD" == "$NEW_HEAD"]];  then
+    if [ "$OLD_HEAD" == "$NEW_HEAD" ];  then
        echo "(Re)installing oref0 installation from ~/src/oref0. version=$NEW_HEAD"
        npm run global-install
     else 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -248,11 +248,14 @@ mkdir -p $HOME/src/
 if [ -d "$HOME/src/oref0/" ]; then
     echo "$HOME/src/oref0/ already exists; pulling latest"
     cd ~/src/oref0
+    OLD_HEAD=$(git rev-parse HEAD)
     (git fetch && git pull) || die "Couldn't pull latest oref0"
-    #  only reinstall if repository has changed
-    if [[ ! -f .oref0_version_installed || `cat .oref0_version_installed` eq `git show | head -n 1 `]]; 
-       echo "(Re)installing oref0 installation from ~/src/oref0"
-       npm run global-install && (git show | head -n 1 > .oref0_version_installed)
+    NEW_HEAD=$(git rev-parse HEAD)
+    if [ $OLD_HEAD -eq $NEW_HEAD ];  then
+       echo "(Re)installing oref0 installation from ~/src/oref0. version=$NEW_HEAD"
+       npm run global-install
+    else 
+       echo "Not need to reinstall. version=$NEW_HEAD is still current"
     fi
 else
    echo -n "Cloning oref0: "

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",
-    "deprecated-global-install : "npm install && sudo npm install -g && sudo npm link && sudo npm link oref0",
+    "deprecated-global-install" : "npm install && sudo npm install -g && sudo npm link && sudo npm link oref0",
     "global-install": "Error: global-install is deprecated. Please use 'npm install -g oref0' for a packaged version, or 'npm install -g .' for a git checkout. See https://github.com/openaps/oref0/pull/302",
     "postinstall" : "echo Installing logrotate scripts; (sudo cp -v logrotate.openaps /etc/logrotate.d/openaps ; sudo cp -v logrotate.rsyslog /etc/logrotate.d/rsyslog ) || die 'Could not install logrotate scripts'"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",
-    # global install was ""npm install && sudo npm install -g && sudo npm link && sudo npm link oref0"
+    "deprecated-global-install : "npm install && sudo npm install -g && sudo npm link && sudo npm link oref0",
     "global-install": "Error: global-install is deprecated. Please use 'npm install -g oref0' for a packaged version, or 'npm install -g .' for a git checkout. See https://github.com/openaps/oref0/pull/302",
     "postinstall" : "echo Installing logrotate scripts; (sudo cp -v logrotate.openaps /etc/logrotate.d/openaps ; sudo cp -v logrotate.rsyslog /etc/logrotate.d/rsyslog ) || die 'Could not install logrotate scripts'"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",
-    "global-install": "npm install && sudo npm install -g && sudo npm link && sudo npm link oref0"
+    # global install was ""npm install && sudo npm install -g && sudo npm link && sudo npm link oref0"
+    "global-install": "Error: global-install is deprecated. Please use 'npm install -g oref0' for a packaged version, or 'npm install -g .' for a git checkout. See https://github.com/openaps/oref0/pull/302",
+    "postinstall" : "echo Installing logrotate scripts; (sudo cp -v logrotate.openaps /etc/logrotate.d/openaps ; sudo cp -v logrotate.rsyslog /etc/logrotate.d/rsyslog ) || die 'Could not install logrotate scripts'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "make test",
     "deprecated-global-install" : "npm install && sudo npm install -g && sudo npm link && sudo npm link oref0",
     "global-install": "Error: global-install is deprecated. Please use 'npm install -g oref0' for a packaged version, or 'npm install -g .' for a git checkout. See https://github.com/openaps/oref0/pull/302",
-    "postinstall" : "echo Installing logrotate scripts; (sudo cp -v logrotate.openaps /etc/logrotate.d/openaps ; sudo cp -v logrotate.rsyslog /etc/logrotate.d/rsyslog ) || die 'Could not install logrotate scripts'"
+    "postinstall" : "echo Installing logrotate scripts; (sudo cp -v logrotate.openaps /etc/logrotate.d/openaps && sudo cp -v logrotate.rsyslog /etc/logrotate.d/rsyslog ) || echo 'failed'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
i noticed the oref0 version was still 0.3.3 so it used the published package instead of the git version in ~/src/oref0 if the ~/src/oref0 is a git repository then install from source. 

i think the Cloning of oref0 should not be necessary when people use a published package