### PR TITLE
Process high and low events as type sgv

### DIFF
--- a/bin/mm-format-ns-glucose.sh
+++ b/bin/mm-format-ns-glucose.sh
@@ -32,7 +32,7 @@ cat $HISTORY | \
   json -E "this.medtronic = this._type;" | \
   json -E "this.dateString = this.dateString ? this.dateString : (this.date + '$(date +%z)')" | \
   json -E "this.date = new Date(this.dateString).getTime();" | \
-  json -E "this.type = (this.name == 'GlucoseSensorData') ? 'sgv' : 'pumpdata'" | \
+  json -E "this.type = (this.name && this.name.indexOf('GlucoseSensorData') > -1) ? 'sgv' : 'pumpdata'" | \
   json -E "this.device = 'openaps://medtronic/pump/cgm'" | (
     json -E "$NSONLY"
   ) > $OUTPUT

--- a/bin/mm-format-oref0-glucose.sh
+++ b/bin/mm-format-oref0-glucose.sh
@@ -26,7 +26,7 @@ cat $HISTORY | \
   json -e "this.medtronic = this._type;" | \
   json -e "this.dateString = this.date + '$(date +%z)'" | \
   json -e "this.date = new Date(this.dateString).getTime();" | \
-  json -e "this.type = (this.name == 'GlucoseSensorData') ? 'sgv' : 'pumpdata'" | \
+  json -E "this.type = (this.name && this.name.indexOf('GlucoseSensorData') > -1) ? 'sgv' : 'pumpdata'" | \
   json -e "this.device = 'openaps://medtronic/pump/cgm'" \
   > $OUTPUT
 

--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -217,7 +217,7 @@ ns)
         json -E "this.dateString = this.dateString ? this.dateString : this.display_time" | \
         json -E "this.dateString = this.dateString ? this.dateString : (this.date + '$(date +%z)')" | \
         json -E "this.date = new Date(this.dateString).getTime();" | \
-        json -E "this.type = (this.name == 'GlucoseSensorData') ? 'sgv' : 'pumpdata'" | \
+        json -E "this.type = (this.name && this.name.indexOf('GlucoseSensorData') > -1) ? 'sgv' : 'pumpdata'" | \
         json -E "this.device = 'openaps://medtronic/pump/cgm'" | (
           json -E "$NSONLY"
         )


### PR DESCRIPTION
This change causes the oref0 and nightscout scripts to treat GlucoseSensorDataLow (<40) and GlucoseSensorDataHigh (>400) events as type=sgv events. As before, oref0 continues to treat regular GlucoseSensorData events as type=sgv.

There is a relevant PR in decocare that adds the decoding of the newly discovered high and low events: https://github.com/openaps/decocare/pull/16.