### PR TITLE
Smarter carbsReq

### DIFF
--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -108,7 +108,7 @@ if (!module.parent) {
     // console.error("Printing this so you know it's getting to the check for autotune.")
 
     //printing microbolus before attempting check
-    console.error("Microbolus var is currently set to: ",params['microbolus']);
+    //console.error("Microbolus var is currently set to: ",params['microbolus']);
 
     if (params['microbolus']) {
         if (fs.existsSync("autotune")) {
@@ -116,10 +116,10 @@ if (!module.parent) {
         } else {
             console.error("Warning: Autotune has not been run. All microboluses will be disabled until you manually run autotune or add it to run nightly in your loop.");
             params['microbolus'] = false;
-            console.error("Microbolus var is currently set to: ",params['microbolus']);
+            //console.error("Microbolus var is currently set to: ",params['microbolus']);
         }
     }
-	
+
     //console.log(carbratio_data);
     var meal_data = { };
     //console.error("meal_input",meal_input);
@@ -206,8 +206,8 @@ if (!module.parent) {
         var reason = "BG data is too old (it's probably this), or clock set incorrectly.  The last BG data was read at "+bgTime+" but your system time currently is "+systemTime;
         console.error(reason);
         var msg = {reason: reason }
-	console.log(JSON.stringify(msg));
-//        errors.push(msg);
+        console.log(JSON.stringify(msg));
+        // errors.push(msg);
         process.exit(1);
     }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -524,8 +524,31 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
     rT.reason += "; ";
     var bgUndershoot = target_bg - Math.max( naive_eventualBG, eventualBG, lastIOBpredBG );
-    // BG undershoot, minus effect of 30m zero temp, converted to grams, minus COB
-    var zeroTempEffect = profile.current_basal*sens*30/60;
+    // calculate how long until COB (or IOB) predBGs drop below min_bg
+    var minutesAboveMinBG = 240;
+    if (meal_data.mealCOB > 0 && ( ci > 0 || remainingCI > 0 )) {
+        for (var i=0; i<COBpredBGs.length; i++) {
+            //console.error(COBpredBGs[i], min_bg);
+            if ( COBpredBGs[i] < min_bg ) {
+                minutesAboveMinBG = 5*i;
+                break;
+            }
+        }
+    } else {
+        for (var i=0; i<IOBpredBGs.length; i++) {
+            //console.error(IOBpredBGs[i], min_bg);
+            if ( IOBpredBGs[i] < min_bg ) {
+                minutesAboveMinBG = 5*i;
+                break;
+            }
+        }
+    }
+
+    console.error("COBpredBG projected to remain above",min_bg,"for",minutesAboveMinBG,"minutes");
+    // include minutesAboveMinBG worth of zero temps in calculating carbsReq
+    var zeroTempDuration = minutesAboveMinBG;
+    // BG undershoot, minus effect of zero temps until hitting min_bg, converted to grams, minus COB
+    var zeroTempEffect = profile.current_basal*sens*zeroTempDuration/60;
     var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -544,7 +544,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
-    console.error("COBpredBG projected to remain above",min_bg,"for",minutesAboveMinBG,"minutes");
+    console.error("BG projected to remain above",min_bg,"for",minutesAboveMinBG,"minutes");
     // include minutesAboveMinBG worth of zero temps in calculating carbsReq
     var zeroTempDuration = minutesAboveMinBG;
     // BG undershoot, minus effect of zero temps until hitting min_bg, converted to grams, minus COB

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -545,8 +545,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     console.error("BG projected to remain above",min_bg,"for",minutesAboveMinBG,"minutes");
-    // include minutesAboveMinBG worth of zero temps in calculating carbsReq
-    var zeroTempDuration = minutesAboveMinBG;
+    // include at least minutesAboveMinBG worth of zero temps in calculating carbsReq
+    // always include at least 30m worth of zero temp (carbs to 80, low temp up to target)
+    var zeroTempDuration = Math.max(30,minutesAboveMinBG);
     // BG undershoot, minus effect of zero temps until hitting min_bg, converted to grams, minus COB
     var zeroTempEffect = profile.current_basal*sens*zeroTempDuration/60;
     var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -555,7 +555,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
     if ( carbsReq > 0 ) {
         rT.carbsReq = carbsReq;
-        rT.reason += "~" + carbsReq + " add'l carbs req + 30m zero temp; ";
+        rT.reason += "~" + carbsReq + " add'l carbs req + " + minutesAboveMinBG + "m zero temp; ";
     }
     // don't low glucose suspend if IOB is already super negative and BG is rising faster than predicted
     if (bg < threshold && iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -586,7 +586,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     if (eventualBG < min_bg) { // if eventual BG is below target:
         rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " < " + convert_bg(min_bg, profile);
-        // TODO: carbsReq
         // if 5m or 30m avg BG is rising faster than expected delta
         if (minDelta > expectedDelta && minDelta > 0) {
             // if naive_eventualBG < 40, set a 30m zero temp (oref0-pump-loop will let any longer SMB zero temp run)

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -553,7 +553,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);
-    console.error("bgUndershoot:",bgUndershoot,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
+    console.error("bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
     if ( carbsReq > 0 ) {
         rT.carbsReq = carbsReq;
         rT.reason += "~" + carbsReq + " add'l carbs req + " + minutesAboveMinBG + "m zero temp; ";


### PR DESCRIPTION
The current pushover alerts tend to false-alarm for carbsReq when BG is still high and there's plenty of time to prevent a low with SMB zero temps.  Rather than simply including 30m worth of zero temps in calculating carbsReq, this calculates how many minutes BG is expected to stay above min_bg (the low end of your target range) and includes that many minutes worth of zero temp in the carbsReq calculations.  So if you aren't projected to go low for 90 minutes, it'll include 90m worth of zero temps, and likely won't alarm prematurely for carbsReq.  If you're already below target, or projected to drop below target in just a few minutes, it'll be much more apt to pushover for carbsReq.