### PR TITLE
Allow additional preferences to be customized in oref0-setup

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -124,7 +124,7 @@ if ! ( git config -l | grep -q user.name ); then
     git config --global user.name $NAME
 fi
 if [[ -z "$DIR" || -z "$serial" ]]; then
-    echo "Usage: oref0-setup.sh <--dir=directory> <--serial=pump_serial_#> [--tty=/dev/ttySOMETHING] [--max_iob=0] [--max_daily_safety_multiplier=3] [--current_basal_safety_multiplier=4] [--bolussnooze_dia_divisor=4] [--min_5m_carbimpact=3] [--ns-host=https://mynightscout.azurewebsites.net] [--api-secret=myplaintextsecret] [--cgm=(G4|shareble|G5|MDT|xdrip)] [--bleserial=SM123456] [--blemac=FE:DC:BA:98:76:54] [--btmac=AB:CD:EF:01:23:45] [--enable='autosens meal dexusb'] [--radio_locale=(WW|US)]"
+    echo "Usage: oref0-setup.sh <--dir=directory> <--serial=pump_serial_#> [--tty=/dev/ttySOMETHING] [--max_iob=0] [--max_daily_safety_multiplier=3] [--current_basal_safety_multiplier=4] [--bolussnooze_dia_divisor=2] [--min_5m_carbimpact=3] [--ns-host=https://mynightscout.azurewebsites.net] [--api-secret=myplaintextsecret] [--cgm=(G4|shareble|G5|MDT|xdrip)] [--bleserial=SM123456] [--blemac=FE:DC:BA:98:76:54] [--btmac=AB:CD:EF:01:23:45] [--enable='autosens meal dexusb'] [--radio_locale=(WW|US)]"
     read -p "Start interactive setup? [Y]/n " -r
     if [[ $REPLY =~ ^[Nn]$ ]]; then
         exit
@@ -321,23 +321,24 @@ cd $directory || die "Can't cd $directory"
 if [[ "$max_iob" -eq 0 && -z "$max_daily_safety_multiplier" && -z "&current_basal_safety_multiplier" && -z "$bolussnooze_dia_divisor" && -z "$min_5m_carbimpact" ]]; then
     oref0-get-profile --exportDefaults > preferences.json || die "Could not run oref0-get-profile"
 else
-    echo "{ " > preferences_from_args.json
+    preferences_from_args=()
     if [[ $max_iob -ne 0 ]]; then
-	echo -e "\"max_iob\": $max_iob,\n" >> preferences_from_args.json
+	preferences_from_args+="\"max_iob\": $max_iob"
     fi
     if [[ ! -z "$max_daily_safety_multiplier" ]]; then
-	echo -e "\"max_daily_safety_multiplier\": $max_daily_safety_multiplier,\n" >> preferences_from_args.json
+        preferences_from_args+="\"max_daily_safety_multiplier\": $max_daily_safety_multiplier"
     fi
     if [[ ! -z "$current_basal_safety_multiplier" ]]; then
-	echo -e "\"current_basal_safety_multiplier\": $current_basal_safety_multiplier,\n" >> preferences_from_args.json
+        preferences_from_args+="\"current_basal_safety_multiplier\": $current_basal_safety_multiplier"
     fi
     if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
-	echo -e "\"bolussnooze_dia_divisor\": $bolussnooze_dia_divisor,\n" >> preferences_from_args.json
+        preferences_from_args+="\"bolussnooze_dia_divisor\": $bolussnooze_dia_divisor"
     fi
     if [[ ! -z "$min_5m_carbimpact" ]]; then
-	echo -e "\"min_5m_carbimpact\": $min_5m_carbimpact,\n" >> preferences_from_args.json
+        preferences_from_args+="\"min_5m_carbimpact\": $min_5m_carbimpact"
     fi
