### PR TITLE
Pushover support for carbsReq and insulinReq notifications

### DIFF
--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -5,7 +5,7 @@ ip -4 -o addr show dev wlan0 | awk '{split($4,a,"/");print a[1]}'
 ip -4 -o addr show dev bnep0 | awk '{split($4,a,"/");print a[1]}'
 echo
 echo -n "At $(date), my wifi network name is "
-printf '%s' $(iwgetid -r)
+iwgetid -r wlan0 | tr -d '\n'
 echo -n ", and my public IP is: "
 if curl --compressed -4 -s -m 15 icanhazip.com | awk -F , '{print $NF}' | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
     # if we are back on wifi (and have connectivity to icanhazip.com), shut down bluetooth

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 echo; echo Starting oref0-online.
+if iwgetid -r wlan0; then
+    if ! ip route | grep default | grep -q wlan0; then
+        echo Attempting to renew wlan0 IP
+        sudo dhclient wlan0
+    fi
+fi
 echo -n "At $(date) my local IP is: "
 ip -4 -o addr show dev wlan0 | awk '{split($4,a,"/");print a[1]}'
 ip -4 -o addr show dev bnep0 | awk '{split($4,a,"/");print a[1]}'
@@ -33,7 +39,7 @@ else
     #sudo dhclient wlan0
     echo
     echo -n "At $(date), my wifi network name is "
-    printf '%s' $(iwgetid -r)
+    iwgetid -r wlan0 | tr -d '\n'
     echo -n ", and my public IP is: "
     # loop over as many MACs as are provided as arguments
     if ! curl --compressed -4 -s -m 15 icanhazip.com | awk -F , '{print $NF}' | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
@@ -58,7 +64,7 @@ else
         echo
     fi
     echo -n "At $(date), my wifi network name is "
-    printf '%s' $(iwgetid -r)
+    iwgetid -r wlan0 | tr -d '\n'
     echo -n ", and my public IP is: "
     curl --compressed -4 -s -m 15 icanhazip.com
 fi

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo; echo Starting oref0-online.
 # if we are connected to wifi but don't have an IP, try to get one
-if iwgetid -r wlan0 | egrep -q "[A-Z]|[a-z]|[0-9]*"; then
+if iwgetid -r wlan0 | egrep -q "[A-Z]|[a-z]|[0-9]?"; then
     if ! ip route | grep default | grep -q wlan0; then
         echo Attempting to renew wlan0 IP
         sudo dhclient wlan0

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -22,15 +22,15 @@ if curl --compressed -4 -s -m 15 icanhazip.com | egrep "^[12]*[0-9]*[0-9]\.[12]*
         sudo dhclient wlan0
     fi
 else
-    echo; echo "Error, cycling networking "
+    #echo; echo "Error, cycling networking "
     # simply restart networking completely for stability purposes
-    sudo /etc/init.d/networking stop
-    sleep 5
-    sudo /etc/init.d/networking start
-    echo "and getting new wlan0 IP"
-    ps aux | grep -v grep | grep -q "dhclient wlan0" && sudo killall dhclient
-    sudo dhclient wlan0 -r
-    sudo dhclient wlan0
+    #sudo /etc/init.d/networking stop
+    #sleep 5
+    #sudo /etc/init.d/networking start
+    #echo "and getting new wlan0 IP"
+    #ps aux | grep -v grep | grep -q "dhclient wlan0" && sudo killall dhclient
+    #sudo dhclient wlan0 -r
+    #sudo dhclient wlan0
     echo
     echo -n "At $(date), my wifi network name is "
     printf '%s' $(iwgetid -r)

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -58,6 +58,7 @@ else
                 if ( ifconfig | grep -A1 wlan0 | grep -q "inet addr" ) && ( ifconfig | grep -A1 bnep0 | grep -q "inet addr" ); then
                     echo -n " and releasing wifi IP"
                     sudo dhclient wlan0 -r
+                    echo
                     echo Sleeping for 2 minutes before trying wifi again
                     sleep 120
                 fi

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -7,7 +7,7 @@ echo
 echo -n "At $(date), my wifi network name is "
 printf '%s' $(iwgetid -r)
 echo -n ", and my public IP is: "
-if curl --compressed -4 -s -m 15 icanhazip.com | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
+if curl --compressed -4 -s -m 15 icanhazip.com | awk -F , '{print $NF}' | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
     # if we are back on wifi (and have connectivity to icanhazip.com), shut down bluetooth
     if ( ifconfig | grep -A1 wlan0 | grep -q "inet addr" ) && ( ifconfig | grep -A1 bnep0 | grep -q "inet addr" ); then
         echo "Back online via wifi; disconnecting BT $MAC"
@@ -36,11 +36,11 @@ else
     printf '%s' $(iwgetid -r)
     echo -n ", and my public IP is: "
     # loop over as many MACs as are provided as arguments
-    if ! curl --compressed -4 -s -m 15 icanhazip.com | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
+    if ! curl --compressed -4 -s -m 15 icanhazip.com | awk -F , '{print $NF}' | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
         echo
         for MAC; do
             echo -n "At $(date) my public IP is: "
-            if ! curl --compressed -4 -s -m 15 icanhazip.com | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
+            if ! curl --compressed -4 -s -m 15 icanhazip.com | awk -F , '{print $NF}' | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
                 echo; echo -n "Error, connecting BT to $MAC"
                 oref0-bluetoothup
                 sudo bt-pan client $MAC -d

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -58,6 +58,8 @@ else
                 if ( ifconfig | grep -A1 wlan0 | grep -q "inet addr" ) && ( ifconfig | grep -A1 bnep0 | grep -q "inet addr" ); then
                     echo -n " and releasing wifi IP"
                     sudo dhclient wlan0 -r
