### PR TITLE
Add trend arrows to medtronic glucose data

### DIFF
--- a/bin/oref0-mdt-trend.js
+++ b/bin/oref0-mdt-trend.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+function findRecord(arr, tell) {
+	for (var i = 0; i < arr.length; ++i)
+	{
+		if (arr[i]._tell == tell)
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
+function usage ( ) {
+    console.log('usage: ', process.argv.slice(0, 2), '<glucose.json>');
+
+}
+
+if (!module.parent) {
+  var glucose_input = process.argv.slice(2, 3).pop();
+  if ([null, '--help', '-h', 'help'].indexOf(glucose_input) > 0) {
+    usage( );
+    process.exit(0)
+  }
+
+  if (!glucose_input) {
+    usage( );
+    process.exit(1);
+  }
+
+  var cwd = process.cwd();
+  var glucose_data = require(cwd + '/' + glucose_input);
+  glucose_data.sort(function (a, b) { return Date.parse(a.date) - Date.parse(b.date) });
+
+  filtered = glucose_data.filter(function(x) { return x.name == "GlucoseSensorData" });
+
+  var last_entries = [];
+  var last_entry_used = 0;
+  var window_mins = 15;
+  var max_entries = window_mins / 5;
+  var max_time = window_mins * 1000 * 60;
+
+  var last_date = new Date(0);
+  var last_glucose = 0;
+
+  for (var i = 0; i < filtered.length; ++i) {
+	var record = filtered[i];
+	var output_record = glucose_data[findRecord(glucose_data, record._tell)];
+	var current_date = Date.parse(record.date);
+
+	var delta = 0; //record.sgv - last_glucose;
+	var delta_time = 0;
+
+	if (record.name != "GlucoseSensorData")
+	{
+		continue;
+	}
+
+	var used_records = 0;
+	for (var j = 0; j < max_entries; j++)
+	{
+		var past_record = last_entries[j];
+		if (typeof past_record == "undefined")
+		{
+			continue;
+		}
+		var entry_delta_time = current_date - past_record.time;
+
+		if (entry_delta_time <= max_time)
+		{
+			delta_time = entry_delta_time;
+			delta += ((record.sgv - past_record.sgv) * 1000 * 60) / delta_time;
+			used_records++;
+		}
+	}	
+	delta /= used_records;
+	last_entries[last_entry_used] = {time: current_date, sgv: record.sgv};
+	last_entry_used = (last_entry_used + 1 ) % max_entries;
+	if (current_date - last_date <= max_time)
+	{
+
+		if (delta > 3)
+		{
+			output_record.trend_arrow = "DOUBLE_UP";
+			output_record.direction = "DoubleUp";
+		}
+		else if (delta > 2)
+		{
+			output_record.trend_arrow = "SINGLE_UP";
+			output_record.direction = "SingleUp";
+		}
+		else if (delta > 1)
+		{
+			output_record.trend_arrow = "45_UP";
+			output_record.direction = "FortyFiveUp";
+		}
+		else if (delta < -1)
+		{
+			output_record.trend_arrow = "45_DOWN";
+			output_record.direction = "FortyFiveDown";
+		}
+		else if (delta < -2)
+		{
+			output_record.trend_arrow = "SINGLE_DOWN";
+			output_record.direction = "SingleDown";
+		}
+		else if (delta < -3)
+		{
+			output_record.trend_arrow = "DOUBLE_DOWN";
+			output_record.direction = "DoubleDown";
+		}
+		else
+		{
+			output_record.trend_arrow = "FLAT";
+			output_record.direction = "Flat";
+		}
+	}
+
+	last_glucose = record.sgv;	
+	last_date = current_date;
+  }
+
+  console.log(JSON.stringify(glucose_data));
+}
+

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "oref0-get-profile": "./bin/oref0-get-profile.js",
     "oref0-html": "./bin/oref0-html.js",
     "oref0-ifttt-notify": "./bin/oref0-ifttt-notify",
+    "oref0-mdt-trend": "./bin/oref0-mdt-trend.js",
     "oref0-meal": "./bin/oref0-meal.js",
     "oref0-mint-max-iob": "./bin/oref0-mint-max-iob.sh",
     "oref0-normalize-temps": "./bin/oref0-normalize-temps.js",


### PR DESCRIPTION
As the title says, attempt to replicate Dexcom trend arrows from Medtronic data. The new command is intended to run on "raw" glucose data from the pump (`iter_glucose` output). 

I ran it locally as `./oref0-mdt-trend.js monitor/glucose_raw.json > monitor/glucose.json; `.
`monitor/glucose.json` can then be used as normal.

The script calculates the rate of change in blood sugar for all BG data in the last 15 minutes, then computes an average of those. An average change of < 1mg/dl/min is "flat", 1-2 is 45 degrees, 2-3 is single arrow, 3+ is double arrow.

Testing would be welcome.