### PR TITLE
Pancred addon

### DIFF
--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+if ! ( hciconfig -a | grep -q "PSCAN" ) ; then
+   sudo killall bluetoothd
+   sudo /usr/local/bin/bluetoothd --experimental &
+fi
+
+if ( hciconfig -a | grep -q "DOWN" ) ; then
+   sudo hciconfig hci0 up
+fi
+
+if !( hciconfig -a | grep -q $HOSTNAME ) ; then
+   sudo hciconfig hci0 name $HOSTNAME
+fi

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -15,8 +15,7 @@ if ! curl -m 15 icanhazip.com; then
     echo -n "At $(date) my IP is: "
     if ! curl -m 15 icanhazip.com; then
         echo -n "Error, connecting BT to $MAC "
-        sudo killall bluetoothd; sleep 5; sudo /usr/local/bin/bluetoothd --experimental &
-        sudo hciconfig hci0 name $HOSTNAME
+        oref0-bluetoothup
         sudo bt-pan client $MAC
         echo -n "and getting bnep0 IP"
         sudo dhclient bnep0

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -592,7 +592,7 @@ fi
 (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l
 if [[ ! -z "$BT_PEB"]]; then
-    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'pan-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'pan-urchin-status $BT_PEB ; openaps urchin-loop' || pan-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
+    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
 fi
 
 if [[ ${CGM,,} =~ "shareble" ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -313,8 +313,7 @@ if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" || ${CGM,,} =~ "shareble" ]]; then
         cd $HOME/src/ && wget https://www.kernel.org/pub/linux/bluetooth/bluez-5.37.tar.gz && tar xvfz bluez-5.37.tar.gz || die "Couldn't download bluez"
         cd $HOME/src/bluez-5.37 && ./configure --enable-experimental --disable-systemd && \
         make && sudo make install && sudo cp ./src/bluetoothd /usr/local/bin/ || die "Couldn't make bluez"
-        sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental &
-	sudo hciconfig hci0 name $HOSTNAME
+        oref0-bluetoothup
     else
         echo bluez v 5.37 already installed
     fi
@@ -532,7 +531,7 @@ if [[ ! -z "$BT_PEB" ]]; then
    sudo pip install libpebble2
    sudo pip install --user git+git://github.com/mddub/pancreabble.git
    sudo apt-get install jq
-   sudo hciconfig hci0 up
+   oref0-bluetoothup
    sudo rfcomm bind hci0 $BT_PEB
    for type in pancreabble; do
      echo importing $type file
@@ -594,7 +593,8 @@ fi
 crontab -l
 if [[ ! -z "$BT_PEB" ]]; then
     (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
-    (crontab -l; crontab -l | grep -q "sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental & " || echo "@reboot sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental & ") | crontab -
+    (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
+
 fi
 
 if [[ ${CGM,,} =~ "shareble" ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -536,7 +536,7 @@ if [[ ! -z "$BT_PEB" ]]; then
      echo importing $type file
      cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
   done 
-  sudo cp $HOME/lib/oref0-setup/pancreoptions.json $HOME/$directory/pancreoptions.json 
+  sudo cp $HOME/src/oref0/lib/oref0-setup/pancreoptions.json $HOME/$directory/pancreoptions.json 
 fi  
 
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -593,7 +593,7 @@ fi
 (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l
 if [[ ! -z "$BT_PEB" ]]; then
-    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
+    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
     (crontab -l; crontab -l | grep -q "sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental & " || echo "@reboot sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental & ") | crontab -
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -592,7 +592,7 @@ fi
 (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l
 if [[ ! -z "$BT_PEB" ]]; then
-    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
+    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop' || peb-urchin-status $BT_PEB && openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
     (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
 
 fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -80,7 +80,7 @@ case $i in
     BT_MAC="${i#*=}"
     shift # past argument=value
     ;;
-    --btpeb=*)
+    -p=*|--btpeb=*)
     BT_PEB="${i#*=}"
     shift # past argument=value
     ;;
@@ -305,7 +305,7 @@ for type in vendor device report alias; do
     cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
 done
 echo Checking for BT Mac, BT Peb or Shareble
-if [[ ! -z "$BT_MAC" || ${CGM,,} =~ "shareble" ]]; then
+if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" || ${CGM,,} =~ "shareble" ]]; then
     # Install Bluez for BT Tethering
     echo Checking bluez installation
     if ! bluetoothd --version | grep -q 5.37 2>/dev/null; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -536,7 +536,7 @@ if [[ ! -z "$BT_PEB" ]]; then
      echo importing $type file
      cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
   done 
-  sudo cp $HOME/src/oref0/lib/oref0-setup/pancreoptions.json $HOME/$directory/pancreoptions.json 
+  sudo cp $HOME/src/oref0/lib/oref0-setup/pancreoptions.json $directory/pancreoptions.json 
 fi  
 
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -530,7 +530,6 @@ echo Checking for BT Pebble Mac
 if [[ ! -z "$BT_PEB" ]]; then
    sudo pip install libpebble2
    sudo pip install --user git+git://github.com/mddub/pancreabble.git
-   sudo apt-get install jq
    oref0-bluetoothup
    sudo rfcomm bind hci0 $BT_PEB
    for type in pancreabble; do

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -527,9 +527,9 @@ if egrep -i "edison" /etc/passwd 2>/dev/null; then
 fi
 # Install Pancreabble
 echo Checking for BT Pebble Mac 
-if [[ ! -z "$BT_PEB"]]; then
+if [[ ! -z "$BT_PEB" ]]; then
    sudo pip install libpebble2
-   pip install --user git+git://github.com/mddub/pancreabble.git
+   sudo pip install --user git+git://github.com/mddub/pancreabble.git
    sudo hciconfig hci0 up
    sudo rfcomm bind hci0 $BT_PEB
    for type in pancreabble; do
@@ -590,7 +590,7 @@ if [[ "$ttyport" =~ "spi" ]]; then
 fi
 (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l
-if [[ ! -z "$BT_PEB"]]; then
+if [[ ! -z "$BT_PEB" ]]; then
     (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -536,7 +536,8 @@ if [[ ! -z "$BT_PEB" ]]; then
    for type in pancreabble; do
      echo importing $type file
      cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
-  done  
+  done 
+  sudo cp $HOME/lib/oref0-setup/pancreoptions.json $HOME/$directory/pancreoptions.json 
 fi  
 
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -182,7 +182,8 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
           else
           echo "Ok, $BT_MAC it is."
        fi
-       if [[ ! -z $BT_PEB ]]; then
+     fi  
+     if [[ ! -z $BT_PEB ]]; then
        read -p "For Pancreabble enter Pebble mac id (i.e. AA:BB:CC:DD:EE:FF) hit enter to skip " -r
        BT_PEB=$REPLY
        echo "Ok, $BT_MAC it is."
@@ -536,7 +537,7 @@ if [[ ! -z "$BT_PEB" ]]; then
      echo importing $type file
      cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
   done  
- fi  
+fi  
 
 
 echo Running: openaps report add enact/suggested.json text determine-basal shell monitor/iob.json monitor/temp_basal.json monitor/glucose.json settings/profile.json $EXTRAS
@@ -590,9 +591,9 @@ if [[ "$ttyport" =~ "spi" ]]; then
 fi
 (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l
-#if [[ ! -z "$BT_PEB" ]]; then
-#    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
-#fi
+if [[ ! -z "$BT_PEB" ]]; then
+    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
+fi
 
 if [[ ${CGM,,} =~ "shareble" ]]; then
     echo

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -531,6 +531,7 @@ echo Checking for BT Pebble Mac
 if [[ ! -z "$BT_PEB" ]]; then
    sudo pip install libpebble2
    sudo pip install --user git+git://github.com/mddub/pancreabble.git
+   sudo apt-get install jq
    sudo hciconfig hci0 up
    sudo rfcomm bind hci0 $BT_PEB
    for type in pancreabble; do
@@ -593,6 +594,7 @@ fi
 crontab -l
 if [[ ! -z "$BT_PEB" ]]; then
     (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
+    (crontab -l; crontab -l | grep -q "sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental & " || echo "@reboot sudo killall bluetoothd; sudo /usr/local/bin/bluetoothd --experimental & ") | crontab -
 fi
 
 if [[ ${CGM,,} =~ "shareble" ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -590,9 +590,9 @@ if [[ "$ttyport" =~ "spi" ]]; then
 fi
 (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
 crontab -l
-if [[ ! -z "$BT_PEB" ]]; then
-    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
-fi
+#if [[ ! -z "$BT_PEB" ]]; then
+#    (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB ; openaps urchin-loop' || peb-urchin-status $BT_PEB ; openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
+#fi
 
 if [[ ${CGM,,} =~ "shareble" ]]; then
     echo

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -305,7 +305,7 @@ for type in vendor device report alias; do
     cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
 done
 echo Checking for BT Mac, BT Peb or Shareble
-if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" || ${CGM,,} =~ "shareble" ]]; then
+if [[ ! -z "$BT_MAC" || ${CGM,,} =~ "shareble" ]]; then
     # Install Bluez for BT Tethering
     echo Checking bluez installation
     if ! bluetoothd --version | grep -q 5.37 2>/dev/null; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -80,7 +80,6 @@ case $i in
     BT_MAC="${i#*=}"
     shift # past argument=value
     ;;
-    ;;
     --btpeb=*)
     BT_PEB="${i#*=}"
     shift # past argument=value

--- a/bin/pan-urchin-status.sh
+++ b/bin/pan-urchin-status.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-MAC=$1
-
-sudo rfcomm bind hci0 $MAC
-
-#Status for Pancreabble Urchin
-#echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
-echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json

--- a/bin/pan-urchin-status.sh
+++ b/bin/pan-urchin-status.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+MAC=$1
+
+sudo rfcomm bind hci0 $MAC
+
+#Status for Pancreabble Urchin
+#echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
+echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json

--- a/bin/peb-urchin-status.sh
+++ b/bin/peb-urchin-status.sh
@@ -6,5 +6,30 @@ if ! ( rfcomm show hci0 | grep -q $MAC ) ; then
 fi 
 
 #Status for Pancreabble Urchin
-#echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
-echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json
+if [[ $(jq .urchin_loop_status pancreoptions.json) != "true" ]]; then
+	echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
+fi 
+if [[ $(jq .urchin_iob pancreoptions.json) != "true" ]]; then
+   echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json
+fi
+
+#Notification Status
+if [[ $(jq .Notify_Temp_Basal pancreoptions.json) = "true" ]]; then
+   if [[ $(jq .rate enact/suggested.json) != null ]]; then
+      if [[ $(jq .rate enact/suggested.json) != $tempb ]]; then
+         openaps use pbbl notify "Temp Basal" "set temp basal: $(jq .rate enact/suggested.json) for $(jq .duration enact/suggested.json) minutes"
+         tempb = $(jq .rate enact/suggested.json)
+      fi
+   fi
+fi
+
+if [[ $(jq .Notify_Battery pancreoptions.json) = "true" ]]; then
+   if [[ $(jq .battery monitor/edison-battery.json) -le $(jq .Notify_Battery_Alarm pancreoptions.json) ]]; then
+      alarms = `jq .Notify_Battery_Alarm_Silence pancreoptions.json`
+	  let "time = alarms * 60"
+      if [[ $time -ge $date ]]; then
+         openaps use pbbl notify "Edison" "Edison Battery at: $(jq .battery monitor/edison-battery.json)%"
+	     tempbatt = $(date)
+      fi   
+   fi
+fi   

--- a/bin/peb-urchin-status.sh
+++ b/bin/peb-urchin-status.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 MAC=$1
 
-sudo rfcomm bind hci0 $MAC
+if ! ( rfcomm show hci0 | grep -q $MAC ) ; then
+   sudo rfcomm bind hci0 $MAC
+fi 
 
 #Status for Pancreabble Urchin
 #echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
 echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json
-

--- a/bin/peb-urchin-status.sh
+++ b/bin/peb-urchin-status.sh
@@ -6,30 +6,17 @@ if ! ( rfcomm show hci0 | grep -q $MAC ) ; then
 fi 
 
 #Status for Pancreabble Urchin
-if [[ $(jq .urchin_loop_status pancreoptions.json) != "true" ]]; then
+if [[ $(jq .urchin_loop_status pancreoptions.json) = "true" ]]; then
 	echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
 fi 
-if [[ $(jq .urchin_iob pancreoptions.json) != "true" ]]; then
+if [[ $(jq .urchin_iob pancreoptions.json) = "true" ]]; then
    echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json
 fi
 
 #Notification Status
 if [[ $(jq .Notify_Temp_Basal pancreoptions.json) = "true" ]]; then
    if [[ $(jq .rate enact/suggested.json) != null ]]; then
-      if [[ $(jq .rate enact/suggested.json) != $tempb ]]; then
-         openaps use pbbl notify "Temp Basal" "set temp basal: $(jq .rate enact/suggested.json) for $(jq .duration enact/suggested.json) minutes"
-         tempb = $(jq .rate enact/suggested.json)
-      fi
+      openaps use pbbl notify "Set Temp Basal" "at $(date +%-I:%M%P): $(jq .rate enact/suggested.json) for $(jq .duration enact/suggested.json) minutes"
    fi
 fi
-
-if [[ $(jq .Notify_Battery pancreoptions.json) = "true" ]]; then
-   if [[ $(jq .battery monitor/edison-battery.json) -le $(jq .Notify_Battery_Alarm pancreoptions.json) ]]; then
-      alarms = `jq .Notify_Battery_Alarm_Silence pancreoptions.json`
-	  let "time = alarms * 60"
-      if [[ $time -ge $date ]]; then
-         openaps use pbbl notify "Edison" "Edison Battery at: $(jq .battery monitor/edison-battery.json)%"
-	     tempbatt = $(date)
-      fi   
-   fi
-fi   
+   

--- a/bin/peb-urchin-status.sh
+++ b/bin/peb-urchin-status.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+MAC=$1
+
+sudo rfcomm bind hci0 $MAC
+
+#Status for Pancreabble Urchin
+#echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
+echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json
+

--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -57,7 +57,7 @@
   },
   {
     "pump-loop": {
-      "command": "! bash -c \"sleep $[ ( $RANDOM / 2048 ) ]s; until(echo Starting pump-loop at $(date): && openaps wait-for-silence && openaps get-bg && openaps refresh-old-pumphistory && openaps refresh-old-pumphistory-24h && openaps refresh-old-profile && openaps refresh-temp-and-enact && openaps refresh-pumphistory-and-enact && openaps refresh-profile && openaps refresh-pumphistory-24h && echo Completed pump-loop at $(date) && echo); do echo Error, retrying && [[ $RANDOM > 30000 ]] && openaps wait-for-long-silence && openaps mmtune; sleep 5; done\""
+      "command": "! bash -c \"sleep $[ ( $RANDOM / 2048 ) ]s; until(echo Starting pump-loop at $(date): && openaps wait-for-silence && openaps get-bg && openaps refresh-old-pumphistory && openaps refresh-old-pumphistory-24h && openaps refresh-old-profile && openaps refresh-temp-and-enact && openaps refresh-pumphistory-and-enact && openaps refresh-profile && openaps refresh-pumphistory-24h && echo Completed pump-loop at $(date) && echo); do echo Error, retrying && [[ $RANDOM > 30000 ]] && openaps wait-for-long-silence ; openaps mmtune; sleep 5; done\""
     },
     "type": "alias",
     "name": "pump-loop"

--- a/lib/oref0-setup/pancreabble.json
+++ b/lib/oref0-setup/pancreabble.json
@@ -16,6 +16,7 @@
     "name": "pbbl",
     "extra": {
       "port": "/dev/rfcomm0"
+    }    
     },
   {
     "type": "report",

--- a/lib/oref0-setup/pancreabble.json
+++ b/lib/oref0-setup/pancreabble.json
@@ -1,0 +1,48 @@
+[
+{
+    "pancreabble": {
+      "path": ".",
+      "module": "pancreabble"
+    },
+    "type": "vendor",
+    "name": "pancreabble"
+  },
+  {
+    "type": "device",
+    "pbbl": {
+      "vendor": "pancreabble",
+      "extra": "pbbl.ini"
+    },
+    "name": "pbbl",
+    "extra": {
+      "port": "/dev/rfcomm0"
+    },
+  {
+    "type": "report",
+    "name": "upload/urchin-data.json",
+    "upload/urchin-data.json": {
+      "use": "format_urchin_data",
+      "reporter": "JSON",
+      "cgm_clock": "monitor/clock.json",
+      "action": "add",
+      "device": "pbbl",
+      "glucose_history": "monitor/glucose-unzoned.json",
+      "status_text": "",
+      "status_json": "upload/urchin-status.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "upload-pbbl",
+    "upload-pbbl": {
+      "command": "! bash -c \"openaps use pbbl send_urchin_data upload/urchin-data.json\""
+    }
+  },
+  {
+    "urchin-loop": {
+      "command": "! bash -c \"openaps invoke upload/urchin-data.json; openaps upload-pbbl\""
+    },
+    "type": "alias",
+    "name": "urchin-loop"
+  }
+]

--- a/lib/oref0-setup/pancreabble.json
+++ b/lib/oref0-setup/pancreabble.json
@@ -41,7 +41,7 @@
   },
   {
     "urchin-loop": {
-      "command": "! bash -c \"openaps invoke upload/urchin-data.json; openaps upload-pbbl\""
+      "command": "! bash -c \"openaps invoke upload/urchin-data.json && openaps upload-pbbl\""
     },
     "type": "alias",
     "name": "urchin-loop"

--- a/lib/oref0-setup/pancreoptions.json
+++ b/lib/oref0-setup/pancreoptions.json
@@ -2,5 +2,5 @@
 	"urchin_loop_status": false,
 	"urchin_iob": true,
 	"urchin_Temp_Rate": false,
-	"Notify_Temp_Basal": true
+	"Notify_Temp_Basal": false
 }

--- a/lib/oref0-setup/pancreoptions.json
+++ b/lib/oref0-setup/pancreoptions.json
@@ -1,0 +1,9 @@
+{
+	"urchin_loop_status": false,
+	"urchin_iob": true,
+	"urchin_Temp_Rate": false,
+	"Notify_Temp_Basal": true,
+	"Notify_Battery": true,
+	"Notify_Battery_Alarm": 80,
+	"Notify_Battery_Alarm_Silence": 5
+}

--- a/lib/oref0-setup/pancreoptions.json
+++ b/lib/oref0-setup/pancreoptions.json
@@ -2,8 +2,5 @@
 	"urchin_loop_status": false,
 	"urchin_iob": true,
 	"urchin_Temp_Rate": false,
-	"Notify_Temp_Basal": true,
-	"Notify_Battery": true,
-	"Notify_Battery_Alarm": 80,
-	"Notify_Battery_Alarm_Silence": 5
+	"Notify_Temp_Basal": true
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "oref0-subg-ww-radio-parameters-timeout": "./bin/oref0-subg-ww-radio-parameters-timeout.sh",
     "oref0-template": "./bin/oref0-template.js",
     "oref0-truncate-git-history": "bin/oref0-truncate-git-history.sh",
-    "send-tempbasal-Azure": "./bin/send-tempbasal-Azure.js"
+    "send-tempbasal-Azure": "./bin/send-tempbasal-Azure.js",
+    "peb-urchin-status": "./bin/peb-urchin-status.sh"    
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "oref0-template": "./bin/oref0-template.js",
     "oref0-truncate-git-history": "bin/oref0-truncate-git-history.sh",
     "send-tempbasal-Azure": "./bin/send-tempbasal-Azure.js",
-    "peb-urchin-status": "./bin/peb-urchin-status.sh"    
+    "peb-urchin-status": "./bin/peb-urchin-status.sh",
+    "oref0-bluetoothup": "./bin/oref0-bluetoothup.sh"
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {


### PR DESCRIPTION
add on @mddub 's Pancreabble to the oref0-setup.

the peb-urchin-status.sh is not by any means perfect. but it does work.  Easy to turn on and off the different types of statues you would like by changing the bools in pancreoptions.json
Ideas on what statues and notifacations to to add to this would be most helpful.
Almost need a way to know if a value has already been sent to the watch, to prevent duplicate notifications. This would also be an easy way to warn you that your battery is low. But I was unable to make the script write to a json file. 

follow https://github.com/mddub/pancreabble for instructions on Pairing Pebble to rig.
I have not tested with a Pi. 

Added the oref0-bluetoothup to simplify turning on the bluetooth when BlueZ is installed. 

Pebble Mac address can be sound in settings of Pebble. 

there is a bug of when an update is sent to the watch, an error message will show up on terminal if you are hooked up to SSH with a usb cable. this does not happen when using network. So it's annoying but you can still work around it. 