+                    echo Sleeping for 2 minutes before trying wifi again
+                    sleep 120
                 fi
                 echo
             fi

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo; echo Starting oref0-online.
-if iwgetid -r wlan0; then
+if iwgetid -r wlan0 | egrep -q "[A-Z]|[a-z]|[0-9]*"; then
     if ! ip route | grep default | grep -q wlan0; then
         echo Attempting to renew wlan0 IP
         sudo dhclient wlan0

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 echo; echo Starting oref0-online.
+# if we are connected to wifi but don't have an IP, try to get one
 if iwgetid -r wlan0 | egrep -q "[A-Z]|[a-z]|[0-9]*"; then
     if ! ip route | grep default | grep -q wlan0; then
         echo Attempting to renew wlan0 IP

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -43,6 +43,7 @@ else
             if ! curl --compressed -4 -s -m 15 icanhazip.com | egrep "^[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]\.[12]*[0-9]*[0-9]$"; then
                 echo; echo -n "Error, connecting BT to $MAC"
                 oref0-bluetoothup
+                sudo bt-pan client $MAC -d
                 sudo bt-pan client $MAC
                 echo -n ", getting bnep0 IP"
                 sudo dhclient bnep0

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -62,7 +62,7 @@ smb_main() {
             && touch monitor/pump_loop_completed -r monitor/pump_loop_enacted \
             && echo \
     ); do
-        if grep -q '"suspended": false' monitor/status.json; then
+        if grep -q '"suspended": true' monitor/status.json; then
             echo -n "Pump suspended; "
         else
             echo Error, retrying && maybe_mmtune

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -80,6 +80,10 @@ function smb_reservoir_before {
     && echo -n "pumphistory.json: " && cat monitor/pumphistory.json | jq -C .[0]._description \
     && echo -n "Checking pump clock: " && (cat monitor/clock-zoned.json; echo) | tr -d '\n' \
     && echo -n " is within 1m of current time: " && date \
+    && if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -60 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 60 )); then
+        echo Pump clock is more than 1m off: attempting to reset it
+        oref0-set-device-clocks
+       fi \
     && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > -60 )) \
     && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < 60 )) \
     && echo -n "and that pumphistory is less than 1m old.  " \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -62,7 +62,11 @@ smb_main() {
             && touch monitor/pump_loop_completed -r monitor/pump_loop_enacted \
             && echo \
     ); do
