### PR TITLE
oref0-setup.sh new cron line for proper shutdown

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -694,6 +694,12 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
        (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
     fi
+
+    # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
+    if egrep -i "edison" /etc/passwd 2>/dev/null; then
+     (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; awk '/batteryVoltage/ {if (\$2<=3050)system(\"sudo shutdown -h now\")}' $directory/monitor/edison-battery.json") | crontab -
+    fi
+    
     crontab -l | tee $HOME/crontab.txt
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -697,7 +697,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 
     # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
     if egrep -i "edison" /etc/passwd 2>/dev/null; then
-     (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; awk '/batteryVoltage/ {if (\$2<=3050)system(\"sudo shutdown -h now\")}' $directory/monitor/edison-battery.json") | crontab -
+     (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; cat $directory/monitor/edison-battery.json | json batteryVoltage | awk '{if (\$1<=3050)system(\"sudo shutdown -h now\")}'") | crontab -
     fi
     
     crontab -l | tee $HOME/crontab.txt


### PR DESCRIPTION
Adding a new cronline for proper shutdown in case the edison battery is empty (< 3050mV; 2950mV is dead)

* running each 15 min (in case of failure one is able to power on and perform `crontab -r`
* using `openaps battery-status`
* parsing monitor/edison-battery.json using `awk` searching for the 2nd column `$2` for the voltage value
* e.g. content of monitor/edison-battery.json `{"batteryVoltage":4057, "battery":88}`
* in case the voltage is < 3050mV `sudo shutdown -h now` will be performed
* when monitor/edison-battery.json is empty or does not exist, nothing is done