### PR TITLE
Save battery

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -324,12 +324,12 @@ function refresh_profile {
     || (echo -n Settings refresh && openaps get-settings 2>/dev/null >/dev/null && echo ed)
 }
 
-low_battery_wait {
+function low_battery_wait {
     if (jq --exit-status ".battery > 60" monitor/edison-battery.json); then
-        echo -n Edison battery ok:
+        echo -n "Edison battery ok: "
         jq .battery monitor/edison-battery.json
     elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json); then
-        echo -n "Edison battery low; waiting up to 5 minutes for new BG:"
+        echo -n "Edison battery low; waiting up to 5 minutes for new BG: "
         jq .battery monitor/edison-battery.json
         for i in `seq 1 30`; do
             if (! (find monitor/ -newer monitor/temp_basal.json | grep -q glucose.json && echo glucose.json newer than temp_basal.json )); then
@@ -344,11 +344,11 @@ low_battery_wait {
 
 function refresh_pumphistory_24h {
     if (jq --exit-status ".battery > 60" monitor/edison-battery.json); then
-        echo -n Edison battery:
+        echo -n "Edison battery: "
         jq .battery monitor/edison-battery.json
         autosens_freq=20
     elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json); then
-        echo -n Edison battery:
+        echo -n "Edison battery: "
         jq .battery monitor/edison-battery.json
         autosens_freq=90
     else

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -326,7 +326,7 @@ function refresh_profile {
 
 function low_battery_wait {
     if (jq --exit-status ".battery > 60" monitor/edison-battery.json > /dev/null); then
-        echo -n "Edison battery ok: $(jq .battery monitor/edison-battery.json)%"
+        echo "Edison battery ok: $(jq .battery monitor/edison-battery.json)%"
     elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json > /dev/null); then
         echo -n "Edison battery low: $(jq .battery monitor/edison-battery.json)%; waiting up to 5 minutes for new BG: "
         for i in `seq 1 30`; do
@@ -342,10 +342,10 @@ function low_battery_wait {
 
 function refresh_pumphistory_24h {
     if (jq --exit-status ".battery > 60" monitor/edison-battery.json > /dev/null); then
-        echo -n "Edison battery ok: $(jq .battery monitor/edison-battery.json)%"
+        echo "Edison battery ok: $(jq .battery monitor/edison-battery.json)%"
         autosens_freq=20
     elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json > /dev/null); then
-        echo -n "Edison battery low: $(jq .battery monitor/edison-battery.json)%"
+        echo "Edison battery low: $(jq .battery monitor/edison-battery.json)%"
         autosens_freq=90
     else
         echo Edison battery level not found

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -324,7 +324,19 @@ function refresh_profile {
 }
 
 function refresh_pumphistory_24h {
-    find settings/ -mmin -20 -size +100c | grep -q pumphistory-24h-zoned && echo Pumphistory-24 less than 20m old \
+    if (jq --exit-status ".battery > 60" monitor/edison-battery.json); then
+        echo -n Edison battery:
+        jq .battery monitor/edison-battery.json
+        autosens_freq=20
+    elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json); then
+        echo -n Edison battery:
+        jq .battery monitor/edison-battery.json
+        autosens_freq=90
+    else
+        echo Edison battery level not found
+        autosens_freq=20
+    fi
+    find settings/ -mmin -$autosens_freq -size +100c | grep -q pumphistory-24h-zoned && echo Pumphistory-24 less than ${autosens_freq}m old \
     || (echo -n pumphistory-24h refresh \
         && openaps report invoke settings/pumphistory-24h.json settings/pumphistory-24h-zoned.json 2>&1 >/dev/null | tail -1 && echo ed)
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -325,12 +325,10 @@ function refresh_profile {
 }
 
 function low_battery_wait {
-    if (jq --exit-status ".battery > 60" monitor/edison-battery.json); then
-        echo -n "Edison battery ok: "
-        jq .battery monitor/edison-battery.json
-    elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json); then
-        echo -n "Edison battery low; waiting up to 5 minutes for new BG: "
-        jq .battery monitor/edison-battery.json
+    if (jq --exit-status ".battery > 60" monitor/edison-battery.json > /dev/null); then
+        echo -n "Edison battery ok: $(jq .battery monitor/edison-battery.json)%"
+    elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json > /dev/null); then
+        echo -n "Edison battery low: $(jq .battery monitor/edison-battery.json)%; waiting up to 5 minutes for new BG: "
         for i in `seq 1 30`; do
             if (! (find monitor/ -newer monitor/temp_basal.json | grep -q glucose.json && echo glucose.json newer than temp_basal.json )); then
                 break
@@ -343,13 +341,11 @@ function low_battery_wait {
 }
 
 function refresh_pumphistory_24h {
-    if (jq --exit-status ".battery > 60" monitor/edison-battery.json); then
-        echo -n "Edison battery: "
-        jq .battery monitor/edison-battery.json
+    if (jq --exit-status ".battery > 60" monitor/edison-battery.json > /dev/null); then
+        echo -n "Edison battery ok: $(jq .battery monitor/edison-battery.json)%"
         autosens_freq=20
-    elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json); then
-        echo -n "Edison battery: "
-        jq .battery monitor/edison-battery.json
+    elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json > /dev/null); then
+        echo -n "Edison battery low: $(jq .battery monitor/edison-battery.json)%"
         autosens_freq=90
     else
         echo Edison battery level not found

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -5,6 +5,7 @@ main() {
     prep
     until( \
         echo && echo Starting pump-loop at $(date): \
+        && low_battery_wait \
         && wait_for_silence \
         && refresh_old_pumphistory \
         && refresh_old_pumphistory_24h \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -291,6 +291,8 @@ function refresh_old_profile {
 }
 
 function refresh_smb_temp_and_enact {
+    # set mtime of monitor/glucose.json to the time of its most recent glucose value
+    touch -d "$(date -R -d @$(jq .[0].date/1000 monitor/glucose.json))" monitor/glucose.json
     if( (find monitor/ -newer monitor/temp_basal.json | grep -q glucose.json && echo glucose.json newer than temp_basal.json ) \
         || (! find monitor/ -mmin -5 -size +5c | grep -q temp_basal && echo temp_basal.json more than 5m old)); then
             smb_enact_temp
@@ -299,6 +301,8 @@ function refresh_smb_temp_and_enact {
     fi
 }
 function refresh_temp_and_enact {
+    # set mtime of monitor/glucose.json to the time of its most recent glucose value
+    touch -d "$(date -R -d @$(jq .[0].date/1000 monitor/glucose.json))" monitor/glucose.json
     if( (find monitor/ -newer monitor/temp_basal.json | grep -q glucose.json && echo glucose.json newer than temp_basal.json ) \
         || (! find monitor/ -mmin -5 -size +5c | grep -q temp_basal && echo temp_basal.json more than 5m old)); then
             (echo -n Temp refresh && openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json monitor/iob.json 2>&1 >/dev/null | tail -1 && echo ed \
@@ -311,6 +315,8 @@ function refresh_temp_and_enact {
 }
 
 function refresh_pumphistory_and_enact {
+    # set mtime of monitor/glucose.json to the time of its most recent glucose value
+    touch -d "$(date -R -d @$(jq .[0].date/1000 monitor/glucose.json))" monitor/glucose.json
     if ((find monitor/ -newer monitor/pumphistory-zoned.json | grep -q glucose.json && echo -n glucose.json newer than pumphistory) \
         || (find enact/ -newer monitor/pumphistory-zoned.json | grep -q enacted.json && echo -n enacted.json newer than pumphistory) \
         || (! find monitor/ -mmin -5 | grep -q pumphistory-zoned && echo -n pumphistory more than 5m old) ); then
@@ -331,6 +337,8 @@ function low_battery_wait {
     elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json > /dev/null); then
         echo -n "Edison battery low: $(jq .battery monitor/edison-battery.json)%; waiting up to 5 minutes for new BG: "
         for i in `seq 1 30`; do
+            # set mtime of monitor/glucose.json to the time of its most recent glucose value
+            touch -d "$(date -R -d @$(jq .[0].date/1000 monitor/glucose.json))" monitor/glucose.json
             if (find monitor/ -newer monitor/temp_basal.json | grep -q glucose.json); then
                 echo glucose.json newer than temp_basal.json
                 break

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -331,10 +331,12 @@ function low_battery_wait {
     elif (jq --exit-status ".battery <= 60" monitor/edison-battery.json > /dev/null); then
         echo -n "Edison battery low: $(jq .battery monitor/edison-battery.json)%; waiting up to 5 minutes for new BG: "
         for i in `seq 1 30`; do
-            if (! (find monitor/ -newer monitor/temp_basal.json | grep -q glucose.json && echo glucose.json newer than temp_basal.json )); then
+            if (find monitor/ -newer monitor/temp_basal.json | grep -q glucose.json); then
+                echo glucose.json newer than temp_basal.json
                 break
+            else
+                echo -n .; sleep 10
             fi
-            echo -n .; sleep 10
         done
     else
         echo Edison battery level not found


### PR DESCRIPTION
When the Edison battery level is below 60%, this makes the rig stop running autosens every 20m, and instead run it every 90m.  It also causes oref0-pump-loop to wait up to 5 minutes for a BG reading newer than the most recent temp basal reading before even trying to use the radio or talk to the pump.  In combination with a new subg_rfspy firmware that I'm testing with @mogar, this should allow us to power down the cc1110 radio most of the time when necessary.

For now, I'm leaving the low battery cutoff at 60%, as the charging voltage reads at about 62-65%.  After some testing, we might want to make this the default mode whenever the rig is not actually plugged in (when battery reads >65% as well as <60%). 