-        echo Error, retrying && maybe_mmtune
+        if grep -q '"suspended": false' monitor/status.json; then
+            echo -n "Pump suspended; "
+        else
+            echo Error, retrying && maybe_mmtune
+        fi
         echo "Sleeping $upto10s; "
         sleep $upto10s
     done

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -172,7 +172,7 @@ function smb_verify_reservoir {
 }
 
 function smb_verify_suggested {
-    if grep incorrectly enact/suggested.json; then
+    if grep incorrectly enact/smb-suggested.json; then
         echo "Checking system clock against pump clock:"
         oref0-set-system-clock 2>&1 >/dev/null
     fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -64,6 +64,7 @@ smb_main() {
     ); do
         if grep -q '"suspended": true' monitor/status.json; then
             echo -n "Pump suspended; "
+            smb_verify_status
         else
             echo Error, retrying && maybe_mmtune
         fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -2,15 +2,21 @@
 
 TOKEN=$1
 USER=$2
-FILE={$3-enact/smb-suggested.json}
-SOUND={$4-none}
-SNOOZE={$5-15}
+FILE=${3-enact/smb-suggested.json}
+SOUND=${4-none}
+SNOOZE=${5-15}
+
+echo "Running: $0 $TOKEN $USER $FILE $SOUND $SNOOZE"
 
 if [ -z $TOKEN ] || [ -z $USER ]; then
     echo "Usage: $0 <TOKEN> <USER> [enact/smb-suggested.json] [none] [15]"
     exit
 fi
 
-if ! find monitor/ -mmin -$SNOOZE -ls | grep pushover-sent && cat $FILE | egrep "add'l|maxBolus"; then
+if find monitor/ -mmin -$SNOOZE -ls | grep -q pushover-sent; then
+    echo "Last pushover sent less than $SNOOZE minutes ago."
+elif cat $FILE | egrep "add'l|maxBolus"; then
     curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
+else
+    echo "No additional carbs or bolus required."
 fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -13,9 +13,9 @@ if [ -z $TOKEN ] || [ -z $USER ]; then
     exit
 fi
 
-if find monitor/ -mmin -$SNOOZE -ls | grep -q pushover-sent; then
+if find monitor/ -mmin -$SNOOZE | grep -q pushover-sent; then
     echo "Last pushover sent less than $SNOOZE minutes ago."
-elif ! find $FILE -mmin -$SNOOZE -ls | grep $FILE; then
+elif ! find $FILE -mmin -$SNOOZE | grep -q $FILE; then
     echo "$FILE more than $SNOOZE minutes old"
 elif ! cat $FILE | egrep "add'l|maxBolus"; then
     echo "No additional carbs or bolus required."

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -6,6 +6,10 @@ FILE={$3-enact/smb-suggested.json}
 SOUND={$4-none}
 SNOOZE={$5-15}
 
+if [ -z $TOKEN ] || [ -z $USER ]; then
+      echo "Usage: $0 <TOKEN> <USER> [enact/smb-suggested.json] [none] [15]"
+fi
+
 if ! find monitor/ -mmin -$SNOOZE -ls | grep pushover-sent && cat $FILE | egrep "add'l|maxBolus"
     curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
 fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -10,6 +10,6 @@ if [ -z $TOKEN ] || [ -z $USER ]; then
       echo "Usage: $0 <TOKEN> <USER> [enact/smb-suggested.json] [none] [15]"
 fi
 
-if ! find monitor/ -mmin -$SNOOZE -ls | grep pushover-sent && cat $FILE | egrep "add'l|maxBolus"
+if ! find monitor/ -mmin -$SNOOZE -ls | grep pushover-sent && cat $FILE | egrep "add'l|maxBolus"; then
     curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
 fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -15,8 +15,10 @@ fi
 
 if find monitor/ -mmin -$SNOOZE -ls | grep -q pushover-sent; then
     echo "Last pushover sent less than $SNOOZE minutes ago."
-elif cat $FILE | egrep "add'l|maxBolus"; then
-    curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
-else
+elif ! find $FILE -mmin -$SNOOZE -ls | grep $FILE; then
+    echo "$FILE more than $SNOOZE minutes old"
+elif ! cat $FILE | egrep "add'l|maxBolus"; then
     echo "No additional carbs or bolus required."
+else
+    curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
 fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -7,7 +7,8 @@ SOUND={$4-none}
 SNOOZE={$5-15}
 
 if [ -z $TOKEN ] || [ -z $USER ]; then
-      echo "Usage: $0 <TOKEN> <USER> [enact/smb-suggested.json] [none] [15]"
+    echo "Usage: $0 <TOKEN> <USER> [enact/smb-suggested.json] [none] [15]"
+    exit
 fi
 
 if ! find monitor/ -mmin -$SNOOZE -ls | grep pushover-sent && cat $FILE | egrep "add'l|maxBolus"; then

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+TOKEN=$1
+USER=$2
+FILE={$3-enact/smb-suggested.json}
+SOUND={$4-none}
+SNOOZE={$5-15}
+
+if ! find monitor/ -mmin -$SNOOZE -ls | grep pushover-sent && cat $FILE | egrep "add'l|maxBolus"
+    curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
+fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -13,6 +13,7 @@ if [ -z $TOKEN ] || [ -z $USER ]; then
     exit
 fi
 
+date
 if find monitor/ -mmin -$SNOOZE | grep -q pushover-sent; then
     echo "Last pushover sent less than $SNOOZE minutes ago."
 elif ! find $FILE -mmin -$SNOOZE | grep -q $FILE; then

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -6,7 +6,7 @@ FILE=${3-enact/smb-suggested.json}
 SOUND=${4-none}
 SNOOZE=${5-15}
 
-echo "Running: $0 $TOKEN $USER $FILE $SOUND $SNOOZE"
+#echo "Running: $0 $TOKEN $USER $FILE $SOUND $SNOOZE"
 
 if [ -z $TOKEN ] || [ -z $USER ]; then
     echo "Usage: $0 <TOKEN> <USER> [enact/smb-suggested.json] [none] [15]"

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -21,5 +21,5 @@ elif ! find $FILE -mmin -$SNOOZE | grep -q $FILE; then
 elif ! cat $FILE | egrep "add'l|maxBolus"; then
     echo "No additional carbs or bolus required."
 else
-    curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
+    curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
 fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -696,7 +696,7 @@ fi
 # If you aren't sure what you're doing, *DO NOT* enable this.
 # If you ignore this warning, it *WILL* administer extra post-meal insulin, which may cause low blood sugar.
 if [[ $ENABLE =~ microbolus ]]; then
-    sudo apt-get -y install bc
+    sudo apt-get -y install bc jq
     cd $directory || die "Can't cd $directory"
     for type in supermicrobolus; do
       echo importing $type file

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -738,7 +738,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     (crontab -l; crontab -l | grep -q "$NIGHTSCOUT_HOST" || echo NIGHTSCOUT_HOST=$NIGHTSCOUT_HOST) | crontab -
     (crontab -l; crontab -l | grep -q "API_SECRET=" || echo API_SECRET=$(nightscout hash-api-secret $API_SECRET)) | crontab -
     (crontab -l; crontab -l | grep -q "PATH=" || echo "PATH=$PATH" ) | crontab -
-    (crontab -l; crontab -l | grep -q "oref0-online $BT_MAC" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-online '$BT_MAC'" || oref0-online '$BT_MAC' >> /var/log/openaps/network.log' ) | crontab -
+    (crontab -l; crontab -l | grep -q "oref0-online $BT_MAC" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-online '$BT_MAC'" || oref0-online '$BT_MAC' 2>&1 >> /var/log/openaps/network.log' ) | crontab -
     (crontab -l; crontab -l | grep -q "sudo wpa_cli scan" || echo '* * * * * sudo wpa_cli scan') | crontab -
     (crontab -l; crontab -l | grep -q "killall -g --older-than 30m oref0" || echo '* * * * * ( killall -g --older-than 30m openaps; killall -g --older-than 30m oref0-pump-loop; killall -g --older-than 30m openaps-report )') | crontab -
     # kill pump-loop after 5 minutes of not writing to pump-loop.log

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -105,6 +105,14 @@ case $i in
     WW_TI_USB_RESET="${i#*=}"
     shift # past argument=value
     ;;
+    -pt=*|--pushover_token=*)
+    PUSHOVER_TOKEN="${i#*=}"
+    shift # past argument=value
+    ;;
+    -pu=*|--pushover_user=*)
+    PUSHOVER_USER="${i#*=}"
+    shift # past argument=value
+    ;;
     *)
             # unknown option
     echo "Option ${i#*=} unknown"
@@ -780,6 +788,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
      (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; cat $directory/monitor/edison-battery.json | json batteryVoltage | awk '{if (\$1<=3050)system(\"sudo shutdown -h now\")}'") | crontab -
     fi
     (crontab -l; crontab -l | grep -q "cd $directory && oref0-delete-future-entries" || echo "@reboot cd $directory && oref0-delete-future-entries") | crontab -
+    if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
+        (crontab -l; crontab -l | grep -q "oref0-pushover" || echo "* * * * * oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log" ) | crontab -
+    fi
 
     crontab -l | tee $HOME/crontab.txt
 fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -789,7 +789,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     fi
     (crontab -l; crontab -l | grep -q "cd $directory && oref0-delete-future-entries" || echo "@reboot cd $directory && oref0-delete-future-entries") | crontab -
     if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
-        (crontab -l; crontab -l | grep -q "oref0-pushover" || echo "* * * * * oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log" ) | crontab -
+        (crontab -l; crontab -l | grep -q "oref0-pushover" || echo "* * * * * cd $directory && oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log" ) | crontab -
     fi
 
     crontab -l | tee $HOME/crontab.txt

--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -29,7 +29,7 @@ var round_basal = require('./round-basal');
     }
 
     var suggestedRate = round_basal(rate, profile);
