### PR TITLE
Updated to use API_SECRET_READ for the api key needed to read from

### DIFF
--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -44,6 +44,10 @@ TERMINAL_LOGGING=true
 RECOMMENDS_REPORT=true
 UNKNOWN_OPTION=""
 
+if [ -n "${API_SECRET_READ}" ]; then
+	HASHED_API_SECRET_READ=`echo -n ${API_SECRET_READ}|sha1sum|cut -f1 -d '-'|cut -f1 -d ' '`
+fi
+
 # If we are running OS X, we need to use a different version
 # of the 'date' command; the built-in 'date' is BSD, which
 # has fewer options than the linux version.  So the user
@@ -148,9 +152,8 @@ echo "Grabbing NIGHTSCOUT treatments.json for date range..."
 # Get Nightscout carb and insulin Treatments
 url="$NIGHTSCOUT_HOST/api/v1/treatments.json?find\[created_at\]\[\$gte\]=`date --date="$START_DATE -4 hours" -Iminutes`&find\[created_at\]\[\$lte\]=`date --date="$END_DATE +1 days" -Iminutes`"
 echo $url
-if [ -n "${API_SECRET_READ}" ]; then 
-	export api_secret=`echo -n ${API_SECRET_READ}|sha1sum|cut -f1 -d '-'|cut -f1 -d ' '`
-	curl -H "api-secret: ${api_secret}" -s $url > ns-treatments.json || die "Couldn't download ns-treatments.json"
+if [ -n "${HASHED_API_SECRET_READ}" ]; then 
+	curl -H "api-secret: ${HASHED_API_SECRET_READ}" -s $url > ns-treatments.json || die "Couldn't download ns-treatments.json"
 else
 	curl -s $url > ns-treatments.json || die "Couldn't download ns-treatments.json"
 fi
@@ -176,9 +179,8 @@ for i in "${date_list[@]}"
 do 
   url="$NIGHTSCOUT_HOST/api/v1/entries/sgv.json?find\[date\]\[\$gte\]=`(date -d $i +%s | tr -d '\n'; echo 000)`&find\[date\]\[\$lte\]=`(date --date="$i +1 days" +%s | tr -d '\n'; echo 000)`&count=1000"
   echo $url
-  if [ -n "${API_SECRET_READ}" ]; then 
-	export api_secret=`echo -n ${API_SECRET_READ}|sha1sum|cut -f1 -d '-'|cut -f1 -d ' '`
-    curl -H "api-secret: ${api_secret}" -s $url > ns-entries.$i.json || die "Couldn't download ns-entries.$i.json"
+  if [ -n "${HASHED_API_SECRET_READ}" ]; then 
+    curl -H "api-secret: ${HASHED_API_SECRET_READ}" -s $url > ns-entries.$i.json || die "Couldn't download ns-entries.$i.json"
   else
     curl -s $url > ns-entries.$i.json || die "Couldn't download ns-entries.$i.json"
   fi


### PR DESCRIPTION
This patch will allow oref-autotune.sh to use the environment variable API_SECRET_READ.  This contains the unhashed API Secret needed to read from Nightscout when the default read permission is deny.