### PR TITLE
unsuspend pump automatically if temp basal duration is zero

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -217,8 +217,12 @@ function smb_bolus {
 function unsuspend_if_no_temp {
     # If temp basal duration is zero, unsuspend pump
     if (cat monitor/temp_basal.json | json -c "this.duration == 0" | grep -q duration); then
-        echo Temp basal has ended: unsuspending pump
-        openaps use pump resume_pump
+        if (grep -iq '"unsuspend_if_no_temp": true' preferences.json); then
+            echo Temp basal has ended: unsuspending pump
+            openaps use pump resume_pump
+        else
+            echo unsuspend_if_no_temp not enabled in preferences.json: leaving pump suspended
+        fi
     else
         # If temp basal duration is > zero, do nothing
         echo Temp basal still running: leaving pump suspended

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -227,7 +227,7 @@ function unsuspend_if_no_temp {
     else
         # If temp basal duration is > zero, do nothing
         echo Temp basal still running: leaving pump suspended
-    fi)
+    fi
 }
 
 # calculate random sleep intervals, and get TTY port

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -66,6 +66,7 @@ smb_main() {
     ); do
         if grep -q '"suspended": true' monitor/status.json; then
             echo -n "Pump suspended; "
+            unsuspend_if_no_temp
             smb_verify_status
         else
             echo Error, retrying && maybe_mmtune
@@ -212,6 +213,16 @@ function smb_bolus {
     else
         echo "No bolus needed (yet)"
     fi
+}
+function unsuspend_if_no_temp {
+    # If temp basal duration is zero, unsuspend pump
+    if (cat monitor/temp_basal.json | json -c "this.duration == 0" | grep -q duration); then
+        echo Temp basal has ended: unsuspending pump
+        openaps use pump resume_pump
+    else
+        # If temp basal duration is > zero, do nothing
+        echo Temp basal still running: leaving pump suspended
+    fi)
 }
 
 # calculate random sleep intervals, and get TTY port

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -64,6 +64,7 @@ smb_main() {
             && touch monitor/pump_loop_completed -r monitor/pump_loop_enacted \
             && echo \
     ); do
+        smb_verify_status
         if grep -q '"suspended": true' monitor/status.json; then
             echo -n "Pump suspended; "
             unsuspend_if_no_temp

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -21,6 +21,7 @@ function defaults ( ) {
     , maxCOB: 120
     , override_high_target_with_low: false // allows a much higher target used only for avoiding bolus wizard overcorrections
     , skip_neutral_temps: false // if true, don't set neutral temps
+    , unsuspend_if_no_temp: false // if true, pump will un-suspend after a zero temp finishes
     , bolussnooze_dia_divisor: 2 // bolus snooze decays after 1/2 of DIA
     , min_5m_carbimpact: 5 // mg/dL per 5m (corresponds to 15g/hr at a CSF of 4 mg/dL/g)
     , carbratio_adjustmentratio: 1 // if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus


### PR DESCRIPTION
Per https://github.com/openaps/oref0/issues/175, sometimes people forget to resume / unsuspend their pump after reconnecting it.  This would cause oref1 to automatically resume the pump if the underlying zero temp has expired.  As long as the zero temp is still running, it would honor the suspend status and do nothing.  As written, this would not apply to users running the old `openaps pump-loop`, only people who have enabled microboluses in oref0-setup and are using oref0-pump-loop.sh.

Thoughts?