### PR TITLE
increase frequency of enlite upload to nightscout

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -657,6 +657,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
     fi
     (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
+    if [[ ${CGM,,} =~ "mdt" ]]; then
+       (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps upload-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps upload-bg' || openaps upload-bg | tee -a /var/log/openaps/upload-bg-loop.log") | crontab -
+    fi
     if [[ $ENABLE =~ autosens ]]; then
         (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens' || openaps autosens | tee -a /var/log/openaps/autosens-loop.log") | crontab -
     fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -540,11 +540,6 @@ fi
 if [[ ${CGM,,} =~ "mdt" ]]; then
     sudo pip install -U openapscontrib.glucosetools || die "Couldn't install glucosetools"
     openaps device remove cgm 2>/dev/null
-    if [[ -z "$ttyport" ]]; then
-        openaps device add cgm medtronic $serial || die "Can't add cgm"
-    else
-        openaps device add cgm mmeowlink subg_rfspy $ttyport $serial $radio_locale || die "Can't add cgm"
-    fi
     for type in mdt-cgm; do
         echo importing $type file
         cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"

--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -19,7 +19,7 @@
   {
     "monitor/cgm-mm-glucosedirty.json": {
       "hours": "24.0",
-      "device": "cgm",
+      "device": "pump",
       "use": "iter_glucose_hours",
       "reporter": "JSON"
     },
@@ -68,7 +68,7 @@
   },
   {
     "pump-loop": {
-      "command": "! bash -c \"sleep $[ ( $RANDOM / 2048 ) ]s; until(echo Starting pump-loop at $(date): && openaps wait-for-silence && openaps get-bg && openaps refresh-old-pumphistory && openaps refresh-old-pumphistory-24h && openaps refresh-old-profile && openaps refresh-temp-and-enact && openaps refresh-pumphistory-and-enact && openaps refresh-profile && openaps refresh-pumphistory-24h && echo Completed pump-loop at $(date) && echo); do echo Error, retrying && [[ $RANDOM > 25000 ]] && ( openaps wait-for-long-silence ; openaps mmtune; sleep 5 ); done\""
+      "command": "! bash -c \"sleep $[ ( $RANDOM / 2048 ) ]s; until(echo Starting pump-loop at $(date): && openaps wait-for-silence && openaps get-bg && openaps refresh-old-pumphistory && openaps refresh-old-pumphistory-24h && openaps refresh-old-profile && openaps refresh-temp-and-enact && openaps refresh-pumphistory-and-enact && openaps get-bg && openaps refresh-profile && openaps refresh-pumphistory-24h && echo Completed pump-loop at $(date) && echo); do echo Error, retrying && [[ $RANDOM > 25000 ]] && ( openaps wait-for-long-silence ; openaps mmtune; sleep 5 ); done\""
     },
     "type": "alias",
     "name": "pump-loop"

--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -68,7 +68,7 @@
   },
   {
     "pump-loop": {
-      "command": "! bash -c \"sleep $[ ( $RANDOM / 2048 ) ]s; until(echo Starting pump-loop at $(date): && openaps wait-for-silence && openaps get-bg && openaps refresh-old-pumphistory && openaps refresh-old-pumphistory-24h && openaps refresh-old-profile && openaps refresh-temp-and-enact && openaps refresh-pumphistory-and-enact && openaps get-bg && openaps refresh-profile && openaps refresh-pumphistory-24h && echo Completed pump-loop at $(date) && echo); do echo Error, retrying && [[ $RANDOM > 25000 ]] && ( openaps wait-for-long-silence ; openaps mmtune; sleep 5 ); done\""
+      "command": "! bash -c \"sleep $[ ( $RANDOM / 2048 ) ]s; until(echo Starting pump-loop at $(date): && openaps wait-for-silence && openaps get-bg && openaps refresh-old-pumphistory && openaps refresh-old-pumphistory-24h && openaps refresh-old-profile && openaps refresh-temp-and-enact && openaps refresh-pumphistory-and-enact && openaps refresh-profile && openaps refresh-pumphistory-24h && echo Completed pump-loop at $(date) && echo); do echo Error, retrying && [[ $RANDOM > 25000 ]] && ( openaps wait-for-long-silence ; openaps mmtune; sleep 5 ); done\""
     },
     "type": "alias",
     "name": "pump-loop"

--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -125,7 +125,7 @@
   },
   {
      "get-bg": {
-      "command": "! bash -c \" (echo -n MDT cgm data retrieve && openaps monitor-cgm 2>/dev/null >/dev/null && grep -q glucose cgm/cgm-glucose.json && echo d) && cp -pu cgm/cgm-glucose.json cgm/glucose.json && cp -pu cgm/glucose.json monitor/glucose-unzoned.json && (echo -n MDT cgm data reformat && openaps report invoke monitor/glucose.json 2>/dev/null >/dev/null && echo ted)\""
+      "command": "! bash -c \" (echo -n MDT cgm data retrieve && openaps monitor-cgm 2>/dev/null >/dev/null && grep -q glucose cgm/cgm-glucose.json && echo d) && cp -pu cgm/cgm-glucose.json cgm/glucose.json && cp -pu cgm/glucose.json monitor/glucose-unzoned.json && (echo -n MDT cgm data reformat && openaps report invoke monitor/glucose.json 2>/dev/null >/dev/null && openaps report invoke nightscout/glucose.json 2>/dev/null >/dev/null && echo ted)\""
      },
     "type": "alias",
     "name": "get-bg"
@@ -133,7 +133,7 @@
   {
     "type": "alias",
     "upload-bg": {
-      "command": "report invoke nightscout/glucose.json nightscout/recent-missing-entries.json nightscout/uploaded-entries.json"
+      "command": "! bash -c \"echo Checking nightscout cgm data at $(date): && (cat nightscout/uploaded-entries.json | grep `jq .[0].dateString nightscout/glucose.json`) && echo Nightscout up to date || (echo -n Uploading nightscout cgm data && echo -n && openaps report invoke nightscout/recent-missing-entries.json nightscout/uploaded-entries.json)\""
     },
     "name": "upload-bg"
   },
@@ -141,7 +141,7 @@
     "type": "alias",
     "name": "upload",
     "upload": {
-      "command": "! bash -c \"echo -n Upload && ( openaps upload-bg; openaps upload-ns-status; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed\""
+      "command": "! bash -c \"echo -n Upload && ( openaps upload-ns-status; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed\""
     }
   },
   {"type": "alias", "first-upload": {"command": "! bash -c \"cat nightscout/glucose.json | json 1 > nightscout/recent-missing-entries.json && openaps report invoke nightscout/uploaded-entries.json\""}, "name": "first-upload"}


### PR DESCRIPTION
This increases the frequency of enlite bg uploads to nightscout.
by removing the upload-bg from the uploads alias
having the nightscout/glucose.json report called by the get-bg
having get-bg called from muliple points in the pump-loop
putting the upload-bg in the cron

also getting rid of the cgm device since everything is on the pump