### PR TITLE
Added additonal logic for HAPP Temp basals

### DIFF
--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -116,6 +116,15 @@ function calcTempTreatments (inputs) {
                 temp.date = temp.started_at.getTime();
                 temp.insulin = current.insulin;
                 tempBoluses.push(temp);
+            } else if (current.eventType == "Temp Basal" && current.enteredBy=="HAPP_App") {
+                var temp = {};
+                temp.rate = current.absolute;
+                temp.duration = current.duration;
+                temp.timestamp = current.created_at;
+                temp.started_at = new Date(tz(temp.timestamp));
+                temp.date = temp.started_at.getTime();
+                temp.duration = current.duration;
+                tempHistory.push(temp);
             } else if (current.eventType == "Temp Basal") {
                 var temp = {};
                 temp.rate = current.rate;

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -109,6 +109,15 @@ function calcTempTreatments (inputs) {
                 temp.date = temp.started_at.getTime();
                 temp.insulin = current.insulin;
                 tempBoluses.push(temp);
+            } else if (current.eventType == "Temp Basal" && current.enteredBy=="HAPP_App") {
+                var temp = {};
+                temp.rate = current.absolute;
+                temp.duration = current.duration;
+                temp.timestamp = current.created_at;
+                temp.started_at = new Date(tz(temp.timestamp));
+                temp.date = temp.started_at.getTime();
+                temp.duration = current.duration;
+                tempHistory.push(temp);
             } else if (current.eventType == "Temp Basal") {
                 var temp = {};
                 temp.rate = current.rate;

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -109,15 +109,6 @@ function calcTempTreatments (inputs) {
                 temp.date = temp.started_at.getTime();
                 temp.insulin = current.insulin;
                 tempBoluses.push(temp);
-            } else if (current.eventType == "Temp Basal" && current.enteredBy=="HAPP_App") {
-                var temp = {};
-                temp.rate = current.absolute;
-                temp.duration = current.duration;
-                temp.timestamp = current.created_at;
-                temp.started_at = new Date(tz(temp.timestamp));
-                temp.date = temp.started_at.getTime();
-                temp.duration = current.duration;
-                tempHistory.push(temp);
             } else if (current.eventType == "Temp Basal") {
                 var temp = {};
                 temp.rate = current.rate;


### PR DESCRIPTION
Needed to change the timestamp and rate to created_at and absolute respectively.