### PR TITLE
add unannounced meal detection to autotune

### DIFF
--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -104,6 +104,7 @@ function categorizeBGDatums(opts) {
     }
     //console.error(treatments);
     absorbing = 0;
+    uam = 0; // unannounced meal
     mealCOB = 0;
     mealCarbs = 0;
     var type="";
@@ -215,11 +216,28 @@ function categorizeBGDatums(opts) {
             //if (i == 0) { glucoseDatum.mealAbsorption = "end"; }
             CSFGlucoseData.push(glucoseDatum);
         } else {
-            // check previous "type" value, and if it was csf, set a mealAbsorption end flag
-            if ( type === "csf" ) {
-                CSFGlucoseData[CSFGlucoseData.length-1].mealAbsorption = "end";
-                console.error(CSFGlucoseData[CSFGlucoseData.length-1].mealAbsorption,"carb absorption");
+          // check previous "type" value, and if it was csf, set a mealAbsorption end flag
+          if ( type === "csf" ) {
+            CSFGlucoseData[CSFGlucoseData.length-1].mealAbsorption = "end";
+            console.error(CSFGlucoseData[CSFGlucoseData.length-1].mealAbsorption,"carb absorption");
+          }
+
+          if (iob.iob > currentBasal || uam) {
+            if (deviation > 0) {
+                uam = 1;
+            } else {
+                uam = 0;
             }
+            if ( type != "uam" ) {
+                glucoseDatum.uamAbsorption = "start";
+                console.error(glucoseDatum.uamAbsorption,"uannnounced meal absorption");
+            }
+            type="uam";
+          } else {
+            if ( type === "uam" ) {
+                console.error("end unannounced meal absorption");
+            }
+
 
             // Go through the remaining time periods and divide them into periods where scheduled basal insulin activity dominates. This would be determined by calculating the BG impact of scheduled basal insulin (for example 1U/hr * 48 mg/dL/U ISF = 48 mg/dL/hr = 5 mg/dL/5m), and comparing that to BGI from bolus and net basal insulin activity.
             // When BGI is positive (insulin activity is negative), we want to use that data to tune basals
@@ -248,9 +266,12 @@ function categorizeBGDatums(opts) {
                     ISFGlucoseData.push(glucoseDatum);
                 }
             }
+          }
         }
         // debug line to print out all the things
-        console.error(absorbing.toString(),"mealCOB:",mealCOB.toFixed(1),"mealCarbs:",mealCarbs,"basalBGI:",basalBGI.toFixed(1),"BGI:",BGI.toFixed(1),"at",BGDate,"dev:",deviation,"avgDelta:",avgDelta,type);
+        BGDateArray = BGDate.toString().split(" ");
+        BGTime = BGDateArray[4];
+        console.error(absorbing.toString(),"mealCOB:",mealCOB.toFixed(1),"mealCarbs:",mealCarbs,"basalBGI:",basalBGI.toFixed(1),"BGI:",BGI.toFixed(1),"IOB:",iob.iob.toFixed(1),"at",BGTime,"dev:",deviation,"avgDelta:",avgDelta,type);
     }
 
     return {


### PR DESCRIPTION
Need some testing to determine if this is a reasonable approach, and whether `iob.iob > currentBasal` is a good IOB threshold for triggering UAM detection, or if it should be higher (maybe `2 * currentBasal`?)