### PR TITLE
Implement BlueZ min version checking.

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -417,14 +417,18 @@ done
 echo Checking for BT Mac, BT Peb or Shareble
 if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" || ${CGM,,} =~ "shareble" ]]; then
     # Install Bluez for BT Tethering
-    echo Checking bluez installation
-    if ! bluetoothd --version | grep -q 5.44 2>/dev/null; then
+    echo Checking bluez installation 
+    bluetoothdversion=$(bluetoothd --version || 0)
+    bluetoothdminversion=5.37
+    bluetoothdversioncompare=$(awk 'BEGIN{ print "'$bluetoothdversion'"<"'$bluetoothdminversion'" }') 
+    if [ "$bluetoothdversioncompare" -eq 1 ]; then
+        killall bluetoothd &>/dev/null #Kill current running version if its out of date and we are updating it
         cd $HOME/src/ && wget https://www.kernel.org/pub/linux/bluetooth/bluez-5.44.tar.gz && tar xvfz bluez-5.44.tar.gz || die "Couldn't download bluez"
         cd $HOME/src/bluez-5.44 && ./configure --enable-experimental --disable-systemd && \
         make && sudo make install && sudo cp ./src/bluetoothd /usr/local/bin/ || die "Couldn't make bluez"
         oref0-bluetoothup
     else
-        echo bluez v 5.44 already installed
+        echo bluez v ${bluetoothdversion} already installed
     fi
 fi
 # add/configure devices


### PR DESCRIPTION
Now checks for at least version 5.37, and will install 5.44 if no new enough version found.