### PR TITLE
Add current_basal and basalprofile to two failing tests

### DIFF
--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -8,6 +8,8 @@ describe('IOB', function ( ) {
 
   it('should calculate IOB', function() {
 
+    var basalprofile = [{'i': 0, 'start': '00:00:00', 'rate': 1, 'minutes': 0}];
+
     var now = Date.now()
       , timestamp = new Date(now).toISOString()
       , inputs = {
@@ -18,9 +20,7 @@ describe('IOB', function ( ) {
         , timestamp: timestamp
         }]
         , profile: {
-          dia: 3
-          , bolussnooze_dia_divisor: 2
-        }
+          dia: 3, bolussnooze_dia_divisor: 2, basalprofile: basalprofile, current_basal: 1 }
       };
 
     var rightAfterBolus = require('../lib/iob')(inputs)[0];
@@ -308,6 +308,8 @@ describe('IOB', function ( ) {
 
   it('should calculate IOB using a 4 hour duration', function() {
 
+    var basalprofile = [{'i': 0, 'start': '00:00:00', 'rate': 1, 'minutes': 0}];
+
     var now = Date.now()
       , timestamp = new Date(now).toISOString()
       , inputs = {
@@ -320,6 +322,8 @@ describe('IOB', function ( ) {
         , profile: {
           dia: 4
           , bolussnooze_dia_divisor: 2
+		  , basalprofile: basalprofile
+		  , current_basal: 1
         }
       };
 


### PR DESCRIPTION
Lack of current_basal causes these tests to error with latest changes to dev due to required values being `undefined`. Hopefully these values are appropriate.