### PR TITLE
spidev5.1 already in use reboot

### DIFF
--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -1,9 +1,11 @@
 radio_errors=`tail /var/log/openaps/pump-loop.log | grep "spidev5.1 already in use"`
 if [ ! -z "$radio_errors" ]; then
     logfile=/var/log/openaps/pump-loop.log
+    echo >> $logfile
+    echo -n "Radio error found at " | tee -a $logfile
     date >> $logfile
-    echo "Radio error found" | tee -a $logfile
     shutdown -r +5 "Rebooting to fix radio errors!" | tee -a $logfile
+    echo >> $logfile
 else
     if [ -e /run/nologin ]; then
         echo "No more radio errors; canceling reboot" | tee -a $logfile

--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -1,0 +1,10 @@
+radio_errors=`tail /var/log/openaps/pump-loop.log | grep "spidev5.1 already in use"`
+if [ ! -z "$radio_errors" ]
+then
+  logfile=~/reset-log.txt
+  date >> $logfile
+  echo "Radio error found" | tee -a $logfile
+  wall "Rebooting to fix radio errors!"
+  reboot | tee -a $logfile
+fi
+

--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -3,7 +3,7 @@ if [ ! -z "$radio_errors" ]; then
     logfile=/var/log/openaps/pump-loop.log
     date >> $logfile
     echo "Radio error found" | tee -a $logfile
-    shutdown -r +11 "Rebooting to fix radio errors!" | tee -a $logfile
+    shutdown -r +5 "Rebooting to fix radio errors!" | tee -a $logfile
 else
     if [ -e /run/nologin ]; then
         echo "No more radio errors; canceling reboot" | tee -a $logfile

--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -1,7 +1,7 @@
 radio_errors=`tail /var/log/openaps/pump-loop.log | grep "spidev5.1 already in use"`
+logfile=/var/log/openaps/pump-loop.log
 if [ ! -z "$radio_errors" ]; then
     if [ ! -e /run/nologin ]; then
-        logfile=/var/log/openaps/pump-loop.log
         echo >> $logfile
         echo -n "Radio error found at " | tee -a $logfile
         date >> $logfile
@@ -11,6 +11,6 @@ if [ ! -z "$radio_errors" ]; then
 else
     if [ -e /run/nologin ]; then
         echo "No more radio errors; canceling reboot" | tee -a $logfile
-        shutdown -c
+        shutdown -c | tee -a $logfile
     fi
 fi

--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -1,11 +1,13 @@
 radio_errors=`tail /var/log/openaps/pump-loop.log | grep "spidev5.1 already in use"`
 if [ ! -z "$radio_errors" ]; then
-    logfile=/var/log/openaps/pump-loop.log
-    echo >> $logfile
-    echo -n "Radio error found at " | tee -a $logfile
-    date >> $logfile
-    shutdown -r +5 "Rebooting to fix radio errors!" | tee -a $logfile
-    echo >> $logfile
+    if [ ! -e /run/nologin ]; then
+        logfile=/var/log/openaps/pump-loop.log
+        echo >> $logfile
+        echo -n "Radio error found at " | tee -a $logfile
+        date >> $logfile
+        shutdown -r +5 "Rebooting to fix radio errors!" | tee -a $logfile
+        echo >> $logfile
+    fi
 else
     if [ -e /run/nologin ]; then
         echo "No more radio errors; canceling reboot" | tee -a $logfile

--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -3,7 +3,7 @@ if [ ! -z "$radio_errors" ]; then
     logfile=/var/log/openaps/pump-loop.log
     date >> $logfile
     echo "Radio error found" | tee -a $logfile
-    shutdown -r +5 "Rebooting to fix radio errors!" | tee -a $logfile
+    shutdown -r +11 "Rebooting to fix radio errors!" | tee -a $logfile
 else
     if [ -e /run/nologin ]; then
         echo "No more radio errors; canceling reboot" | tee -a $logfile

--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -1,10 +1,12 @@
 radio_errors=`tail /var/log/openaps/pump-loop.log | grep "spidev5.1 already in use"`
-if [ ! -z "$radio_errors" ]
-then
-  logfile=~/reset-log.txt
-  date >> $logfile
-  echo "Radio error found" | tee -a $logfile
-  wall "Rebooting to fix radio errors!"
-  reboot | tee -a $logfile
+if [ ! -z "$radio_errors" ]; then
+    logfile=/var/log/openaps/pump-loop.log
+    date >> $logfile
+    echo "Radio error found" | tee -a $logfile
+    shutdown -r +5 "Rebooting to fix radio errors!" | tee -a $logfile
+else
+    if [ -e /run/nologin ]; then
+        echo "No more radio errors; canceling reboot" | tee -a $logfile
+        shutdown -c
+    fi
 fi
-

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -686,6 +686,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     fi
     if [[ "$ttyport" =~ "spi" ]]; then
         (crontab -l; crontab -l | grep -q "reset_spi_serial.py" || echo "@reboot reset_spi_serial.py") | crontab -
+        (crontab -l; crontab -l | grep -q "oref0-radio-reboot" || echo "*/10 * * * * oref0-radio-reboot") | crontab -
     fi
     (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
     if [[ ! -z "$BT_PEB" ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -686,7 +686,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     fi
     if [[ "$ttyport" =~ "spi" ]]; then
         (crontab -l; crontab -l | grep -q "reset_spi_serial.py" || echo "@reboot reset_spi_serial.py") | crontab -
-        (crontab -l; crontab -l | grep -q "oref0-radio-reboot" || echo "*/5 * * * * oref0-radio-reboot") | crontab -
+        (crontab -l; crontab -l | grep -q "oref0-radio-reboot" || echo "* * * * * oref0-radio-reboot") | crontab -
     fi
     (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
     if [[ ! -z "$BT_PEB" ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -686,7 +686,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     fi
     if [[ "$ttyport" =~ "spi" ]]; then
         (crontab -l; crontab -l | grep -q "reset_spi_serial.py" || echo "@reboot reset_spi_serial.py") | crontab -
-        (crontab -l; crontab -l | grep -q "oref0-radio-reboot" || echo "*/10 * * * * oref0-radio-reboot") | crontab -
+        (crontab -l; crontab -l | grep -q "oref0-radio-reboot" || echo "*/5 * * * * oref0-radio-reboot") | crontab -
     fi
     (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
     if [[ ! -z "$BT_PEB" ]]; then

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "oref0-online": "./bin/oref0-online.sh",
     "oref0-upload-profile": "./bin/oref0-upload-profile.js",
     "oref0-pebble": "./bin/oref0-pebble.js",
+    "oref0-radio-reboot": "./bin/oref0-radio-reboot.sh",
     "oref0-raw": "./bin/oref0-raw.js",
     "oref0-reset-git": "bin/oref0-reset-git.sh",
     "oref0-reset-usb": "bin/oref0-reset-usb.sh",


### PR DESCRIPTION
Sometimes, particularly after oref0-online restarts networking and/or switches back and forth between Bluetooth and wifi lots of times, we'll see the issue described at https://github.com/openaps/oref0/issues/406#issuecomment-281543469 and will need to reboot to fix.  This PR attempts to safely automate rebooting only in that situation.