### PR TITLE
Delete Future Data for better recovery of Time on System during No network power on for edison

### DIFF
--- a/bin/oref0-delete-future-entries.sh
+++ b/bin/oref0-delete-future-entries.sh
@@ -1,0 +1,22 @@
+#!/bin/bash 
+ 
+# Since the Edison does not have an internal clock 
+# after a reboot if you do not have the correct time your date will be older than  
+# the time on the CGM data in the monitor folder.  
+# Currently all the checks for time in the system is looking at data being older than current  
+# time 
+# This will delete all the data in the  
+# monitor directory. Allowing oref0 to gather all of the data again in pump-loop 
+
+NEWTIME=$(date -d `(jq .[1].display_time monitor/glucose.json; echo ) | sed 's/"//g'` +%s)
+TIME=$(date --date '5 minutes' +%s)  
+
+echo $NEWTIME 
+echo $TIME
+
+if [ $NEWTIME -gt $TIME ]; then 
+    echo CGM Time is newer than Edison Time$'\n'Deleting All Monitor Files
+    sudo rm -rf monitor/*
+elif [ $NEWTIME -lt $TIME ]; then  
+	echo "No Newer CGM Data found" 
+fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -694,7 +694,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
        (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
     fi
-    (crontab -l; crontab -l | grep -q "oref0-delete-future-entries" || echo "@reboot oref0-delete-future-entries") | crontab -
+    (crontab -l; crontab -l | grep -q "cd $directory && oref0-delete-future-entries" || echo "@reboot cd $directory && oref0-delete-future-entries") | crontab -
     crontab -l | tee $HOME/crontab.txt
 fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -694,6 +694,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
        (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
     fi
+    (crontab -l; crontab -l | grep -q "oref0-delete-future-entries" || echo "@reboot oref0-delete-future-entries") | crontab -
     crontab -l | tee $HOME/crontab.txt
 fi
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "send-tempbasal-Azure": "./bin/send-tempbasal-Azure.js",
     "peb-urchin-status": "./bin/peb-urchin-status.sh",
     "oref0-bluetoothup": "./bin/oref0-bluetoothup.sh",
-    "wifi": "./bin/oref0-tail-wifi.sh"
+    "wifi": "./bin/oref0-tail-wifi.sh",
+    "oref0-delete-future-entries": "./bin/oref0-delete-future-entries.sh"
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,9 +38,11 @@
     "oref0-autotune-export-to-xlsx": "./bin/oref0-autotune-export-to-xlsx.py",
     "oref0-autotune-prep": "./bin/oref0-autotune-prep.js",
     "oref0-autotune-recommends-report": "./bin/oref0-autotune-recommends-report.sh",
+    "oref0-bluetoothup": "./bin/oref0-bluetoothup.sh",
     "oref0-calculate-iob": "./bin/oref0-calculate-iob.js",
     "oref0-copy-fresher": "./bin/oref0-copy-fresher",
     "oref0-crun": "./bin/oref0-conditional-run.sh",
+    "oref0-delete-future-entries": "./bin/oref0-delete-future-entries.sh",
     "oref0-detect-sensitivity": "./bin/oref0-detect-sensitivity.js",
     "oref0-determine-basal": "./bin/oref0-determine-basal.js",
     "oref0-dexusb-cgm-loop": "./bin/oref0-dexusb-cgm-loop.py",
@@ -72,9 +74,7 @@
     "oref0-truncate-git-history": "bin/oref0-truncate-git-history.sh",
     "send-tempbasal-Azure": "./bin/send-tempbasal-Azure.js",
     "peb-urchin-status": "./bin/peb-urchin-status.sh",
-    "oref0-bluetoothup": "./bin/oref0-bluetoothup.sh",
-    "wifi": "./bin/oref0-tail-wifi.sh",
-    "oref0-delete-future-entries": "./bin/oref0-delete-future-entries.sh"
+    "wifi": "./bin/oref0-tail-wifi.sh"
   },
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {


### PR DESCRIPTION
This runs a bash Script when the system reboots that checks the Date on the last CGM entry in monitor/glucose to see if that is in the future of the current time.
This is only an issue with the network was not available and the clock was not automatically set.
If the date of the rig is still in 1999 and it sees that the time is in the future. 
all the other checks in the Loop only look to see if the time is older than current system time.
so if you have a monitor/clock-zoned.json that time will not always be current when the oref0-set-system-clock is run, it will either not set the clock correctly, or the time that is there is from when the rig was last ran.
so if the time is in the future of the rig, it will delete the contents of the monitor folder, allowing the rig to fully grab all data from the pump fresh. 
I found that I had a ~correct time set within two loops of the  pump-loop and I was setting Temp basals within 3 loops. 