### PR TITLE
Add MDT Enlite CGM support to oref0-pump-loop for SMB

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -217,7 +217,7 @@ function prep {
 }
 
 function if_mdt_get_bg {
-    if grep "MDT cgm" openaps.ini
+    if grep "MDT cgm" openaps.ini; then
         openaps get-bg
     fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -226,7 +226,7 @@ function preflight {
     # only 515, 522, 523, 715, 722, and 723 pump models have been tested with SMB
     openaps report invoke settings/model.json 2>&1 >/dev/null | tail -1 \
     && egrep -q "[57](15|22|23)" settings/model.json \
-    && echo -n "Preflight OK. " \
+    && echo -n "Preflight OK. "
 }
 
 # reset radio, init world wide pump (if applicable), mmtune, and wait_for_silence 60 if no signal

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -384,7 +384,7 @@ function low_battery_wait {
 }
 
 function wait_for_bg {
-    if grep "MDT cgm" openaps.ini
+    if grep "MDT cgm" openaps.ini; then
         echo "MDT CGM configured; not waiting"
     else
         echo -n "Waiting up to 4 minutes for new BG: "


### PR DESCRIPTION
This checks whether the get-bg alias is configured for a MDT CGM, and if so, skips the wait_for_bg (since we have to talk to the pump anyway to get BG data) and performs `openaps get-bg` as the MDT `openaps pump-loop` alias does, right after wait-for-silence.  Needs testing by @ericfeibelman and anyone else trying to run MDT CGM with SMB.