-    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
+    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && currenttemp.duration <= 120 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
         rT.reason += currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
         return rT;
     }

--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -30,7 +30,7 @@ var round_basal = require('./round-basal');
 
     var suggestedRate = round_basal(rate, profile);
     if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > 20 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
-        rT.reason += currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no action required";
+        rT.reason += currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
         return rT;
     }
 

--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -29,7 +29,7 @@ var round_basal = require('./round-basal');
     }
 
     var suggestedRate = round_basal(rate, profile);
-    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > 20 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
+    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
         rT.reason += currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
         return rT;
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -772,10 +772,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 durationReq = Math.min(120,Math.max(0,durationReq));
             }
             //console.error(durationReq);
-            rT.reason += "insulinReq " + insulinReq + ". "
-            if (durationReq > 0) {
-                rT.reason += "Setting " + durationReq + "m zero temp. "
+            rT.reason += "insulinReq " + insulinReq;
+            if (insulinReq == round(maxBolus,1)) {
+                rT.reason +=  "; maxBolus " + maxBolus;
             }
+            if (durationReq > 0) {
+                rT.reason += "; setting " + durationReq + "m zero temp";
+            }
+            rT.reason += ". ";
 
             //allow SMBs every 3 minutes
             var nextBolusMins = round(3-lastBolusAge,1);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -72,12 +72,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (bg < 39) {  //Dexcom is in ??? mode or calibrating
         rT.reason = "CGM is calibrating or in ??? state";
         if (basal <= currenttemp.rate * 1.2) { // high temp is running
-            rT.reason += "; setting current basal of " + basal + " as temp";
+            rT.reason += "; setting current basal of " + basal + " as temp. ";
             rT.deliverAt = deliverAt;
             rT.temp = 'absolute';
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         } else { //do nothing.
-            rT.reason += ", temp " + currenttemp.rate + " <~ current basal " + basal + "U/hr";
+            rT.reason += ", temp " + currenttemp.rate + " <~ current basal " + basal + "U/hr. ";
             return rT;
         }
     }
@@ -100,7 +100,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (typeof profile.min_bg !== 'undefined' && typeof profile.max_bg !== 'undefined') {
             target_bg = (profile.min_bg + profile.max_bg) / 2;
         } else {
-            rT.error ='Error: could not determine target_bg';
+            rT.error ='Error: could not determine target_bg. ';
             return rT;
         }
     }
@@ -124,7 +124,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     if (typeof iob_data === 'undefined' ) {
-        rT.error ='Error: iob_data undefined';
+        rT.error ='Error: iob_data undefined. ';
         return rT;
     }
 
@@ -135,7 +135,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     if (typeof iob_data.activity === 'undefined' || typeof iob_data.iob === 'undefined' ) {
-        rT.error ='Error: iob_data missing some property';
+        rT.error ='Error: iob_data missing some property. ';
         return rT;
     }
 
@@ -218,7 +218,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     var expectedDelta = calculate_expected_delta(profile.dia, target_bg, eventualBG, bgi);
     if (typeof eventualBG === 'undefined' || isNaN(eventualBG)) {
-        rT.error ='Error: could not calculate eventualBG';
+        rT.error ='Error: could not calculate eventualBG. ';
         return rT;
     }
 
@@ -531,10 +531,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             rT.reason += ", min delta " + minDelta.toFixed(2) + ">0";
         }
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
             return rT;
         } else {
-            rT.reason += "; setting current basal of " + basal + " as temp";
+            rT.reason += "; setting current basal of " + basal + " as temp. ";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     }
@@ -545,7 +545,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (minDelta > expectedDelta && minDelta > 0) {
             // if naive_eventualBG < 40, set a 30m zero temp (oref0-pump-loop will let any longer SMB zero temp run)
             if (naive_eventualBG < 40) {
-                rT.reason += ", naive_eventualBG < 40";
+                rT.reason += ", naive_eventualBG < 40. ";
                 return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
             }
             if (glucose_status.delta > minDelta) {
@@ -554,10 +554,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 rT.reason += ", but Min. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
             }
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
                 return rT;
             } else {
-                rT.reason += "; setting current basal of " + basal + " as temp";
+                rT.reason += "; setting current basal of " + basal + " as temp. ";
                 return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
             }
         }
@@ -570,10 +570,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                     rT.reason += ", bolus snooze: eventual BG range " + convert_bg(eventualBG, profile) + "-" + convert_bg(snoozeBG, profile);
                     //console.error(currenttemp, basal );
                     if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                        rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+                        rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
                         return rT;
                     } else {
-                        rT.reason += "; setting current basal of " + basal + " as temp";
+                        rT.reason += "; setting current basal of " + basal + " as temp. ";
                         return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
                     }
                 }
@@ -602,11 +602,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 // by both normal and naive calculations, then raise the rate
                 var minInsulinReq = Math.min(insulinReq,naiveInsulinReq);
                 if (insulinScheduled < minInsulinReq - basal*0.3) {
-                    rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate).toFixed(2) + " is a lot less than needed";
+                    rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate).toFixed(2) + " is a lot less than needed. ";
                     return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
                 }
                 if (typeof currenttemp.rate !== 'undefined' && (currenttemp.duration > 5 && rate >= currenttemp.rate * 0.8)) {
-                    rT.reason += ", temp " + currenttemp.rate + " ~< req " + rate + "U/hr";
+                    rT.reason += ", temp " + currenttemp.rate + " ~< req " + rate + "U/hr. ";
                     return rT;
                 } else {
                     // calculate a long enough zero temp to eventually correct back up to target
@@ -638,7 +638,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                             }
                         //}
                     } else {
-                        rT.reason += ", setting " + rate + "U/hr";
+                        rT.reason += ", setting " + rate + "U/hr. ";
                     }
                     return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
                 }
