### PR TITLE
Fix low glucose suspend

### DIFF
--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -30,7 +30,7 @@ var round_basal = require('./round-basal');
 
     var suggestedRate = round_basal(rate, profile);
     if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && currenttemp.duration <= 120 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
-        rT.reason += currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
+        rT.reason += " "+currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
         return rT;
     }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -537,7 +537,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
     // don't low glucose suspend if IOB is already super negative and BG is rising faster than predicted
     if (iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {
-        rT.reason += "IOB < " + round(-profile.current_basal*20/60,2);
+        rT.reason += "IOB "+iob_data.iob+" < " + round(-profile.current_basal*20/60,2);
         rT.reason += " and minDelta " + minDelta + " > " + "expectedDelta " + expectedDelta + "; ";
     }
     // low glucose suspend mode: BG is < ~80

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -535,8 +535,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.carbsReq = carbsReq;
         rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
     }
-    // low glucose suspend mode: BG is < ~80 and IOB > 20m worth of basal
-    if (bg < threshold && iob_data.iob > profile.current_basal*sens*20/60) {
+    // don't low glucose suspend if IOB > - 20m worth of basal and BG is rising faster than predicted
+    if (iob_data.iob > -profile.current_basal*sens*20/60 && minDelta > 0 && minDelta > expectedDelta) {
+        rT.reason += "IOB > " + -profile.current_basal*sens*20/60;
+        rT.reason += "and minDelta " + minDelta + " > " + "expectedDelta " expectedDelta + "; ";
+    }
+    // low glucose suspend mode: BG is < ~80
+    else if (bg < threshold) {
         rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile) + "; ";
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -538,7 +538,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // don't low glucose suspend if IOB > - 20m worth of basal and BG is rising faster than predicted
     if (iob_data.iob > -profile.current_basal*sens*20/60 && minDelta > 0 && minDelta > expectedDelta) {
         rT.reason += "IOB > " + -profile.current_basal*sens*20/60;
-        rT.reason += "and minDelta " + minDelta + " > " + "expectedDelta " expectedDelta + "; ";
+        rT.reason += "and minDelta " + minDelta + " > " + "expectedDelta " + expectedDelta + "; ";
     }
     // low glucose suspend mode: BG is < ~80
     else if (bg < threshold) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -536,7 +536,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
     }
     // don't low glucose suspend if IOB is already super negative and BG is rising faster than predicted
-    if (iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {
+    if (bg < threshold && iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {
         rT.reason += "IOB "+iob_data.iob+" < " + round(-profile.current_basal*20/60,2);
         rT.reason += " and minDelta " + minDelta + " > " + "expectedDelta " + expectedDelta + "; ";
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -535,9 +535,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.carbsReq = carbsReq;
         rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
     }
-    // don't low glucose suspend if IOB > - 20m worth of basal and BG is rising faster than predicted
-    if (iob_data.iob > -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {
-        rT.reason += "IOB > " + round(-profile.current_basal*20/60,2);
+    // don't low glucose suspend if IOB is already super negative and BG is rising faster than predicted
+    if (iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {
+        rT.reason += "IOB < " + round(-profile.current_basal*20/60,2);
         rT.reason += " and minDelta " + minDelta + " > " + "expectedDelta " + expectedDelta + "; ";
     }
     // low glucose suspend mode: BG is < ~80

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -536,15 +536,16 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
     }
     // don't low glucose suspend if IOB > - 20m worth of basal and BG is rising faster than predicted
-    if (iob_data.iob > -profile.current_basal*sens*20/60 && minDelta > 0 && minDelta > expectedDelta) {
-        rT.reason += "IOB > " + -profile.current_basal*sens*20/60;
-        rT.reason += "and minDelta " + minDelta + " > " + "expectedDelta " + expectedDelta + "; ";
+    if (iob_data.iob > -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {
+        rT.reason += "IOB > " + round(-profile.current_basal*20/60,2);
+        rT.reason += " and minDelta " + minDelta + " > " + "expectedDelta " + expectedDelta + "; ";
     }
     // low glucose suspend mode: BG is < ~80
     else if (bg < threshold) {
-        rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile) + "; ";
+        rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile);
         if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
             // BG is still falling / rising slower than predicted
+            rT.reason += ", minDelta " + minDelta + " < " + "expectedDelta " + expectedDelta + "; ";
             return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         }
         if (glucose_status.delta > minDelta) {
@@ -572,7 +573,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
             }
             if (glucose_status.delta > minDelta) {
-                rT.reason += ", but Delta " + tick + " > Exp. Delta " + expectedDelta;
+                rT.reason += ", but Delta " + tick + " > expectedDelta " + expectedDelta;
             } else {
                 rT.reason += ", but Min. Delta " + minDelta.toFixed(2) + " > Exp. Delta " + expectedDelta;
             }


### PR DESCRIPTION
One of the changes merged to dev from the pushover branch attempted to disable low glucose suspend mode when IOB was highly negative, but that change went too far and mostly disabled LGS.  This fixes LGS to only be disabled when IOB is already super negative and BG is rising faster than predicted (such as from a meal eaten after a long period of zero temping).  It also adds that information to the reason field when disabling LGS.