### PR TITLE
Autotune: Porting to Python - oref0-autotune.py

### DIFF
--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -158,7 +158,7 @@ def get_nightscout_bg_entries(nightscout_host, start_date, end_date, directory):
         url = url.format(nightscout_host, date)
         #TODO: Add ability to use API secret for Nightscout.
         res = requests.get(url)
-        with open(os.path.join(directory, 'autotune', 'ns-entries.{date}.json'.format(date=date.strftime("%Y-%m-%d")), 'w') as f:
+        with open(os.path.join(directory, 'autotune', 'ns-entries.{date}.json'.format(date=date.strftime("%Y-%m-%d")), 'w')) as f:
             f.write(res.text.encode('utf-8'))
 
 def run_autotune(start_date, end_date, number_of_runs, directory):

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -88,7 +88,7 @@ def assign_args_to_variables(args):
            EXPORT_EXCEL, TERMINAL_LOGGING, RECOMMENDS_REPORT
     
     # On Unix and Windows, return the argument with an initial component of
-    # ~ or ~user replaced by that user‘s home directory.
+    # ~ or ~user replaced by that user's home directory.
     DIR = os.path.expanduser(args.dir)
     
     NIGHTSCOUT_HOST = args.ns_host

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -90,13 +90,8 @@ def assign_args_to_variables(args):
     # TODO: Check if directory is a symlink, get actual path.  
     DIR = args.dir
     
-    try:
-        requests.get(args.ns_host)
-        NIGHTSCOUT_HOST = args.ns_host
-    except:
-        #TODO: Use a real error.
-        print "Something's wrong"
-    
+    NIGHTSCOUT_HOST = args.ns_host
+
     START_DATE = args.start_date
     
     if args.end_date is not None:

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -143,6 +143,7 @@ def get_openaps_profile(directory):
     # cat autotune/profile.json | json | grep -q start || cp autotune/profile.pump.json autotune/profile.json'])
 
 def get_nightscout_carb_and_insulin_treatments(nightscout_host, start_date, end_date, directory):
+    logging.info('Grabbing NIGHTSCOUT treatments.json for date range: {0} to {1}'.format(start_date, end_date))
     # TODO: What does 'T20:00-05:00' mean?
     output_file_name = os.path.join(directory, 'autotune', 'ns-treatments.json')
     start_date = start_date.strftime("%Y-%m-%d") + 'T20:00-05:00'
@@ -154,7 +155,7 @@ def get_nightscout_carb_and_insulin_treatments(nightscout_host, start_date, end_
         f.write(res.text.encode('utf-8'))
 
 def get_nightscout_bg_entries(nightscout_host, start_date, end_date, directory):
-    logging.info('Gathering bg entries from {0} to {1}'.format(start_date, end_date))
+    logging.info('Grabbing NIGHTSCOUT enries/sgv.json for date range: {0} to {1}'.format(start_date, end_date))
     date_list = [start_date + datetime.timedelta(days=x) for x in range(0, (end_date - start_date).days)]
 
     for date in date_list:

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -87,8 +87,9 @@ def assign_args_to_variables(args):
     global DIR, NIGHTSCOUT_HOST, START_DATE, END_DATE, NUMBER_OF_RUNS, \
            EXPORT_EXCEL, TERMINAL_LOGGING, RECOMMENDS_REPORT
     
-    # TODO: Check if directory is a symlink, get actual path.  
-    DIR = args.dir
+    # On Unix and Windows, return the argument with an initial component of
+    # ~ or ~user replaced by that user‘s home directory.
+    DIR = os.path.expanduser(args.dir)
     
     NIGHTSCOUT_HOST = args.ns_host
 

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -150,7 +150,7 @@ def get_nightscout_carb_and_insulin_treatments(nightscout_host, start_date, end_
         f.write(res.text.encode('utf-8'))
 
 def get_nightscout_bg_entries(nightscout_host, start_date, end_date, directory):
-    logging.info('Grabbing NIGHTSCOUT enries/sgv.json for date range: {0} to {1}'.format(start_date, end_date))
+    logging.info('Grabbing NIGHTSCOUT enries/sgv.json for date range: {0} to {1}'.format(start_date.strftime("%Y-%m-%d"), end_date.strftime("%Y-%m-%d")))
     date_list = [start_date + datetime.timedelta(days=x) for x in range(0, (end_date - start_date).days)]
 
     for date in date_list:
@@ -205,7 +205,7 @@ def run_autotune(start_date, end_date, number_of_runs, directory):
         
             # Copy tuned profile produced by autotune to profile.json for use with next day of data
             # cp newprofile.$RUN_NUMBER.$DATE.json profile.json
-            shutil.copy(os.path.join(autotune_directory, 'newprofile.{0}.{1}.json'.format(run_number, date)),
+            shutil.copy(os.path.join(autotune_directory, 'newprofile.{run_number}.{date}.json'.format(run_number=run_number, date=date.strftime("%Y-%m-%d"))),
                         os.path.join(autotune_directory, 'profile.json'))
 
 def export_to_excel(output_directory, output_excel_filename):

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -158,7 +158,7 @@ def get_nightscout_bg_entries(nightscout_host, start_date, end_date, directory):
         url = url.format(nightscout_host, date)
         #TODO: Add ability to use API secret for Nightscout.
         res = requests.get(url)
-        with open(os.path.join(directory, 'autotune', 'ns-entries.{date}.json'.format(date=date.strftime("%Y-%m-%d")), 'w')) as f:
+        with open(os.path.join(directory, 'autotune', 'ns-entries.{date}.json'.format(date=date.strftime("%Y-%m-%d"))), 'w') as f:
             f.write(res.text.encode('utf-8'))
 
 def run_autotune(start_date, end_date, number_of_runs, directory):
@@ -169,7 +169,7 @@ def run_autotune(start_date, end_date, number_of_runs, directory):
             # cp profile.json profile.$run_number.$i.json
             shutil.copy(os.path.join(autotune_directory, 'profile.json'),
                         os.path.join(autotune_directory, 'profile.{run_number}.{date}.json'
-                        .format(run_number=run_number, date=date.strftime("%Y-%m-%d")))
+                        .format(run_number=run_number, date=date.strftime("%Y-%m-%d"))))
         
             # Autotune Prep (required args, <pumphistory.json> <profile.json> <glucose.json>), output prepped glucose 
             # data or <autotune/glucose.json> below
@@ -197,7 +197,7 @@ def run_autotune(start_date, end_date, number_of_runs, directory):
             
             # newprofile.$RUN_NUMBER.$DATE.json
             newprofile_run_filename = os.path.join(autotune_directory, 'newprofile.{run_number}.{date}.json'
-                                                   .format(run_number=run_number, date=date.strftime("%Y-%m-%d"))
+                                                   .format(run_number=run_number, date=date.strftime("%Y-%m-%d")))
             with open(newprofile_run_filename, "w+") as output:
                 logging.info('Running {script}'.format(script=autotune_core))
                 call(autotune_core, stdout=output, shell=True)

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -1,0 +1,252 @@
+# Python version of oref0-autotune.sh
+# Original bash code: scottleibrand, pietergit, beached, danamlewis
+
+# This script sets up an easy test environment for autotune, allowing the user to vary parameters 
+# like start/end date and number of runs.
+#
+# Required Inputs: 
+#   DIR, (--dir=<OpenAPS Directory>)
+#   NIGHTSCOUT_HOST, (--ns-host=<NIGHTSCOUT SITE URL)
+#   START_DATE, (--start-date=<YYYY-MM-DD>)
+# Optional Inputs:
+#   END_DATE, (--end-date=<YYYY-MM-DD>) 
+#     if no end date supplied, assume we want a months worth or until day before current day
+#   NUMBER_OF_RUNS (--runs=<integer, number of runs desired>)
+#     if no number of runs designated, then default to 5
+#   EXPORT_EXCEL (--xlsx=<filenameofexcel>)
+#     export to excel. Disabled by default
+#   TERMINAL_LOGGING (--log <true/false(true)>
+#     logs terminal output to autotune.<date stamp>.log in the autotune directory, default to true
+
+
+import argparse
+import requests
+import datetime
+import os, errno
+import logging
+from subprocess import call
+import shutil
+
+
+DIR = ''
+NIGHTSCOUT_HOST = ''
+START_DATE = datetime.datetime.today() - datetime.timedelta(days=1)
+END_DATE = datetime.datetime.today()
+NUMBER_OF_RUNS = 1
+EXPORT_EXCEL = None
+TERMINAL_LOGGING = True
+RECOMMENDS_REPORT = True
+
+def get_input_arguments():
+    parser = argparse.ArgumentParser(description='Autotune')
+    
+    # Required
+    # NOTE: As the code runs right now, this directory needs to exist and as well as the subfolders: autotune, settings
+    parser.add_argument('--dir',
+                        '-d',
+                        type=str,
+                        required=True,
+                        help='(--dir=<OpenAPS Directory>)')        
+    parser.add_argument('--ns-host',
+                        '-n',
+                        type=str,
+                        required=True,
+                        metavar='NIGHTSCOUT_HOST',
+                        help='(--ns-host=<NIGHTSCOUT SITE URL)')
+    parser.add_argument('--start-date',
+                        '-s',
+                        type=lambda d: datetime.datetime.strptime(d, '%Y-%m-%d'),
+                        required=True,
+                        help='(--start-date=<YYYY-MM-DD>)')
+    # Optional
+    parser.add_argument('--end-date',
+                        '-e',
+                        type=lambda d: datetime.datetime.strptime(d, '%Y-%m-%d'),
+                        help='(--end-date=<YYYY-MM-DD>) ')
+    parser.add_argument('--runs',
+                        '-r',
+                        type=int,
+                        metavar='NUMBER_OF_RUNS',
+                        help='(--runs=<integer, number of runs desired>)')
+    parser.add_argument('--xlsx',
+                        '-x',
+                        type=str,
+                        metavar='EXPORT_EXCEL',
+                        help='(--xlsx=<filenameofexcel>)')                
+    parser.add_argument('--log',
+                        '-l',
+                        type=str,
+                        metavar='TERMINAL_LOGGING',
+                        help='(--log <true/false(true)>)')
+    
+    return parser.parse_args()
+
+def assign_args_to_variables(args):
+    # TODO: Input checking.
+    
+    # TODO: Check if directory is a symlink, get actual path.
+    global DIR, NIGHTSCOUT_HOST, START_DATE, END_DATE, NUMBER_OF_RUNS, \
+           EXPORT_EXCEL, TERMINAL_LOGGING, RECOMMENDS_REPORT
+           
+    DIR = args.dir
+    
+    try:
+        requests.get(args.ns_host)
+        NIGHTSCOUT_HOST = args.ns_host
+    except:
+        #TODO: Use a real error.
+        print "Something's wrong"
+    
+    START_DATE = args.start_date
+    
+    if args.end_date is not None:
+        END_DATE = args.end_date
+        
+    if args.runs is not None:
+        NUMBER_OF_RUNS = args.runs
+        
+    if args.xlsx is not None:
+        EXPORT_EXCEL = args.xlsx
+    
+    if args.log is not None:
+        RECOMMENDS_REPORT = args.logs
+
+def get_nightscout_profile(nightscout_host):
+    #TODO: Add ability to use API secret.
+    res = requests.get(nightscout_host + '/api/v1/profile.json')
+    with open(os.path.join(autotune_directory, 'nightscout.profile.json'), 'w') as f:
+        f.write(res.text)
+
+def get_openaps_profile(directory):
+    shutil.copy(os.path.join(directory, 'settings', 'pumpprofile.json'), os.path.join(directory, 'autotune', 'profile.pump.json'))
+    
+    # If a previous valid settings/autotune.json exists, use that; otherwise start from settings/profile.json
+    
+    # This allows manual users to be able to run autotune by simply creating a settings/pumpprofile.json file.
+    # cp -up settings/pumpprofile.json settings/profile.json
+    shutil.copy(os.path.join(directory, 'settings', 'pumpprofile.json'), os.path.join(directory, 'settings', 'profile.json'))
+    
+    # TODO: Get this to work. For now, just copy from settings/profile.json each time.
+    # If a previous valid settings/autotune.json exists, use that; otherwise start from settings/profile.json
+    # cp settings/autotune.json autotune/profile.json && cat autotune/profile.json | json | grep -q start || cp autotune/profile.pump.json autotune/profile.json
+    # create_autotune_json = "cp {0}settings/autotune.json {0}autotune/profile.json && cat {0}autotune/profile.json | json | grep -q start || cp {0}autotune/profile.pump.json {0}autotune/profile.json".format(directory)
+    # print create_autotune_json
+    # call(create_autotune_json, shell=True)
+
+    # cp settings/autotune.json autotune/profile.json
+    shutil.copy(os.path.join(directory, 'settings', 'profile.json'), os.path.join(directory, 'settings', 'autotune.json'))
+    
+    # cp settings/autotune.json autotune/profile.json
+    shutil.copy(os.path.join(directory, 'settings', 'autotune.json'), os.path.join(directory, 'autotune', 'profile.json'))
+    
+    #TODO: Do the correct copying here.
+    # cat autotune/profile.json | json | grep -q start || cp autotune/profile.pump.json autotune/profile.json'])
+
+def get_nightscout_carb_and_insulin_treatments(nightscout_host, start_date, end_date, directory):
+    # TODO: What does 'T20:00-05:00' mean?
+    output_file_name = os.path.join(directory, 'autotune', 'ns-treatments.json')
+    start_date = start_date.strftime("%Y-%m-%d") + 'T20:00-05:00'
+    end_date = end_date.strftime("%Y-%m-%d") + 'T20:00-05:00'
+    url='{0}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=`date --date="{1} -4 hours" -Iminutes`&find\[created_at\]\[\$lte\]=`date --date="{2} +1 days" -Iminutes`'.format(nightscout_host, start_date, end_date)
+    res = requests.get(url)
+    with open(output_file_name, 'w') as f:
+        f.write(res.text.encode('utf-8'))
+
+def get_nightscout_bg_entries(nightscout_host, start_date, end_date, directory):
+    logging.info('Gathering bg entries from {0} to {1}'.format(start_date, end_date))
+    date_list = [start_date + datetime.timedelta(days=x) for x in range(0, (end_date - start_date).days)]
+
+    for date in date_list:
+        url="{0}/api/v1/entries/sgv.json?find\[date\]\[\$gte\]={1}&find\[date\]\[\$lte\]={1}`&count=1000"
+        url = url.format(nightscout_host, date)
+        res = requests.get(url)
+        with open(os.path.join(directory, 'autotune', 'ns-entries.{date}.json'.format(date=date)), 'w') as f:
+            f.write(res.text.encode('utf-8'))
+
+def run_autotune(start_date, end_date, number_of_runs, directory):
+    date_list = [start_date + datetime.timedelta(days=x) for x in range(0, (end_date - start_date).days)]
+    autotune_directory = os.path.join(directory, 'autotune')
+    for run_number in range(1, number_of_runs + 1):
+        for date in date_list:
+            # cp profile.json profile.$run_number.$i.json
+            shutil.copy(os.path.join(autotune_directory, 'profile.json'),
+                        os.path.join(autotune_directory, 'profile.{run_number}.{date}.json'
+                        .format(run_number=run_number, date=date)))
+        
+            # Autotune Prep (required args, <pumphistory.json> <profile.json> <glucose.json>), output prepped glucose 
+            # data or <autotune/glucose.json> below
+            # oref0-autotune-prep ns-treatments.json profile.json ns-entries.$DATE.json > autotune.$RUN_NUMBER.$DATE.json
+            ns_treatments = os.path.join(autotune_directory, 'ns-treatments.json')
+            profile = os.path.join(autotune_directory, 'profile.json')
+            ns_entries = os.path.join(autotune_directory, 'ns-entries.{date}.json'.format(date=date.strftime("%Y-%m-%d")))
+            autotune_prep = 'oref0-autotune-prep {ns_treatments} {profile} {ns_entries}'.format(ns_treatments=ns_treatments, profile=profile, ns_entries=ns_entries)
+            
+            # autotune.$RUN_NUMBER.$DATE.json  
+            autotune_run_filename = os.path.join(autotune_directory, 'autotune.{run_number}.{date}.json'
+                                                 .format(run_number=run_number, date=date.strftime("%Y-%m-%d")))
+            with open(autotune_run_filename, "w+") as output:
+                logging.info('Running {script}'.format(script=autotune_prep))
+                call(autotune_prep, stdout=output, shell=True)
+                logging.info('Writing output to {filename}'.format(filename=autotune_run_filename))
+        
+            # Autotune  (required args, <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>), 
+            # output autotuned profile or what will be used as <autotune/autotune.json> in the next iteration
+            # oref0-autotune-core autotune.$RUN_NUMBER.$DATE.json profile.json profile.pump.json > newprofile.$RUN_NUMBER.$DATE.json
+        
+            # oref0-autotune-core autotune.$run_number.$i.json profile.json profile.pump.json > newprofile.$RUN_NUMBER.$DATE.json
+            autotune_core = 'oref0-autotune-core {0}autotune.{1}.{2}.json {0}profile.json {0}profile.pump.json'.format(autotune_directory, run_number, date)
+            
+            # newprofile.$RUN_NUMBER.$DATE.json
+            newprofile_run_filename = os.path.join(autotune_directory, 'newprofile.{run_number}.{date}.json'
+                                                   .format(run_number=run_number, date=date))
+            with open(autotune_run_filename, "w+") as output:
+                call(autotune_core, stdout=output, shell=True)
+        
+            # Copy tuned profile produced by autotune to profile.json for use with next day of data
+            # cp newprofile.$RUN_NUMBER.$DATE.json profile.json
+            shutil.copy(os.path.join(autotune_directory, 'newprofile.{0}.{1}.json'.format(run_number, date)),
+                        os.path.join(autotune_directory, 'profile.json'))
+
+def export_to_excel(output_directory, output_excel_filename):
+    autotune_export_to_xlsx = 'oref0-autotune-export-to-xlsx --dir {0} --output {1}'.format(output_directory, output_excel_filename)
+    call(autotune_export_to_xlsx, shell=True)
+
+def create_summary_report_and_display_results(output_directory):
+    print 
+    print "Autotune pump profile recommendations:"
+    print "---------------------------------------------------------"
+    
+    report_file = os.path.join(output_directory, 'autotune', 'autotune_recommendations.log')
+    autotune_recommends_report = 'oref0-autotune-recommends-report {0}'.format(output_directory)
+    
+    call(autotune_recommends_report, shell=True)
+    print "Recommendations Log File: {0}".format(report_file)
+    
+    # Go ahead and echo autotune_recommendations.log to the terminal, minus blank lines
+    # cat $report_file | egrep -v "\| *\| *$"
+    call(['cat {0} | egrep -v "\| *\| *$"'.format(report_file)], shell=True)
+
+if __name__ == "__main__":
+    # Set log level for this app to DEBUG.
+    logging.basicConfig(level=logging.DEBUG)
+    # Supress non-essential logs (below WARNING) from requests module.
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    
+    args = get_input_arguments()
+    assign_args_to_variables(args)
+    
+    print DIR, NIGHTSCOUT_HOST, START_DATE, END_DATE, NUMBER_OF_RUNS, EXPORT_EXCEL, TERMINAL_LOGGING, RECOMMENDS_REPORT
+    
+    # TODO: Convert Nightscout profile to OpenAPS profile format.
+    #get_nightscout_profile(NIGHTSCOUT_HOST)
+    
+    get_openaps_profile(DIR)
+    get_nightscout_carb_and_insulin_treatments(NIGHTSCOUT_HOST, START_DATE, END_DATE, DIR)
+    get_nightscout_bg_entries(NIGHTSCOUT_HOST, START_DATE, END_DATE, DIR)
+    run_autotune(START_DATE, END_DATE, NUMBER_OF_RUNS, DIR)
+    
+    if EXPORT_EXCEL:
+        export_to_excel(DIR, EXPORT_EXCEL)
+    
+    if RECOMMENDS_REPORT:
+        create_summary_report_and_display_results(DIR)

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -158,7 +158,7 @@ def get_nightscout_bg_entries(nightscout_host, start_date, end_date, directory):
         url = url.format(nightscout_host, date)
         #TODO: Add ability to use API secret for Nightscout.
         res = requests.get(url)
-        with open(os.path.join(directory, 'autotune', 'ns-entries.{date}.json'.format(date=date)), 'w') as f:
+        with open(os.path.join(directory, 'autotune', 'ns-entries.{date}.json'.format(date=date.strftime("%Y-%m-%d")), 'w') as f:
             f.write(res.text.encode('utf-8'))
 
 def run_autotune(start_date, end_date, number_of_runs, directory):
@@ -169,7 +169,7 @@ def run_autotune(start_date, end_date, number_of_runs, directory):
             # cp profile.json profile.$run_number.$i.json
             shutil.copy(os.path.join(autotune_directory, 'profile.json'),
                         os.path.join(autotune_directory, 'profile.{run_number}.{date}.json'
-                        .format(run_number=run_number, date=date)))
+                        .format(run_number=run_number, date=date.strftime("%Y-%m-%d")))
         
             # Autotune Prep (required args, <pumphistory.json> <profile.json> <glucose.json>), output prepped glucose 
             # data or <autotune/glucose.json> below
@@ -197,7 +197,7 @@ def run_autotune(start_date, end_date, number_of_runs, directory):
             
             # newprofile.$RUN_NUMBER.$DATE.json
             newprofile_run_filename = os.path.join(autotune_directory, 'newprofile.{run_number}.{date}.json'
-                                                   .format(run_number=run_number, date=date))
+                                                   .format(run_number=run_number, date=date.strftime("%Y-%m-%d"))
             with open(newprofile_run_filename, "w+") as output:
                 logging.info('Running {script}'.format(script=autotune_core))
                 call(autotune_core, stdout=output, shell=True)


### PR DESCRIPTION
# Summary
I decided to tackle the Python version of Autotune. This is a work-in-progress.

### Going Forward:
-  **Add ability to use API secret for Nightscout**. #397
There are three separate places in the code that make a call to the Nightscout server. Using Python's request module, this would fairly straightforward to implement the API secret during these calls.

- **Convert Nightscout profile to OpenAPS profile format.** #300
If a Nightscout profile to OpenAPS profile converter is created, it would be fairly simple to add that as an argument `--use-nightscout-profile` and *get_nightscout_profile()* could be called instead of *get_openaps_profile()*.

- **Support running on all platforms.** 
Using Python is a step closer to manual mode being run on all platforms without a VM.

- **Better input checking, self-explanatory error messages, and bailing if missing input** #349

  - 1. *Input checking*
Input checking is handled to a degree better. The ArgumentParser checks to make sure the correct types are being given. (ex. Input dates must be in date format to be accepted). There's a function assign_args_to_variables(args) that would be a good place to add more checks in the future.
  - 2. *Self-explanatory error messages*
Appropriate error messages can be displayed using error logging and be returned right when the failure happens instead of at the end. Plus different levels of logging (debug/warning/info/error) can be used depending on the situation.
  - 3. *Bailing if missing input*
With this modular layout, checks can be made before moving on to the next step/calling the next function. Also it might be worthwhile to support skipping steps if needed. (ex. If that part of the process has been run before)

### Notes:

- The way the code is written, it requires whatever directory you plan on using (I've been using `myopenaps-python`) to already exist as well as the `myopenaps-python/settings` and `myopenaps-python/autotune` subdirectories.

- This code incorporates the #392 PR which has the user initially provide `settings/pumpprofile.json` instead of `settings/profile.json`.

- This code uses a Python's request module and needs to be added as a dependency in order to run.

### Questions:

- I tried to emulate the algorithm of the bash script as best as possible and there were a few places that I need further clarification for.

  - 1. In the get_openaps_profile(directory), I wanted to make sure all the write copying was done. In fact, a general run-through would to make sure all the functionality is exactly as intended would be informative.
  - 2. When retrieving the Nightscout insulin and carb treatments, the calls appear to have 'T20:00-05:00' appended to them. What does this mean? Is this a reference to a time stamp/time range?

### Review/Feedback:

- The goal was to make the code as readable as possible so let me know if there are places where it is unclear so I can make them clear!
- The output I get from this is slightly different from the output from running the master version of autotune. This probably has something to do with the times not being set the same way or the algorithm not perfectly matching the bash script. The discrepancy could probably discovered through code review and/or a general run-through to make sure the intentions of the bash script are the same as the algorithm here.
- It would be great to have someone read through this and give some code review. I look forward to the feedback!

### Testing and Docs:

- The rest of this is notes on how I've been testing it on a Mac and a Linux VM and an approximation of how the documentation would look.

# Testing

## Testing on a Mac

- Install dependencies.
```bash
cd ~
brew install coreutils
brew install jq
curl -s https://raw.githubusercontent.com/openaps/docs/master/scripts/quick-packages.sh | bash -
npm run global-install
```

-  Clone my fork and switch to my branch, install the dev branch.
```bash
git clone git://github.com/jessiepusateri/oref0.git oref0-dev
cd oref0-dev
git checkout wip/python-autotune
```

- Create the necessary /myopenaps-python/settings and /myopenaps-python/autotune directories and pumprofile.json file.
```bash
mkdir -p ~/myopenaps-python/settings && mkdir -p ~/myopenaps-python/autotune
cd ~/myopenaps-python/settings
--- Create the pumpprofile.json file. ---
```

- Install new dependency and run the python version of autotune.
```bash
pip install requests
python  ~/oref-dev/bin/oref0-autotune.py --dir=~/myopenaps-python --ns-host=https://mynightscout.azurewebsites.net --start-date=YYYY-MM-DD
```


## Testing on a Linux VM

* A. Create a Linux VM: Ubuntu 16.04.1 x64 VM.

* B. Log in to the VM, create a new user, switch to that user. 
```bash
ssh root@provided-ip-address
adduser demo
gpasswd -a demo sudo
su - demo
```

* C. Get lastest version of of oref0 and jq.
```bash
curl -s https://raw.githubusercontent.com/openaps/docs/master/scripts/quick-packages.sh | bash -
sudo apt-get install jq
```

* D. Clone my fork and switch to my branch, install the dev branch.
```bash
git clone git://github.com/jessiepusateri/oref0.git oref0-dev
cd oref0-dev/
git checkout wip/python-autotune
npm run global-install
```

* E. Create the necessary /myopenaps-python/settings and /myopenaps-python/autotune directories and pumprofile.json file.
```bash
mkdir -p ~/myopenaps-python/settings && mkdir -p ~/myopenaps-python/autotune
cd ~/myopenaps-python/settings
--- Create the pumpprofile.json file inside this directory. ---
```

* F. Install new dependency and run the python version of autotune.

```bash
pip install requests
python ~/oref0-dev/bin/oref0-autotune.py  --dir=~/myopenaps-python --ns-host=https://mynightscout.azurewebsites.net --start-date=YYYY-MM-DD
```


# Documentation 

This is rough mock-up of how this would be added to the docs for Mac/Linux.
### Step 1: Install oref0 onto machine.
```
npm list -g oref0 | egrep oref0@0.4.[0-9] || (echo Installing latest oref0 package && sudo npm install -g oref0)
```

### Step 2: Create a profile.json with your settings
* A. Create a myopenaps-python and settings directory.
```bash
mkdir -p ~/myopenaps-python/settings && mkdir -p ~/myopenaps-python/autotune
```
* B. Change into that directory
```bash
cd ~/myopenaps-python/settings
```
* C. Create a pumpprofile.json file.

* D. Verify your pumpprofile.json is valid json by running the following. If it prints a colorful version of your pumpprofile.json, you’re good to proceed. If not, go back and edit your profile.json to fix the error.
```bash
 jq . pumpprofile.json 
```


### Step 3: Run autotune on retrospective data from Nightscout
* E. Run autotune. *
```bash
oref0-autotune --dir=~/myopenaps-python --ns-host=https://mynightscout.azurewebsites.net --start-date=YYYY-MM-DD
```

\* - this is probably different, I'm not sure how this will be run in the package.