@@ -679,10 +679,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Min. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + expectedDelta;
             }
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
                 return rT;
             } else {
-                rT.reason += "; setting current basal of " + basal + " as temp";
+                rT.reason += "; setting current basal of " + basal + " as temp. ";
                 return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
             }
         }
@@ -691,7 +691,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (Math.min(eventualBG,snoozeBG,minPredBG) < max_bg) {
         // if there is a high-temp running and eventualBG > max_bg, let it run
         if (eventualBG > max_bg && round_basal(currenttemp.rate, profile) > round_basal(basal, profile) ) {
-            rT.reason += eventualBG + " > " + max_bg + ": no action required (letting high temp of " + currenttemp.rate + " run)."
+            rT.reason += eventualBG + " > " + max_bg + ": no action required (letting high temp of " + currenttemp.rate + " run). "
             return rT;
         }
 
@@ -699,10 +699,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (! (microBolusAllowed && enableSMB )) {
             rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(Math.min(minPredBG,snoozeBG), profile)+" in range: no temp required";
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
                 return rT;
             } else {
-                rT.reason += "; setting current basal of " + basal + " as temp";
+                rT.reason += "; setting current basal of " + basal + " as temp. ";
                 return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
             }
         }
@@ -808,22 +808,22 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
         var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
         if (insulinScheduled >= insulinReq * 2) { // if current temp would deliver >2x more than the required insulin, lower the rate
-            rT.reason += currenttemp.duration + "m@" + (currenttemp.rate).toFixed(2) + " > 2 * insulinReq. Setting temp basal of " + rate + "U/hr";
+            rT.reason += currenttemp.duration + "m@" + (currenttemp.rate).toFixed(2) + " > 2 * insulinReq. Setting temp basal of " + rate + "U/hr. ";
             return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
         }
 
         if (typeof currenttemp.duration == 'undefined' || currenttemp.duration == 0) { // no temp is set
-            rT.reason += "no temp, setting " + rate + "U/hr";
+            rT.reason += "no temp, setting " + rate + "U/hr. ";
             return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
         }
 
         if (currenttemp.duration > 5 && (round_basal(rate, profile) <= round_basal(currenttemp.rate, profile))) { // if required temp <~ existing temp basal
-            rT.reason += "temp " + currenttemp.rate + " >~ req " + rate + "U/hr";
+            rT.reason += "temp " + currenttemp.rate + " >~ req " + rate + "U/hr. ";
             return rT;
         }
 
         // required temp > existing temp basal
-        rT.reason += "temp " + currenttemp.rate + "<" + rate + "U/hr";
+        rT.reason += "temp " + currenttemp.rate + "<" + rate + "U/hr. ";
         return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
     }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -774,6 +774,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             var smbTarget = target_bg;
             var worstCaseInsulinReq = (smbTarget - (naive_eventualBG + minIOBPredBG)/2 ) / sens;
             var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
