### PR TITLE
Detect and fix additional case of git corruption (broken HEAD).

### DIFF
--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -49,5 +49,5 @@ if [ $status -lt 128 ]; then
 fi
 # if git repository is too corrupt to do anything, mv it to /tmp and start over.
 
-(git status && git diff && ! df | grep 100% && ! df -i | grep 100%) > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; rm -rf .git; openaps init . )
+(git status && git diff && git symbolic-ref HEAD && ! df | grep 100% && ! df -i | grep 100%) > /dev/null || (echo "Saving backup to: $BACKUP" > /dev/stderr; mv .git $BACKUP; rm -rf .git; openaps init . )
 


### PR DESCRIPTION
This detects and fixes an additional type of git corruption due to a broken HEAD reference.

All openaps report commands were failing with the following callstack:
```
Traceback (most recent call last):
  File "/usr/local/bin/openaps-report", line 8, in <module>
    execfile(__file__)
  File "/home/pi/src/openaps/bin/openaps-report", line 82, in <module>
    app( )
  File "/home/pi/src/openaps/openaps/cli/__init__.py", line 52, in __call__
    self.epilog( )
  File "/home/pi/src/openaps/bin/openaps-report", line 69, in epilog
    super(ReportToolApp, self).epilog( )
  File "/home/pi/src/openaps/openaps/cli/__init__.py", line 75, in epilog
    self.create_git_commit( )
  File "/home/pi/src/openaps/openaps/cli/__init__.py", line 98, in create_git_commit
    self.repo.index.commit(msg)
  File "/usr/local/lib/python2.7/dist-packages/git/index/base.py", line 949, in commit
    author_date=author_date, commit_date=commit_date)
  File "/usr/local/lib/python2.7/dist-packages/git/objects/commit.py", line 315, in create_from_tree
    parent_commits = [repo.head.commit]
  File "/usr/local/lib/python2.7/dist-packages/git/refs/symbolic.py", line 183, in _get_commit
    obj = self._get_object()
  File "/usr/local/lib/python2.7/dist-packages/git/refs/symbolic.py", line 176, in _get_object
    return Object.new_from_sha(self.repo, hex_to_bin(self.dereference_recursive(self.repo, self.path)))
  File "/usr/local/lib/python2.7/dist-packages/git/refs/symbolic.py", line 125, in dereference_recursive
    hexsha, ref_path = cls._get_ref_info(repo, ref_path)
  File "/usr/local/lib/python2.7/dist-packages/git/refs/symbolic.py", line 143, in _get_ref_info
    assert(len(tokens) != 0)
AssertionError
```

Trying to do a manual `git commit` gave the following:
```
error: unable to resolve reference HEAD: Invalid argument
fatal: cannot lock HEAD ref
```
Both `git status` and `git diff` succeeded in this scenario, but `git symbolic-ref HEAD` failed with:
```
fatal: No such ref: HEAD
```