### PR TITLE
fix ns-temptargets

### DIFF
--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -51,7 +51,7 @@
   {
     "type": "alias",
     "ns-temptargets": {
-      "command": "! bash -c \"curl -m 30 -s \\\"$NIGHTSCOUT_HOST/api/v1/treatments.json?find\\[created_at\\]\\[\\$gte\\]=$(date -d \\\"6 hours ago\\\" -Iminutes)&find\\[eventType\\]\\[\\$regex\\]=Target\\\" > settings/temptargets.json; openaps report invoke settings/profile.json 2>/dev/null >/dev/null; exit 0 \""
+      "command": "! bash -c \"curl -m 30 -s \\\"$NIGHTSCOUT_HOST/api/v1/treatments.json?find\\[created_at\\]\\[\\$gte\\]=$(date -d \\\"6 hours ago\\\" -Iminutes -u)&find\\[eventType\\]\\[\\$regex\\]=Target\\\" > settings/temptargets.json; openaps report invoke settings/profile.json 2>/dev/null >/dev/null; exit 0 \""
     },
     "name": "ns-temptargets"
   },


### PR DESCRIPTION
Setting temporary targets from Nightscout doesn't work for anyone in timezones +0600 or greater and is probably patchy for anyone in +0100 to +0500. The alias `ns-temptargets` filters `treatments.json` by date string to keep only those in a 6 hour lookback (it also looks for the word "Targets" in the `eventType`.

However, the date used for comparison is in the user's timezone, and NS dates are UTC. This PR adds the flag `-u` to the unix `date` command to use UTC instead.

Should also be noted somewhere that any temporary targets greater than 6 hours in duration will be terminated at the 6 hour mark.