+
+            // if no microBolus required, and lastCOBpredBG > target_bg, don't set a zero temp
+            if (microBolus < 0.1 && lastCOBpredBG > target_bg) {
+                durationReq = 0;
+            }
+
             if (durationReq < 0) {
                 durationReq = 0;
             // don't set a temp longer than 120 minutes

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -522,6 +522,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile) + "; ";
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted
+            // TODO: carbsReq
             return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         }
         if (glucose_status.delta > minDelta) {
@@ -610,7 +611,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 } else {
                     // calculate a long enough zero temp to eventually correct back up to target
                     if ( rate < 0 ) {
-                        var bgUndershoot = target_bg - (naive_eventualBG + minIOBPredBG)/2;
+                        var bgUndershoot = target_bg - naive_eventualBG;
                         var worstCaseInsulinReq = bgUndershoot / sens;
                         var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
                         if (durationReq < 0) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -776,7 +776,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
             rT.reason += " insulinReq " + insulinReq;
             console.error("maxBolus:",maxBolus);
-            if (microBolus >= maxBolus-0.1) {
+            if (microBolus >= maxBolus) {
                 rT.reason +=  "; maxBolus " + maxBolus;
             }
             if (durationReq > 0) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -759,7 +759,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // only microbolus if insulinReq represents 20m or more of basal
         if (microBolusAllowed && enableSMB) {
             // never bolus more than 30m worth of basal
-            maxBolus = profile.current_basal/2;
+            maxBolus = round(profile.current_basal/2,1);
             // bolus 1/3 the insulinReq, up to maxBolus
             microBolus = round(Math.min(insulinReq/3,maxBolus),1);
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -783,9 +783,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 durationReq = round(durationReq/30)*30;
                 durationReq = Math.min(120,Math.max(0,durationReq));
             }
-            //console.error(durationReq);
             rT.reason += "insulinReq " + insulinReq;
-            if (insulinReq == round(maxBolus,1)) {
+            console.error("maxBolus:",maxBolus);
+            if (insulinReq >= maxBolus-0.1) {
                 rT.reason +=  "; maxBolus " + maxBolus;
             }
             if (durationReq > 0) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -518,7 +518,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += ", UAMpredBG " + convert_bg(lastUAMpredBG, profile)
     }
     rT.reason += "; ";
-    var bgUndershoot = target_bg - naive_eventualBG;
+    var bgUndershoot = target_bg - Math.max( naive_eventualBG, eventualBG, lastIOBpredBG );
     // BG undershoot, minus effect of 30m zero temp, converted to grams, minus COB
     var zeroTempEffect = profile.current_basal*sens*30/60;
     var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -519,7 +519,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
     rT.reason += "; ";
     if (bg < threshold) { // low glucose suspend mode: BG is < ~80
-        rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile);
+        rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile) + "; ";
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted
             return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -785,7 +785,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
             rT.reason += "insulinReq " + insulinReq;
             console.error("maxBolus:",maxBolus);
-            if (insulinReq >= maxBolus-0.1) {
+            if (microBolus >= maxBolus-0.1) {
                 rT.reason +=  "; maxBolus " + maxBolus;
             }
             if (durationReq > 0) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -633,7 +633,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                         console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
                         //if (durationReq > 30) {
                             if ( carbsReq > 0 ) {
-                                rT.reason += "(~" + carbsReq + " add'l carbs + 30m zero temp)";
+                                rT.reason += "(~" + carbsReq + " add'l carbs + 30m zero temp) ";
                             }
                         //}
                     } else {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -494,7 +494,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // make sure minPredBG isn't higher than avgPredBG
     minPredBG = Math.min( minPredBG, avgPredBG );
 
-    console.error("minPredBG:",minPredBG,"minIOBPredBG:",minIOBPredBG,"minCOBPredBG:",minCOBPredBG,"minUAMPredBG:",minUAMPredBG,"avgPredBG:",avgPredBG,"COB:",meal_data.mealCOB,"carbs:",meal_data.carbs);
+    process.stderr.write("minPredBG: "+minPredBG+" minIOBPredBG: "+minIOBPredBG);
+    if (minCOBPredBG < 400) {
+        process.stderr.write(" minCOBPredBG: "+minCOBPredBG);
+    }
+    if (minUAMPredBG < 400) {
+        process.stderr.write(" minUAMPredBG: "+minUAMPredBG);
+    }
+    console.error(" avgPredBG:",avgPredBG,"COB:",meal_data.mealCOB,"carbs:",meal_data.carbs);
     // But if the COB line falls off a cliff, don't trust UAM too much:
     // use maxCOBPredBG if it's been set and lower than minPredBG
     if ( maxCOBPredBG > bg ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -763,8 +763,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //console.error(lastBolusAge);
         //console.error(profile.temptargetSet, target_bg, rT.COB);
         // only allow microboluses with COB or low temp targets, or within DIA hours of a bolus
-        // only microbolus if insulinReq represents 20m or more of basal
-        if (microBolusAllowed && enableSMB) {
+        // only microbolus if 0.1U SMB represents 20m or less of basal (0.3U/hr or higher)
+        if (microBolusAllowed && enableSMB && profile.current_basal >= 0.3) {
             // never bolus more than 30m worth of basal
             maxBolus = round(profile.current_basal/2,1);
             // bolus 1/3 the insulinReq, up to maxBolus

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -637,6 +637,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                         if (durationReq > 0) {
                             rT.reason += ", setting " + durationReq + "m zero temp. ";
                         }
+                        return tempBasalFunctions.setTempBasal(rate, durationReq, profile, rT, currenttemp);
                     } else {
                         rT.reason += ", setting " + rate + "U/hr. ";
                     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -582,8 +582,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if (eventualBG < min_bg) {
             // if we've bolused recently, we can snooze until the bolus IOB decays (at double speed)
             if (snoozeBG > min_bg) { // if adding back in the bolus contribution BG would be above min
-                // If we're in SMB mode with COB, disable bolus snooze
-                if (! (microBolusAllowed && rT.COB)) {
+                // If we're not in SMB mode with COB, or lastCOBpredBG > target_bg, bolus snooze
+                if (! (microBolusAllowed && rT.COB) || lastCOBpredBG > target_bg) {
                     rT.reason += ", bolus snooze: eventual BG range " + convert_bg(eventualBG, profile) + "-" + convert_bg(snoozeBG, profile);
                     //console.error(currenttemp, basal );
                     if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -637,16 +637,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                         if (durationReq > 0) {
                             rT.reason += ", setting " + durationReq + "m zero temp. ";
                         }
-                        // BG undershoot, minus effect of 30m zero temp, converted to grams, minus COB
-                        var zeroTempEffect = profile.current_basal*sens*30/60;
-                        var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;
-                        zeroTempEffect = round(zeroTempEffect);
-                        carbsReq = round(carbsReq);
-                        console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
-                        if ( carbsReq > 0 ) {
-                            rT.carbsReq = carbsReq;
-                            rT.reason += "(~" + carbsReq + " add'l carbs + 30m zero temp) ";
-                        }
                     } else {
                         rT.reason += ", setting " + rate + "U/hr. ";
                     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -633,7 +633,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                         console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
                         //if (durationReq > 30) {
                             if ( carbsReq > 0 ) {
-                                rT.reason += "(~" + carbsReq + "add'l carbs + 30m zero temp)";
+                                rT.reason += "(~" + carbsReq + " add'l carbs + 30m zero temp)";
                             }
                         //}
                     } else {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -518,21 +518,21 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += ", UAMpredBG " + convert_bg(lastUAMpredBG, profile)
     }
     rT.reason += "; ";
+    var bgUndershoot = target_bg - naive_eventualBG;
+    // BG undershoot, minus effect of 30m zero temp, converted to grams, minus COB
+    var zeroTempEffect = profile.current_basal*sens*30/60;
+    var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;
+    zeroTempEffect = round(zeroTempEffect);
+    carbsReq = round(carbsReq);
+    console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
+    if ( carbsReq > 0 ) {
+        rT.carbsReq = carbsReq;
+        rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
+    }
     if (bg < threshold) { // low glucose suspend mode: BG is < ~80
         rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile) + "; ";
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted
-            var bgUndershoot = target_bg - naive_eventualBG;
-            // BG undershoot, minus effect of 30m zero temp, converted to grams, minus COB
-            var zeroTempEffect = profile.current_basal*sens*30/60;
-            var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;
-            zeroTempEffect = round(zeroTempEffect);
-            carbsReq = round(carbsReq);
-            console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
-            if ( carbsReq > 0 ) {
-                rT.carbsReq = carbsReq;
-                rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
-            }
             return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         }
         if (glucose_status.delta > minDelta) {
@@ -551,6 +551,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     if (eventualBG < min_bg) { // if eventual BG is below target:
         rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " < " + convert_bg(min_bg, profile);
+        // TODO: carbsReq
         // if 5m or 30m avg BG is rising faster than expected delta
         if (minDelta > expectedDelta && minDelta > 0) {
             // if naive_eventualBG < 40, set a 30m zero temp (oref0-pump-loop will let any longer SMB zero temp run)
@@ -783,7 +784,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 durationReq = round(durationReq/30)*30;
                 durationReq = Math.min(120,Math.max(0,durationReq));
             }
-            rT.reason += "insulinReq " + insulinReq;
+            rT.reason += " insulinReq " + insulinReq;
             console.error("maxBolus:",maxBolus);
             if (microBolus >= maxBolus-0.1) {
                 rT.reason +=  "; maxBolus " + maxBolus;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -691,7 +691,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (Math.min(eventualBG,snoozeBG,minPredBG) < max_bg) {
         // if there is a high-temp running and eventualBG > max_bg, let it run
         if (eventualBG > max_bg && round_basal(currenttemp.rate, profile) > round_basal(basal, profile) ) {
-            rT.reason += eventualBG + " > " + max_bg + ": no action required (letting high temp of " + currenttemp.rate + " run). "
+            rT.reason += eventualBG + " > " + max_bg + ": no temp required (letting high temp of " + currenttemp.rate + " run). "
             return rT;
         }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -522,7 +522,17 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile) + "; ";
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted
-            // TODO: carbsReq
+            var bgUndershoot = target_bg - naive_eventualBG;
+            // BG undershoot, minus effect of 30m zero temp, converted to grams, minus COB
+            var zeroTempEffect = profile.current_basal*sens*30/60;
+            var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;
+            zeroTempEffect = round(zeroTempEffect);
+            carbsReq = round(carbsReq);
+            console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
+            if ( carbsReq > 0 ) {
+                rT.carbsReq = carbsReq;
+                rT.reason += "~" + carbsReq + " add'l carbs + 30m zero temp; ";
+            }
             return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         }
         if (glucose_status.delta > minDelta) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -535,7 +535,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.carbsReq = carbsReq;
         rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
     }
-    if (bg < threshold) { // low glucose suspend mode: BG is < ~80
+    // low glucose suspend mode: BG is < ~80 and IOB > 20m worth of basal
+    if (bg < threshold && iob_data.iob > profile.current_basal*sens*20/60) {
         rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile) + "; ";
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -717,10 +717,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (basaliob > max_iob) {
         rT.reason += "basaliob " + round(basaliob,2) + " > max_iob " + max_iob;
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr";
+            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
             return rT;
         } else {
-            rT.reason += "; setting current basal of " + basal + " as temp";
+            rT.reason += "; setting current basal of " + basal + " as temp. ";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     } else { // otherwise, calculate 30m high-temp required to get projected BG down to target

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -610,7 +610,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 } else {
                     // calculate a long enough zero temp to eventually correct back up to target
                     if ( rate < 0 ) {
-                        var worstCaseInsulinReq = (target_bg - (naive_eventualBG + minIOBPredBG)/2 ) / sens;
+                        var bgUndershoot = target_bg - (naive_eventualBG + minIOBPredBG)/2;
+                        var worstCaseInsulinReq = bgUndershoot / sens;
                         var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
                         if (durationReq < 0) {
                             durationReq = 0;
@@ -625,13 +626,16 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                             rT.reason += ", setting " + durationReq + "m zero temp. ";
                         }
                         // BG undershoot, minus effect of 30m zero temp, converted to grams, minus COB
-                        var carbsReq = (target_bg - (naive_eventualBG + minIOBPredBG)/2 - (profile.current_basal/2*sens) ) / csf - meal_data.mealCOB;
-                        console.error("carbsReq:",carbsReq);
-                        if (durationReq > 30) {
+                        var zeroTempEffect = profile.current_basal*sens*30/60;
+                        var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;
+                        zeroTempEffect = round(zeroTempEffect);
+                        carbsReq = round(carbsReq);
+                        console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
+                        //if (durationReq > 30) {
                             if ( carbsReq > 0 ) {
                                 rT.reason += "(~" + carbsReq + "add'l carbs + 30m zero temp)";
                             }
-                        }
+                        //}
                     } else {
                         rT.reason += ", setting " + rate + "U/hr";
                     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -634,6 +634,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                         console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
                         //if (durationReq > 30) {
                             if ( carbsReq > 0 ) {
+                                rT.carbsReq = carbsReq;
                                 rT.reason += "(~" + carbsReq + " add'l carbs + 30m zero temp) ";
                             }
                         //}

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -775,8 +775,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             var worstCaseInsulinReq = (smbTarget - (naive_eventualBG + minIOBPredBG)/2 ) / sens;
             var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
 
-            // if no microBolus required, and lastCOBpredBG > target_bg, don't set a zero temp
-            if (microBolus < 0.1 && lastCOBpredBG > target_bg) {
+            // if no microBolus required, snoozeBG > target_bg, and lastCOBpredBG > target_bg, don't set a zero temp
+            if (microBolus < 0.1 && snoozeBG > target_bg && lastCOBpredBG > target_bg) {
                 durationReq = 0;
             }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -531,7 +531,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
             if ( carbsReq > 0 ) {
                 rT.carbsReq = carbsReq;
-                rT.reason += "~" + carbsReq + " add'l carbs + 30m zero temp; ";
+                rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
             }
             return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         }
@@ -642,12 +642,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                         zeroTempEffect = round(zeroTempEffect);
                         carbsReq = round(carbsReq);
                         console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
-                        //if (durationReq > 30) {
-                            if ( carbsReq > 0 ) {
-                                rT.carbsReq = carbsReq;
-                                rT.reason += "(~" + carbsReq + " add'l carbs + 30m zero temp) ";
-                            }
-                        //}
+                        if ( carbsReq > 0 ) {
+                            rT.carbsReq = carbsReq;
+                            rT.reason += "(~" + carbsReq + " add'l carbs + 30m zero temp) ";
+                        }
                     } else {
                         rT.reason += ", setting " + rate + "U/hr. ";
                     }
@@ -719,12 +717,15 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
-    // eventual BG is at/above target:
+    // eventual BG is at/above target (or bolus snooze disabled for SMB)
     // if iob is over max, just cancel any temps
     var basaliob;
     if (iob_data.basaliob) { basaliob = iob_data.basaliob; }
     else { basaliob = iob_data.iob - iob_data.bolussnooze; }
-    rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " >= " +  convert_bg(max_bg, profile) + ", ";
+    // if we're not here because of SMB, eventual BG is at/above target
+    if (! (microBolusAllowed && rT.COB)) {
+        rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " >= " +  convert_bg(max_bg, profile) + ", ";
+    }
     if (basaliob > max_iob) {
         rT.reason += "basaliob " + round(basaliob,2) + " > max_iob " + max_iob;
         if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -635,8 +635,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                         //rT.reason += "insulinReq " + insulinReq + "; "
                         if (durationReq > 0) {
                             rT.reason += ", setting " + durationReq + "m zero temp. ";
+                            return tempBasalFunctions.setTempBasal(rate, durationReq, profile, rT, currenttemp);
                         }
-                        return tempBasalFunctions.setTempBasal(rate, durationReq, profile, rT, currenttemp);
                     } else {
                         rT.reason += ", setting " + rate + "U/hr. ";
                     }

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -64,7 +64,6 @@ function diaCarbs(opts, time) {
     //console.error(c.currentDeviation, c.minDeviationSlope);
 
     // set a hard upper limit on COB to mitigate impact of erroneous or malicious carb entry
-    // TODO: make this configurable with a much lower default
     mealCOB = Math.min( profile.maxCOB, mealCOB );
 
     return {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "oref0-online": "./bin/oref0-online.sh",
     "oref0-pebble": "./bin/oref0-pebble.js",
     "oref0-pump-loop": "./bin/oref0-pump-loop.sh",
+    "oref0-pushover": "./bin/oref0-pushover.sh",
     "oref0-radio-reboot": "./bin/oref0-radio-reboot.sh",
     "oref0-raw": "./bin/oref0-raw.js",
     "oref0-reset-git": "bin/oref0-reset-git.sh",

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -109,12 +109,12 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":-5,"glucose":75,"long_avgdelta":-5,"short_avgdelta":-5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
-        output.duration.should.equal(30);
+        output.duration.should.be.above(29);
         //output.reason.should.match(/BG 75<80/);
     });
 
-    it('should not extend temp to 0 when >20m left', function () {
-        var currenttemp = {"duration":27,"rate":0,"temp":"absolute"};
+    it('should not extend temp to 0 when <10m elapsed', function () {
+        var currenttemp = {"duration":57,"rate":0,"temp":"absolute"};
         var glucose_status = {"delta":-5,"glucose":75,"long_avgdelta":-5,"short_avgdelta":-5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
@@ -163,8 +163,9 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":-1,"glucose":75,"long_avgdelta":-1,"short_avgdelta":-1};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
+        //console.log(output);
         output.rate.should.equal(0);
-        output.duration.should.equal(30);
+        output.duration.should.be.above(29);
         //output.reason.should.match(/BG 75<80/);
     });
 
@@ -290,7 +291,7 @@ describe('determine-basal', function ( ) {
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.be.below(0.2);
-        output.duration.should.equal(30);
+        output.duration.should.be.above(29);
         //output.reason.should.match(/Eventual BG .*< 110.*setting .*/);
     });
 
@@ -474,17 +475,17 @@ describe('determine-basal', function ( ) {
 
     it('profile should contain min_bg,max_bg or target_bg', function () {
       var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0}, undefined, meal_data, tempBasalFunctions);
-      result.error.should.equal('Error: could not determine target_bg');
+      result.error.should.equal('Error: could not determine target_bg. ');
     });
 
     it('iob_data should not be undefined', function () {
       var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0, "target_bg":100}, undefined, meal_data, tempBasalFunctions);
-      result.error.should.equal('Error: iob_data undefined');
+      result.error.should.equal('Error: iob_data undefined. ');
     });
 
     it('iob_data should contain activity, iob, bolussnooze', function () {
       var result = determine_basal({glucose:100}, undefined,{"activity":0}, {"current_basal":0.0, "target_bg":100}, undefined, meal_data, tempBasalFunctions);
-      result.error.should.equal('Error: iob_data missing some property');
+      result.error.should.equal('Error: iob_data missing some property. ');
     });
 
 /*

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -250,16 +250,16 @@ describe('determine-basal', function ( ) {
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
-        output.duration.should.equal(30);
+        output.duration.should.be.above(29);
         //output.reason.should.match(/BG 39<80/);
     });
 
-    it('should temp to 0 when LOW w/ negative IOB', function () {
+    it('should low temp when LOW w/ negative IOB', function () {
         var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0,"short_avgdelta":0};
         var iob_data = {"iob":-2.5,"activity":-0.03,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
-        output.rate.should.equal(0);
-        output.duration.should.equal(30);
+        output.rate.should.be.below(0.8);
+        output.duration.should.be.above(29);
         //output.reason.should.match(/BG 39<80/);
     });
 
@@ -268,7 +268,7 @@ describe('determine-basal', function ( ) {
         var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
-        output.duration.should.equal(30);
+        output.duration.should.be.above(29);
         //output.reason.should.match(/BG 39<80/);
     });
 


### PR DESCRIPTION
Most significant changes in this PR, in order of appearance in the diff:

- oref0-online updates for stability
- oref0-set-device-clocks if pump clock is >1m off
- oref0-set-system-clock if determine-basal complains it's set incorrectly
- support for oref1 pushover alerts of insulinReq and carbsReq
- allow non-SMB code paths to set temps up to 120 minutes when needed
- allow non-zero temps in SMB mode when lastCOBpredBG > target_bg
- don't SMB if basal is < 0.3 U/hr (if 0.1U SMB represents >20m of basal)