-    echo } >> preferences_from_args.json
+    function join_by { local IFS="$1"; shift; echo "$*"; }
+    echo "{ $(join_by , ${preferences_from_args[@]}) }" > preferences_from_args.json
     oref0-get-profile --updatePreferences preferences_from_args.json > preferences.json && rm preferences_from_args.json || die "Could not run oref0-get-profile"
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -321,22 +321,23 @@ cd $directory || die "Can't cd $directory"
 if [[ "$max_iob" -eq 0 && -z "$max_daily_safety_multiplier" && -z "&current_basal_safety_multiplier" && -z "$bolussnooze_dia_divisor" && -z "$min_5m_carbimpact" ]]; then
     oref0-get-profile --exportDefaults > preferences.json || die "Could not run oref0-get-profile"
 else
-    rm -f preferences_from_args.json
+    echo "{ " > preferences_from_args.json
     if [[ $max_iob -ne 0 ]]; then
-	echo "{ \"max_iob\": $max_iob }" >> preferences_from_args.json
+	echo "\"max_iob\": $max_iob,\n" >> preferences_from_args.json
     fi
     if [[ ! -z "$max_daily_safety_multiplier" ]]; then
-	echo "{ \"max_daily_safety_multiplier\": $max_daily_safety_multiplier }" >> preferences_from_args.json
+	echo "\"max_daily_safety_multiplier\": $max_daily_safety_multiplier,\n" >> preferences_from_args.json
     fi
     if [[ ! -z "$current_basal_safety_multiplier" ]]; then
-	echo "{ \"current_basal_safety_multiplier\": $current_basal_safety_multiplier }" >> preferences_from_args.json
+	echo "\"current_basal_safety_multiplier\": $current_basal_safety_multiplier,\n" >> preferences_from_args.json
     fi
     if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
-	echo "{ \"bolussnooze_dia_divisor\": $bolussnooze_dia_divisor }" >> preferences_from_args.json
+	echo "\"bolussnooze_dia_divisor\": $bolussnooze_dia_divisor,\n" >> preferences_from_args.json
     fi
     if [[ ! -z "$min_5m_carbimpact" ]]; then
-	echo "{ \"min_5m_carbimpact\": $min_5m_carbimpact }" >> preferences_from_args.json
+	echo "\"min_5m_carbimpact\": $min_5m_carbimpact,\n" >> preferences_from_args.json
     fi
+    echo } >> preferences_from_args.json
     oref0-get-profile --updatePreferences preferences_from_args.json > preferences.json && rm preferences_from_args.json || die "Could not run oref0-get-profile"
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -268,7 +268,9 @@ fi
 if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
     echo -n " --bolussnooze_dia_divisor=$bolussnooze_dia_divisor";
 fi
-
+if [[ ! -z "$min_5m_carbimpact" ]]; then
+    echo -n " --min_5m_carbimpact=$min_5m_carbimpact";
+fi
 if [[ ! -z "$ENABLE" ]]; then echo -n " --enable='$ENABLE'"; fi
 if [[ ! -z "$radio_locale" ]]; then echo -n " --radio_locale='$radio_locale'"; fi
 echo; echo

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -226,10 +226,10 @@ else
     echo -n TTY $ttyport
 fi
 if [[ "$max_iob" != "0" ]]; then echo -n ", max_iob $max_iob"; fi
-if [[ -z "$max_daily_safety_multiplier" ]]; then
+if [[ ! -z "$max_daily_safety_multiplier" ]]; then
     echo -n ", max_daily_safety_multiplier $max_daily_safety_multiplier";
 fi
-if [[ -z "$current_basal_safety_multiplier" ]]; then
+if [[ ! -z "$current_basal_safety_multiplier" ]]; then
     echo -n ", current_basal_safety_multiplier $current_basal_safety_multiplier";
 fi
 if [[ ! -z "$ENABLE" ]]; then echo -n ", advanced features $ENABLE"; fi
@@ -245,10 +245,10 @@ if [[ ! -z "$ttyport" ]]; then
     echo -n " --tty=$ttyport"
 fi
 if [[ "$max_iob" -ne 0 ]]; then echo -n " --max_iob=$max_iob"; fi
-if [[ "$max_daily_safety_multiplier" -ne 0 ]]; then
+if [[ ! -z "$max_daily_safety_multiplier" ]]; then
     echo -n " --max_daily_safety_multiplier=$max_daily_safety_multiplier";
 fi
