### PR TITLE
Sort treatments before calculating COB

### DIFF
--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -1,5 +1,4 @@
 var tz = require('moment-timezone');
-var _ = require('lodash');
 var calcMealCOB = require('oref0/lib/determine-basal/cob-autosens');
 
 function diaCarbs(opts, time) {
@@ -28,7 +27,13 @@ function diaCarbs(opts, time) {
     };
     var mealCOB = 0;
 
-    treatments = _.sortBy(treatments, 'timestamp');
+    // this sorts the treatments collection in order.
+    treatments.sort(function (a, b) {
+        var aDate = new Date(tz(a.timestamp));
+        var bDate = new Date(tz(b.timestamp));
+        //console.error(aDate);
+        return bDate.getTime() - aDate.getTime();
+    });
 
     treatments.forEach(function(treatment) {
         var now = time.getTime();

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -1,4 +1,5 @@
 var tz = require('moment-timezone');
+var _ = require('lodash');
 var calcMealCOB = require('oref0/lib/determine-basal/cob-autosens');
 
 function diaCarbs(opts, time) {
@@ -26,6 +27,8 @@ function diaCarbs(opts, time) {
     ,   mealTime: mealCarbTime
     };
     var mealCOB = 0;
+
+    treatments = _.sortBy(treatments, 'timestamp');
 
     treatments.forEach(function(treatment) {
         var now = time.getTime();


### PR DESCRIPTION
Improperly sorted treatments appear to be causing, or at least contributing to, https://github.com/openaps/oref0/issues/390, in cases where carbs come from multiple sources (in the Crawford's case, both pump and NS).  This PR makes sure they're sorted properly before calculating COB.