### PR TITLE
Pancre add

### DIFF
--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if ( ifconfig wlan0 | grep -q "inet addr" ) && ( ifconfig bnep0 | grep -q "inet addr" ); then
+   sudo killall bluetoothd
+fi
 
 if ! ( hciconfig -a | grep -q "PSCAN" ) ; then
    sudo killall bluetoothd
@@ -8,6 +11,7 @@ fi
 
 if ( hciconfig -a | grep -q "DOWN" ) ; then
    sudo hciconfig hci0 up
+   sudo /usr/local/bin/bluetoothd --experimental &
 fi
 
 if !( hciconfig -a | grep -q $HOSTNAME ) ; then

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+
+if ! ( hciconfig -a | grep -q "PSCAN" ) ; then
+   sudo killall bluetoothd
+   sudo /usr/local/bin/bluetoothd --experimental &
+fi
+
+if ( hciconfig -a | grep -q "DOWN" ) ; then
+   sudo hciconfig hci0 up
+fi
+
+if !( hciconfig -a | grep -q $HOSTNAME ) ; then
+   sudo hciconfig hci0 name $HOSTNAME
+fi

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+MAC=$1
 
 if ( ifconfig wlan0 | grep -q "inet addr" ) && ( ifconfig bnep0 | grep -q "inet addr" ); then
-   sudo killall bluetoothd
+   sudo bt-pan client $MAC -d
 fi
 
 if ! ( hciconfig -a | grep -q "PSCAN" ) ; then

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -15,8 +15,7 @@ if ! curl -m 15 icanhazip.com; then
     echo -n "At $(date) my IP is: "
     if ! curl -m 15 icanhazip.com; then
         echo -n "Error, connecting BT to $MAC "
-        sudo killall bluetoothd; sleep 5; sudo /usr/local/bin/bluetoothd --experimental &
-        sudo hciconfig hci0 name $HOSTNAME
+        oref0-bluetoothup
         sudo bt-pan client $MAC
         echo -n "and getting bnep0 IP"
         sudo dhclient bnep0

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -189,7 +189,7 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
        BT_PEB=$REPLY
        echo "Ok, $BT_PEB it is."
     else