-if [[ "$current_basal_safety_multiplier" -ne 0 ]]; then
+if [[ ! -z "$current_basal_safety_multiplier" ]]; then
     echo -n " --current_basal_safety_multiplier=$current_basal_safety_multiplier";
 fi
 if [[ ! -z "$ENABLE" ]]; then echo -n " --enable='$ENABLE'"; fi
@@ -305,10 +305,10 @@ else
     if [[ $max_iob -ne 0 ]]; then
 	echo "{ \"max_iob\": $max_iob }" >> preferences_from_args.json
     fi
-    if [[ $max_daily_safety_multiplier -ne 0 ]]; then
+    if [[ ! -z "$max_daily_safety_multiplier" ]]; then
 	echo "{ \"max_daily_safety_multiplier\": $max_daily_safety_multiplier }" >> preferences_from_args.json
     fi
-    if [[ $current_basal_safety_multiplier -ne 0 ]]; then
+    if [[ ! -z "$current_basal_safety_multiplier" ]]; then
 	echo "{ \"current_basal_safety_multiplier\": $current_basal_safety_multiplier }" >> preferences_from_args.json
     fi
     oref0-get-profile --updatePreferences preferences_from_args.json > preferences.json && rm preferences_from_args.json || die "Could not run oref0-get-profile"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -124,7 +124,7 @@ if ! ( git config -l | grep -q user.name ); then
     git config --global user.name $NAME
 fi
 if [[ -z "$DIR" || -z "$serial" ]]; then
-    echo "Usage: oref0-setup.sh <--dir=directory> <--serial=pump_serial_#> [--tty=/dev/ttySOMETHING] [--max_iob=0] [--max_daily_safety_multiplier=3] [--current_basal_safety_multiplier=4] [--bolussnooze_dia_divisor=2] [--min_5m_carbimpact=3] [--ns-host=https://mynightscout.azurewebsites.net] [--api-secret=myplaintextsecret] [--cgm=(G4|shareble|G5|MDT|xdrip)] [--bleserial=SM123456] [--blemac=FE:DC:BA:98:76:54] [--btmac=AB:CD:EF:01:23:45] [--enable='autosens meal dexusb'] [--radio_locale=(WW|US)]"
+    echo "Usage: oref0-setup.sh <--dir=directory> <--serial=pump_serial_#> [--tty=/dev/ttySOMETHING] [--max_iob=0] [--ns-host=https://mynightscout.azurewebsites.net] [--api-secret=myplaintextsecret] [--cgm=(G4|shareble|G5|MDT|xdrip)] [--bleserial=SM123456] [--blemac=FE:DC:BA:98:76:54] [--btmac=AB:CD:EF:01:23:45] [--enable='autosens meal dexusb'] [--radio_locale=(WW|US)]"
     read -p "Start interactive setup? [Y]/n " -r
     if [[ $REPLY =~ ^[Nn]$ ]]; then
         exit

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -226,10 +226,10 @@ else
     echo -n TTY $ttyport
 fi
 if [[ "$max_iob" != "0" ]]; then echo -n ", max_iob $max_iob"; fi
-if [[ "$max_daily_safety_multiplier" != "0" ]]; then
+if [[ -z $max_daily_safety_multiplier ]]; then
     echo -n ", max_daily_safety_multiplier $max_daily_safety_multiplier";
 fi
