### PR TITLE
Adding a check for existing autotune folder. If it does not exist, warn user that microbolus-related features will be disabled.

### DIFF
--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -102,29 +102,24 @@ if (!module.parent) {
         return console.error("Could not parse input data: ", e);
     }
 
+    //attempting to provide a check for autotune
+    //if autotune directory does not exist, SMB/oref1 should not be able to run
 
+    // console.error("Printing this so you know it's getting to the check for autotune.")
 
-//attempting to provide a check for autotune
-//if autotune directory does not exist, SMB/oref1 should not be able to run
-
-// console.error("Printing this so you know it's getting to the check for autotune.")
-
-//printing microbolus before attempting check
-console.error("Microbolus var is currently set to: ",params['microbolus']);
-
-if (fs.existsSync("autotune")) {
-    console.error("Autotune exists! Hoorah!")
-    }
-else {
-    console.error("Warning: Autotune has not been run. All microboluses will be disabled until you manually run autotune or add it to run nightly in your loop.");
-    params['microbolus'] = false;
+    //printing microbolus before attempting check
     console.error("Microbolus var is currently set to: ",params['microbolus']);
+
+    if (params['microbolus']) {
+        if (fs.existsSync("autotune")) {
+            console.error("Autotune exists! Hoorah! You can use microbolus-related features.")
+        } else {
+            console.error("Warning: Autotune has not been run. All microboluses will be disabled until you manually run autotune or add it to run nightly in your loop.");
+            params['microbolus'] = false;
+            console.error("Microbolus var is currently set to: ",params['microbolus']);
+        }
     }
-
-
-
-
-
+	
     //console.log(carbratio_data);
     var meal_data = { };
     //console.error("meal_input",meal_input);

--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -102,6 +102,29 @@ if (!module.parent) {
         return console.error("Could not parse input data: ", e);
     }
 
+
+
+//attempting to provide a check for autotune
+//if autotune directory does not exist, SMB/oref1 should not be able to run
+
+// console.error("Printing this so you know it's getting to the check for autotune.")
+
+//printing microbolus before attempting check
+console.error("Microbolus var is currently set to: ",params['microbolus']);
+
+if (fs.existsSync("autotune")) {
+    console.error("Autotune exists! Hoorah!")
+    }
+else {
+    console.error("Warning: Autotune has not been run. All microboluses will be disabled until you manually run autotune or add it to run nightly in your loop.");
+    params['microbolus'] = false;
+    console.error("Microbolus var is currently set to: ",params['microbolus']);
+    }
+
+
+
+
+
     //console.log(carbratio_data);
     var meal_data = { };
     //console.error("meal_input",meal_input);

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -825,10 +825,11 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         echo Resetting spi_serial
         reset_spi_serial.py
     fi
-    echo Attempting to communicate with pump:
-    ( killall -g openaps; killall -g oref0-pump-loop ) 2>/dev/null
-    openaps mmtune
-    echo
+# Commenting out the mmtune as attempt to stop the radio reboot errors that happen when re-setting up. 
+#    echo Attempting to communicate with pump:
+#    ( killall -g openaps; killall -g oref0-pump-loop ) 2>/dev/null
+#    openaps mmtune
+#    echo
 
     read -p "Schedule openaps in cron? y/[N] " -r
     if [[ $REPLY =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
Per https://github.com/openaps/oref0/issues/468, this is a proposed solution to check for the presence of autotune directory folder, to further the strong recommendation that people only use oref1 features with well-tuned basals. This folder is created when someone’s enabled autotune to run nightly; or by running autotune manually.  

To test, grab the autotune-check branch.
You may want to uncomment line 110 (("Printing this so you know it's getting to the check for autotune.") to help you spot the output in the logs.

If you have autotune enabled already and running (and an existing directory), you should see the “Autotune exists! Hoorah!” message in your logs, along with a note about microbolus being set to true. 

To test this works properly, you then want to change the name of your autotune directory (ie. `mv autotune changedname`) and watch the logs. You should then see microbolus as true; followed by “Warning: Autotune has not been run. All microboluses will be disabled until you manually run autotune or add it to run nightly in your loop.", then microbolus = false. 

(Then go back in and re-change your name of autotune, via `mv changedname autotune). 