-       echo echo Ok, no Pancreabble for you.
+       echo Ok, no Pancreabble for you.
     fi
     read -p "Do you need any advanced features? y/[N] " -r
     if [[ $REPLY =~ ^[Yy]$ ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -583,14 +583,13 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         (crontab -l; crontab -l | grep -q "reset_spi_serial.py" || echo "@reboot reset_spi_serial.py") | crontab -
     fi
     (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
-    crontab -l
     if [[ ! -z "$BT_PEB" ]]; then
        (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop' || peb-urchin-status $BT_PEB && openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
     fi
-    crontab -l
     if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
-       (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
+       (crontab -l; crontab -l | grep -q "oref0-bluetoothup  $BT_MAC" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup  '$BT_MAC' || oref0-bluetoothup  '$BT_MAC' >> /var/log/openaps/network.log' ) | crontab -
     fi
+    crontab -l
 fi
 
 if [[ ${CGM,,} =~ "shareble" ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -188,8 +188,6 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
        read -p "For Pancreabble enter Pebble mac id (i.e. AA:BB:CC:DD:EE:FF) hit enter to skip " -r
        BT_PEB=$REPLY
        echo "Ok, $BT_PEB it is."
-    else
-       echo Ok, no Pancreabble for you.
     fi
     read -p "Do you need any advanced features? y/[N] " -r
     if [[ $REPLY =~ ^[Yy]$ ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -587,7 +587,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
        (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop' || peb-urchin-status $BT_PEB && openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
     fi
     if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
-       (crontab -l; crontab -l | grep -q "oref0-bluetoothup  $BT_MAC" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup  '$BT_MAC' || oref0-bluetoothup  '$BT_MAC' >> /var/log/openaps/network.log' ) | crontab -
+       (crontab -l; crontab -l | grep -q "oref0-bluetoothup $BT_MAC" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup '$BT_MAC'" || oref0-bluetoothup '$BT_MAC' >> /var/log/openaps/network.log' ) | crontab -
     fi
     crontab -l
 fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -586,6 +586,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     crontab -l
     if [[ ! -z "$BT_PEB" ]]; then
        (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop' || peb-urchin-status $BT_PEB && openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
+    fi
+    crontab -l
+    if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
        (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
     fi
 fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -187,12 +187,9 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
     if [[ ! -z $BT_PEB ]]; then
        read -p "For Pancreabble enter Pebble mac id (i.e. AA:BB:CC:DD:EE:FF) hit enter to skip " -r
        BT_PEB=$REPLY
-       echo "Ok, $BT_MAC it is."
-       if [[ -z $BT_PEB ]]; then
-          echo Ok, no Pancreabble for you.
-          else
-          echo "Ok, $BT_PEB it is."
-       fi
+       echo "Ok, $BT_PEB it is."
+    else
+       echo echo Ok, no Pancreabble for you.
     fi
     read -p "Do you need any advanced features? y/[N] " -r
     if [[ $REPLY =~ ^[Yy]$ ]]; then

--- a/bin/peb-urchin-status.sh
+++ b/bin/peb-urchin-status.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+MAC=$1
+
+if ! ( rfcomm show hci0 | grep -q $MAC ) ; then
+   sudo rfcomm bind hci0 $MAC
+fi 
+
+#Status for Pancreabble Urchin
+if [[ $(jq .urchin_loop_status pancreoptions.json) = "true" ]]; then
+	echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
+fi 
+if [[ $(jq .urchin_iob pancreoptions.json) = "true" ]]; then
+   echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json
+fi
+
+#Notification Status
+if [[ $(jq .Notify_Temp_Basal pancreoptions.json) = "true" ]]; then
+   if [[ $(jq .rate enact/suggested.json) != null ]]; then
+      openaps use pbbl notify "Set Temp Basal" "at $(date +%-I:%M%P): $(jq .rate enact/suggested.json) for $(jq .duration enact/suggested.json) minutes"
+   fi
+fi

--- a/bin/peb-urchin-status.sh
+++ b/bin/peb-urchin-status.sh
@@ -14,7 +14,7 @@ if [[ $(jq .urchin_iob pancreoptions.json) = "true" ]]; then
 fi
 
 #Notification Status
-if [[ $(jq .Notify_Temp_Basal pancreoptions.json) = "true" ]]; then
+if [[ $(jq .notify_temp_basal pancreoptions.json) = "true" ]]; then
    if [[ $(jq .rate enact/suggested.json) != null ]]; then
       openaps use pbbl notify "Set Temp Basal" "at $(date +%-I:%M%P): $(jq .rate enact/suggested.json) for $(jq .duration enact/suggested.json) minutes"
    fi

--- a/lib/oref0-setup/pancreabble.json
+++ b/lib/oref0-setup/pancreabble.json
@@ -1,0 +1,49 @@
+[
+{
+    "pancreabble": {
+      "path": ".",
+      "module": "pancreabble"
+    },
+    "type": "vendor",
+    "name": "pancreabble"
+  },
+  {
+    "type": "device",
+    "pbbl": {
+      "vendor": "pancreabble",
+      "extra": "pbbl.ini"
+    },
+    "name": "pbbl",
+    "extra": {
+      "port": "/dev/rfcomm0"
+    }    
+    },
+  {
+    "type": "report",
+    "name": "upload/urchin-data.json",
+    "upload/urchin-data.json": {
+      "use": "format_urchin_data",
+      "reporter": "JSON",
+      "cgm_clock": "monitor/clock.json",
+      "action": "add",
+      "device": "pbbl",
+      "glucose_history": "monitor/glucose-unzoned.json",
+      "status_text": "",
+      "status_json": "upload/urchin-status.json"
+    }
+  },
+  {
+    "type": "alias",
+    "name": "upload-pbbl",
+    "upload-pbbl": {
+      "command": "! bash -c \"openaps use pbbl send_urchin_data upload/urchin-data.json\""
+    }
+  },
+  {
+    "urchin-loop": {
+      "command": "! bash -c \"openaps invoke upload/urchin-data.json && openaps upload-pbbl\""
+    },
+    "type": "alias",
+    "name": "urchin-loop"
+  }
+]

--- a/lib/oref0-setup/pancreoptions.json
+++ b/lib/oref0-setup/pancreoptions.json
@@ -1,0 +1,6 @@
+{
+	"urchin_loop_status": false,
+	"urchin_iob": true,
+	"urchin_Temp_Rate": false,
+	"Notify_Temp_Basal": false
+}

--- a/lib/oref0-setup/pancreoptions.json
+++ b/lib/oref0-setup/pancreoptions.json
@@ -1,6 +1,6 @@
 {
 	"urchin_loop_status": false,
 	"urchin_iob": true,
-	"urchin_Temp_Rate": false,
-	"Notify_Temp_Basal": false
+	"urchin_temp_rate": false,
+	"notify_temp_basal": false
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "oref0-subg-ww-radio-parameters-timeout": "./bin/oref0-subg-ww-radio-parameters-timeout.sh",
     "oref0-template": "./bin/oref0-template.js",
     "oref0-truncate-git-history": "bin/oref0-truncate-git-history.sh",
-    "send-tempbasal-Azure": "./bin/send-tempbasal-Azure.js"
+    "send-tempbasal-Azure": "./bin/send-tempbasal-Azure.js",
+    "peb-urchin-status": "./bin/peb-urchin-status.sh",
+    "oref0-bluetoothup": "./bin/oref0-bluetoothup.sh"    
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {


### PR DESCRIPTION
add on @mddub 's Pancreabble to the oref0-setup.

the peb-urchin-status.sh is not by any means perfect. but it does work. Easy to turn on and off the different types of statues you would like by changing the bools in pancreoptions.json
Ideas on what statues and notifacations to to add to this would be most helpful.
Almost need a way to know if a value has already been sent to the watch, to prevent duplicate notifications. This would also be an easy way to warn you that your battery is low. But I was unable to make the script write to a json file.

follow https://github.com/mddub/pancreabble for instructions on Pairing Pebble to rig.
I have not tested with a Pi.

Added the oref0-bluetoothup to simplify turning on the bluetooth when BlueZ is installed.

Pebble Mac address can be sound in settings of Pebble.

there is a bug of when an update is sent to the watch, an error message will show up on terminal if you are hooked up to SSH with a usb cable. this does not happen when using network. So it's annoying but you can still work around it.