### PR TITLE
lowtempimpact based on 30 minutes

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -377,7 +377,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
   
     var minutes_running;
     if (typeof currenttemp.duration == 'undefined' || currenttemp.duration == 0) {
-        minutes_running = 0;
+        minutes_running = 30;
     } else if (typeof currenttemp.minutesrunning !== 'undefined'){
         // If the time the current temp is running is not defined, use default request duration of 30 minutes.
         minutes_running = currenttemp.minutesrunning;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -374,10 +374,20 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
         }
     }
+  
+    var minutes_running;
+    if (typeof currenttemp.duration == 'undefined' || currenttemp.duration == 0) {
+        minutes_running = 0;
+    } else if (typeof currenttemp.minutesrunning !== 'undefined'){
+        // If the time the current temp is running is not defined, use default request duration of 30 minutes.
+        minutes_running = currenttemp.minutesrunning;
+    } else {
+        minutes_running = 30 - currenttemp.duration;
+    }
 
     // if there is a low-temp running, and eventualBG would be below min_bg without it, let it run
     if (round_basal(currenttemp.rate, profile) < round_basal(basal, profile) ) {
-        var lowtempimpact = (currenttemp.rate - basal) * (currenttemp.duration/60) * sens;
+        var lowtempimpact = (currenttemp.rate - basal) * ((30-minutes_running)/60) * sens;
         var adjEventualBG = eventualBG + lowtempimpact;
         if ( adjEventualBG < min_bg ) {
             rT.reason += "letting low temp of " + currenttemp.rate + " run.";


### PR DESCRIPTION
@scottleibrand, @MilosKozak 

This is my proposition of how to handle running low temps. If `currenttemp.minutesrunning` is not defined (like in Oref0), it will be assumed that the overall length is 30 minutes.

This will reduce the changed calculation of `30-minutes_running` to `30-(30-currenttemp.duration)` = `currenttemp.duration` and not change anything for the default case.

In case the overall duration is longer (as in some cases in AndroidAPS), it will be calculated as if it was 30 minutes long.

If a low temp is actually running longer than 30 mintues, `adjEventualBG` will rise over `eventualBG` and the "keep it running" branch will not be entered. (As the `eventualBG < min_bg` situation is already handled above.)