-if [[ "$current_basal_safety_multiplier" != "0" ]]; then
+if [[ -z $current_basal_safety_multiplier ]]; then
     echo -n ", current_basal_safety_multiplier $current_basal_safety_multiplier";
 fi
 if [[ ! -z "$ENABLE" ]]; then echo -n ", advanced features $ENABLE"; fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -323,19 +323,19 @@ if [[ "$max_iob" -eq 0 && -z "$max_daily_safety_multiplier" && -z "&current_basa
 else
     preferences_from_args=()
     if [[ $max_iob -ne 0 ]]; then
-	preferences_from_args+="\"max_iob\": $max_iob"
+	preferences_from_args+="\"max_iob\":$max_iob "
     fi
     if [[ ! -z "$max_daily_safety_multiplier" ]]; then
-        preferences_from_args+="\"max_daily_safety_multiplier\": $max_daily_safety_multiplier"
+        preferences_from_args+="\"max_daily_safety_multiplier\":$max_daily_safety_multiplier "
     fi
     if [[ ! -z "$current_basal_safety_multiplier" ]]; then
-        preferences_from_args+="\"current_basal_safety_multiplier\": $current_basal_safety_multiplier"
+        preferences_from_args+="\"current_basal_safety_multiplier\":$current_basal_safety_multiplier "
     fi
     if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
-        preferences_from_args+="\"bolussnooze_dia_divisor\": $bolussnooze_dia_divisor"
+        preferences_from_args+="\"bolussnooze_dia_divisor\":$bolussnooze_dia_divisor "
     fi
     if [[ ! -z "$min_5m_carbimpact" ]]; then
-        preferences_from_args+="\"min_5m_carbimpact\": $min_5m_carbimpact"
+        preferences_from_args+="\"min_5m_carbimpact\":$min_5m_carbimpact "
     fi
     function join_by { local IFS="$1"; shift; echo "$*"; }
     echo "{ $(join_by , ${preferences_from_args[@]}) }" > preferences_from_args.json

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -323,19 +323,19 @@ if [[ "$max_iob" -eq 0 && -z "$max_daily_safety_multiplier" && -z "&current_basa
 else
     echo "{ " > preferences_from_args.json
     if [[ $max_iob -ne 0 ]]; then
-	echo "\"max_iob\": $max_iob,\n" >> preferences_from_args.json
+	echo -e "\"max_iob\": $max_iob,\n" >> preferences_from_args.json
     fi
     if [[ ! -z "$max_daily_safety_multiplier" ]]; then
-	echo "\"max_daily_safety_multiplier\": $max_daily_safety_multiplier,\n" >> preferences_from_args.json
+	echo -e "\"max_daily_safety_multiplier\": $max_daily_safety_multiplier,\n" >> preferences_from_args.json
     fi
     if [[ ! -z "$current_basal_safety_multiplier" ]]; then
-	echo "\"current_basal_safety_multiplier\": $current_basal_safety_multiplier,\n" >> preferences_from_args.json
+	echo -e "\"current_basal_safety_multiplier\": $current_basal_safety_multiplier,\n" >> preferences_from_args.json
     fi
     if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
-	echo "\"bolussnooze_dia_divisor\": $bolussnooze_dia_divisor,\n" >> preferences_from_args.json
+	echo -e "\"bolussnooze_dia_divisor\": $bolussnooze_dia_divisor,\n" >> preferences_from_args.json
     fi
     if [[ ! -z "$min_5m_carbimpact" ]]; then
-	echo "\"min_5m_carbimpact\": $min_5m_carbimpact,\n" >> preferences_from_args.json
+	echo -e "\"min_5m_carbimpact\": $min_5m_carbimpact,\n" >> preferences_from_args.json
     fi
     echo } >> preferences_from_args.json
     oref0-get-profile --updatePreferences preferences_from_args.json > preferences.json && rm preferences_from_args.json || die "Could not run oref0-get-profile"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -14,9 +14,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Exit when variables are unset or functions fail
-set -eu
-
 die() {
   echo "$@"
   exit 1

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -226,10 +226,10 @@ else
     echo -n TTY $ttyport
 fi
 if [[ "$max_iob" != "0" ]]; then echo -n ", max_iob $max_iob"; fi
-if [[ -z $max_daily_safety_multiplier ]]; then
+if [[ -z "$max_daily_safety_multiplier" ]]; then
     echo -n ", max_daily_safety_multiplier $max_daily_safety_multiplier";
 fi
-if [[ -z $current_basal_safety_multiplier ]]; then
+if [[ -z "$current_basal_safety_multiplier" ]]; then
     echo -n ", current_basal_safety_multiplier $current_basal_safety_multiplier";
 fi
 if [[ ! -z "$ENABLE" ]]; then echo -n ", advanced features $ENABLE"; fi


### PR DESCRIPTION
In addition to max_iob, allow the following from preferences.json to be specified during setup:
- max_daily_safety_multiplier
- current_basal_safety_multiplier
- bolussnooze_dia_divisor
- min_5m_carbimpact