### PR TITLE
only consider carbs from last DIA hours as a workaround for undead carbs

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -218,7 +218,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // CI = current carb impact on BG in mg/dL/5m
     ci = round((minDelta - bgi),1);
     if (meal_data.mealCOB * 3 > meal_data.carbs) {
-        // set ci to a minimum of 3mg/dL/5m (default) if at least 1/3 of carbs from the last 1.5*DIA hours are still unabsorbed
+        // set ci to a minimum of 3mg/dL/5m (default) if at least 1/3 of carbs from the last DIA hours are still unabsorbed
         ci = Math.max(profile.min_5m_carbimpact, ci);
     }
     aci = 10;

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -37,7 +37,7 @@ function diaCarbs(opts, time) {
 
     treatments.forEach(function(treatment) {
         var now = time.getTime();
-        var dia_ago = now - 1.5*profile_data.dia*60*60*1000;
+        var dia_ago = now - profile_data.dia*60*60*1000;
         var treatmentDate = new Date(tz(treatment.timestamp));
         var treatmentTime = treatmentDate.getTime();
         if (treatmentTime > dia_ago && treatmentTime <= now) {


### PR DESCRIPTION
Currently AMA considers carbs up to 1.5*DIA hours old, but the pumphistory-zoned.json file only has 5 hours of insulin history.  As a result, when boluses age off at the 5h mark, carbs associated with them are decayed more slowly (often at min_5m_carbimpact), resulting in COB "coming back from the dead".  The longer-term solution to this is probably to merge the pumphistory-zoned.json with the pumphistory-24h-zoned.json so we can properly decay carbs back to 1.5*DIA, but until we do that, it would be safer to exclude carbs from more than DIA hours ago (typically 3-4h).