### PR TITLE
Mdt trend setup

### DIFF
--- a/bin/oref0-mdt-trend.js
+++ b/bin/oref0-mdt-trend.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-function findRecord(arr, tell) {
+function findRecord(arr, tell, date) {
 	for (var i = 0; i < arr.length; ++i)
 	{
-		if (arr[i]._tell == tell)
+		if (arr[i]._tell == tell && arr[i].date == date)
 		{
 			return i;
 		}
@@ -45,7 +45,7 @@ if (!module.parent) {
 
   for (var i = 0; i < filtered.length; ++i) {
 	var record = filtered[i];
-	var output_record = glucose_data[findRecord(glucose_data, record._tell)];
+	var output_record = glucose_data[findRecord(glucose_data, record._tell, record.date)];
 	var current_date = Date.parse(record.date);
 
 	var delta = 0; //record.sgv - last_glucose;

--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -38,14 +38,25 @@
       "input": "raw-cgm/raw-entries.json",
       "device": "glucose",
       "timezone": "",
-      "infile": "monitor/cgm-mm-glucosedirty.json"
+      "infile": "monitor/cgm-mm-glucosetrend.json"
+    }
+  },
+  {
+    "type": "report",
+    "name": "monitor/cgm-mm-glucosetrend.json",
+    "monitor/cgm-mm-glucosetrend.json": {
+      "device": "oref0",
+      "remainder": "mdt-trend monitor/cgm-mm-glucosedirty.json",
+      "use": "shell",
+      "json_default": "True",
+      "reporter": "JSON"
     }
   },
   {
     "type": "alias",
     "name": "monitor-cgm",
     "monitor-cgm": {
-      "command": "report invoke monitor/cgm-mm-glucosedirty.json cgm/cgm-glucose.json"
+      "command": "report invoke monitor/cgm-mm-glucosedirty.json monitor/cgm-mm-glucosetrend.json cgm/cgm-glucose.json"
     }
   },
     {


### PR DESCRIPTION
Add medtronic trend data to the default oref0-setup script. Takes in `monitor/cgm-mm-glucosedirty.json`, produces `monitor/cgm-mm-glucosetrend.json`. 

`cgm/cgm-glucose.json` then reads `glucosetrend.json` instead of `glucosedirty.json`.

Also fixes an issue where the _tell resets halfway through glucose data (caused by sensor restart?)