### PR TITLE
Reset autosens on site change

### DIFF
--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -37,6 +37,7 @@ if (!module.parent) {
     try {
         var cwd = process.cwd();
         var glucose_data = require(cwd + '/' + glucose_input);
+        // require 6 hours of data to run autosens
         if (glucose_data.length < 72) {
             console.error("Optional feature autosens disabled: not enough glucose data to calculate sensitivity");
             return console.log('{ "ratio": 1, "reason": "not enough glucose data to calculate autosens" }');

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -1,5 +1,5 @@
 var tz = require('moment-timezone');
-var calcMealCOB = require('oref0/lib/determine-basal/cob-autosens');
+//var calcMealCOB = require('oref0/lib/determine-basal/cob-autosens');
 var basal = require('oref0/lib/profile/basal');
 var getIOB = require('oref0/lib/iob');
 var ISF = require('../profile/isf');

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -16,6 +16,25 @@ function detectSensitivityandCarbAbsorption(inputs) {
 
     //console.error(mealTime);
 
+    // use last 24h worth of data by default
+    var lastSiteChange = new Date(new Date().getTime() - (24 * 60 * 60 * 1000));
+    if (inputs.iob_inputs.profile.rewind_resets_autosens) {
+        // scan through pumphistory and set lastSiteChange to the time of the last pump rewind event
+        // if not present, leave lastSiteChange unchanged at 24h ago.
+        var history = inputs.iob_inputs.history;
+        for (var h=1; h < history.length; ++h) {
+            if ( ! history[h]._type || history[h]._type != "Rewind" ) {
+                //process.stderr.write("-");
+                continue;
+            }
+            if ( history[h].timestamp ) {
+                lastSiteChange = new Date( history[h].timestamp );
+                console.error("Setting lastSiteChange to",lastSiteChange,"using timestamp",history[h].timestamp);
+                break;
+            }
+        }
+    }
+
     var avgDeltas = [];
     var bgis = [];
     var deviations = [];
@@ -43,8 +62,15 @@ function detectSensitivityandCarbAbsorption(inputs) {
         // only consider BGs for 6h before a meal
         if (mealTime) {
             hoursBeforeMeal = (bgTime-mealTime)/(60*60*1000);
-                if (hoursBeforeMeal > 6 || hoursBeforeMeal < 0) {
-                    continue;
+            if (hoursBeforeMeal > 6 || hoursBeforeMeal < 0) {
+                continue;
+            }
+        }
+        // only consider BGs since lastSiteChange
+        if (lastSiteChange) {
+            hoursSinceSiteChange = (bgTime-lastSiteChange)/(60*60*1000);
+            if (hoursSinceSiteChange < 0) {
+                continue;
             }
         }
         var elapsed_minutes = (bgTime - lastbgTime)/(60*1000);
@@ -152,6 +178,16 @@ function detectSensitivityandCarbAbsorption(inputs) {
     inputs.mealTime || process.stderr.write(" ");
     //console.log(JSON.stringify(avgDeltas));
     //console.log(JSON.stringify(bgis));
+    // when we have less than 12h worth of deviation data, add up to 1h of zero deviations
+    // this dampens any large sensitivity changes detected based on too little data, without ignoring them completely
+    if (deviations.length < 144) {
+        pad = Math.round((1 - deviations.length/144) * 12);
+        console.error("Found",deviations.length,"deviations since",lastSiteChange,"- adding",pad,"more zero deviations");
+        for (var d=0; d<pad; d++) {
+            //inputs.mealTime || process.stderr.write(".");
+            deviations.push(0);
+        }
+    }
     avgDeltas.sort(function(a, b){return a-b});
     bgis.sort(function(a, b){return a-b});
     deviations.sort(function(a, b){return a-b});
@@ -159,7 +195,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
         //console.error("p="+i.toFixed(2)+": "+percentile(avgDeltas, i).toFixed(2)+", "+percentile(bgis, i).toFixed(2)+", "+percentile(deviations, i).toFixed(2));
         if ( percentile(deviations, (i+0.02)) >= 0 && percentile(deviations, i) < 0 ) {
             //console.error("p="+i.toFixed(2)+": "+percentile(avgDeltas, i).toFixed(2)+", "+percentile(bgis, i).toFixed(2)+", "+percentile(deviations, i).toFixed(2));
-            inputs.mealTime || console.error(Math.round(100*i)+"% of non-meal deviations negative (target 45%-50%)");
+            inputs.mealTime || console.error(Math.round(100*i)+"% of non-meal deviations <= 0 (target 45%-50%)");
         }
     }
     pSensitive = percentile(deviations, 0.50);

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -180,7 +180,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
     //console.log(JSON.stringify(bgis));
     // when we have less than 12h worth of deviation data, add up to 1h of zero deviations
     // this dampens any large sensitivity changes detected based on too little data, without ignoring them completely
-    if (deviations.length < 144) {
+    if (! inputs.mealTime && deviations.length < 144) {
         pad = Math.round((1 - deviations.length/144) * 12);
         console.error("Found",deviations.length,"deviations since",lastSiteChange,"- adding",pad,"more zero deviations");
         for (var d=0; d<pad; d++) {

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -18,7 +18,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
 
     // use last 24h worth of data by default
     var lastSiteChange = new Date(new Date().getTime() - (24 * 60 * 60 * 1000));
-    if (inputs.iob_inputs.profile.rewind_resets_autosens) {
+    if (inputs.iob_inputs.profile.rewind_resets_autosens && ! inputs.mealTime ) {
         // scan through pumphistory and set lastSiteChange to the time of the last pump rewind event
         // if not present, leave lastSiteChange unchanged at 24h ago.
         var history = inputs.iob_inputs.history;

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -81,9 +81,6 @@ function detectSensitivityandCarbAbsorption(inputs) {
     //console.error(bucketed_data);
     for (var i=0; i < bucketed_data.length-3; ++i) {
         var bgTime = new Date(bucketed_data[i].date);
-        if (inputs.bgTime && bgTime > inputs.bgTime) {
-            continue;
-        }
 
         var sens = isf.isfLookup(profile.isfProfile,bgTime);
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -19,7 +19,7 @@ function defaults ( ) {
     , bolussnooze_dia_divisor: 2
     , min_5m_carbimpact: 3 //mg/dL/5m
     , carbratio_adjustmentratio: 1 //if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
-    , rewind_resets_autosens: false
+    , rewind_resets_autosens: false // pump rewind would reset autosensitivity calcs for a time
   };
   return profile;
 }

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -13,13 +13,13 @@ function defaults ( ) {
     , current_basal_safety_multiplier: 4
     , autosens_max: 1.2
     , autosens_min: 0.7
-    , autosens_adjust_targets: true
-    , override_high_target_with_low: false
-    , skip_neutral_temps: false
-    , bolussnooze_dia_divisor: 2
-    , min_5m_carbimpact: 3 //mg/dL/5m
-    , carbratio_adjustmentratio: 1 //if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
-    , rewind_resets_autosens: false // pump rewind would reset autosensitivity calcs for a time
+    , autosens_adjust_targets: true // when autosens detects sensitivity/resistance, also adjust BG target accordingly
+    , override_high_target_with_low: false // allows a much higher target used only for avoiding bolus wizard overcorrections
+    , skip_neutral_temps: false // if true, don't set neutral temps
+    , bolussnooze_dia_divisor: 2 // bolus snooze decays after 1/2 of DIA
+    , min_5m_carbimpact: 3 // mg/dL per 5m
+    , carbratio_adjustmentratio: 1 // if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
+    , rewind_resets_autosens: false // reset autosensitivity to neutral for awhile after each pump rewind
   };
   return profile;
 }

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -19,6 +19,7 @@ function defaults ( ) {
     , bolussnooze_dia_divisor: 2
     , min_5m_carbimpact: 3 //mg/dL/5m
     , carbratio_adjustmentratio: 1 //if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
+    , rewind_resets_autosens: false
   };
   return profile;
 }


### PR DESCRIPTION
Implements https://github.com/openaps/oref0/issues/447

This has been tested and confirmed to:
 - Do nothing when the preference is not enabled
 - Do nothing when the last site change was more than 24h ago
 - Reset autosens to neutral after a site change:
```
Setting lastSiteChange to Fri Apr 28 2017 22:38:09 GMT-0700 (MST) using timestamp 2017-04-28T22:38:09-07:00
----++++++++++- Found 15 deviations since Fri Apr 28 2017 22:38:09 GMT-0700 (MST) - adding 11 more zero deviations
18% of non-meal deviations <= 0 (target 45%-50%)
Sensitivity normal.
```