### PR TITLE
Bt device name

### DIFF
--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -14,6 +14,7 @@ if ! curl -m 15 icanhazip.com; then
     if ! curl -m 15 icanhazip.com; then
         echo -n "Error, connecting BT to $MAC "
         sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental &
+        sudo hciconfig hci0 name $HOSTNAME
         sudo bt-pan client $MAC
         echo -n "and getting bnep0 IP"
         sudo dhclient bnep0

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -300,6 +300,7 @@ if [[ ! -z "$BT_MAC" || ${CGM,,} =~ "shareble" ]]; then
         cd $HOME/src/bluez-5.37 && ./configure --enable-experimental --disable-systemd && \
         make && sudo make install && sudo cp ./src/bluetoothd /usr/local/bin/ || die "Couldn't make bluez"
         sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental &
+	sudo hciconfig hci0 name $HOSTNAME
     else
         echo bluez v 5.37 already installed
     fi


### PR DESCRIPTION
To pair with phone

reboot edison

```
sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental &

sudo hciconfig hci0 name $HOSTNAME

bluetoothctl

power off

power on

discoverable on

agent on

default-agent
```
**************************
for android

select device from phone

Type **yes** on terminal

**************************
for iPhone
```
pair AA:BB:CC:DD:EE:FF
```
Type **yes** on terminal
 
**************************

type 
```
trust AA:BB:CC:DD:EE:FF
```