### PR TITLE
Support multiple bluetooth MACs

### DIFF
--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 MAC=$1
 
-if ( ifconfig wlan0 | grep -q "inet addr" ) && ( ifconfig bnep0 | grep -q "inet addr" ); then
-   sudo bt-pan client $MAC -d
-fi
-
 if ! ( hciconfig -a | grep -q "PSCAN" ) ; then
    sudo killall bluetoothd
    sudo /usr/local/bin/bluetoothd --experimental &

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-MAC=$1
 
 if ! ( hciconfig -a | grep -q "PSCAN" ) ; then
    sudo killall bluetoothd

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -1,41 +1,58 @@
 #!/bin/bash
-MAC=$1
-MAC2=$2
+echo; echo Starting oref0-online.
 echo -n "At $(date) my local IP is: "
-ifconfig wlan0 | grep "inet " | awk '{print $2}' | awk -F : '{print $2}'
-ifconfig bnep0 | grep "inet " | awk '{print $2}' | awk -F : '{print $2}'
+ifconfig | grep -A1 wlan0 | grep "inet " | awk '{print $2}' | awk -F : '{print $2}'
+ifconfig | grep -A1 bnep0 | grep "inet " | awk '{print $2}' | awk -F : '{print $2}'
+echo
 echo -n "At $(date) my public IP is: "
-if ! curl -m 15 icanhazip.com; then
-    echo -n "Error, cycling networking "
+if curl -m 15 icanhazip.com; then
+    # if we are back on wifi (and have connectivity to icanhazip.com), shut down bluetooth
+    if ( ifconfig | grep -A1 wlan0 | grep -q "inet addr" ) && ( ifconfig | grep -A1 bnep0 | grep -q "inet addr" ); then
+        echo "Back online via wifi; disconnecting BT $MAC"
+        ifdown bnep0
+        # loop over as many MACs as are provided as arguments
+        for MAC; do
+            sudo bt-pan client $MAC -d
+        done
+        echo "and getting new wlan0 IP"
+        ps aux | grep -v grep | grep -q "dhclient wlan0" && sudo killall dhclient
+        sudo dhclient wlan0 -r
+        sudo dhclient wlan0
+    fi
+else
+    echo; echo "Error, cycling networking "
     # simply restart networking completely for stability purposes
     sudo /etc/init.d/networking stop
     sleep 5
     sudo /etc/init.d/networking start
-    echo -n "and getting new wlan0 IP"
+    echo "and getting new wlan0 IP"
     ps aux | grep -v grep | grep -q "dhclient wlan0" && sudo killall dhclient
     sudo dhclient wlan0 -r
     sudo dhclient wlan0
     echo
     echo -n "At $(date) my public IP is: "
+    # loop over as many MACs as are provided as arguments
     if ! curl -m 15 icanhazip.com; then
-        echo -n "Error, connecting BT to $MAC "
-        oref0-bluetoothup
-        sudo bt-pan client $MAC
-        echo -n "and getting bnep0 IP"
-        sudo dhclient bnep0
         echo
-        echo -n "At $(date) my public IP is: "
-        if ! curl -m 15 icanhazip.com; then
-            if [[ ! -z "${MAC2}" ]]; then
-                echo -n "Error, connecting BT to $MAC2 "
+        for MAC; do
+            echo -n "At $(date) my public IP is: "
+            if ! curl -m 15 icanhazip.com; then
+                echo; echo -n "Error, connecting BT to $MAC"
                 oref0-bluetoothup
-                sudo bt-pan client $MAC2
-                echo -n "and getting bnep0 IP"
+                sudo bt-pan client $MAC
+                echo -n ", getting bnep0 IP"
                 sudo dhclient bnep0
+                # if we couldn't reach the Internet over wifi, but we have a bnep0 IP, release the wifi IP/route
+                if ( ifconfig | grep -A1 wlan0 | grep -q "inet addr" ) && ( ifconfig | grep -A1 bnep0 | grep -q "inet addr" ); then
+                    echo -n " and releasing wifi IP"
+                    sudo dhclient wlan0 -r
+                fi
                 echo
-                echo -n "At $(date) my public IP is: "
             fi
-        fi
+        done
         echo
     fi
+    echo -n "At $(date) my public IP is: "
+    curl -m 15 icanhazip.com
 fi
+echo Finished oref0-online.

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 MAC=$1
+MAC2=$2
 echo -n "At $(date) my local IP is: "
 ifconfig wlan0 | grep "inet " | awk '{print $2}' | awk -F : '{print $2}'
 ifconfig bnep0 | grep "inet " | awk '{print $2}' | awk -F : '{print $2}'
@@ -24,7 +25,17 @@ if ! curl -m 15 icanhazip.com; then
         sudo dhclient bnep0
         echo
         echo -n "At $(date) my public IP is: "
-        curl -m 15 icanhazip.com
+        if ! curl -m 15 icanhazip.com; then
+            if [[ ! -z "${MAC2}" ]]; then
+                echo -n "Error, connecting BT to $MAC2 "
+                oref0-bluetoothup
+                sudo bt-pan client $MAC2
+                echo -n "and getting bnep0 IP"
+                sudo dhclient bnep0
+                echo
+                echo -n "At $(date) my public IP is: "
+            fi
+        fi
         echo
     fi
 fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -665,7 +665,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
        (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB && openaps urchin-loop' || peb-urchin-status $BT_PEB && openaps urchin-loop ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -
     fi
     if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
-       (crontab -l; crontab -l | grep -q "oref0-bluetoothup $BT_MAC" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup '$BT_MAC'" || oref0-bluetoothup '$BT_MAC' >> /var/log/openaps/network.log' ) | crontab -
+       (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
     fi
     crontab -l
 fi


### PR DESCRIPTION
And if wifi is not working (for example an open wifi with a captive portal) but Bluetooth is, it will disable wifi (release the wlan0 IP) until Bluetooth goes away (most likely after you get home and kill the hotspot manually).  If it doesn't have to do that, it gracefully turns off Bluetooth when it gets a working wifi IP.