### PR TITLE
Hotfix for mraa

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -509,7 +509,7 @@ if [[ "$ttyport" =~ "spi" ]]; then
         else
             echo -n "Cloning mraa "
             #(echo -n "master branch. " && cd ~/src && git clone -b master https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 dev
-            (echo -n "stable release ${MRAA_RELEASE}. " && cd $HOME/src && git clone -b ${MRAA_RELEASE} https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 master
+            (echo -n "stable release ${MRAA_RELEASE}. " && cd $HOME/src && git clone -b ${MRAA_RELEASE} https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa release ${MRAA_RELEASE}" # used for oref0 master
         fi
         ( cd $HOME/src/ && mkdir -p mraa/build && cd $_ && cmake .. -DBUILDSWIGNODE=OFF && \
         make && sudo make install && echo && touch /tmp/reboot-required && echo mraa installed. Please reboot before using. && echo ) || die "Could not compile mraa"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -500,13 +500,16 @@ if [[ "$ttyport" =~ "spi" ]]; then
     if ! ldconfig -p | grep -q mraa; then
         echo Installing swig etc.
         sudo apt-get install -y libpcre3-dev git cmake python-dev swig || die "Could not install swig etc."
+        MRAA_RELEASE="v1.7.0" # GitHub hash 8ddbcde84e2d146bc0f9e38504d6c89c14291480
 
         if [ -d "$HOME/src/mraa/" ]; then
-            echo "$HOME/src/mraa/ already exists; pulling latest master branch"
-            (cd ~/src/mraa && git fetch && git checkout master && git pull) || die "Couldn't pull latest mraa master"
+            echo -n "$HOME/src/mraa/ already exists; "
+            #(echo "Pulling latest master branch" && cd ~/src/mraa && git fetch && git checkout master && git pull) || die "Couldn't pull latest mraa master" # used for oref0 dev
+            (echo "Updating mraa source to stable release ${MRAA_RELEASE}" && cd $HOME/src/mraa && git fetch && git checkout ${MRAA_RELEASE} && git pull) || die "Couldn't pull latest mraa ${MRAA_RELEASE}  release" # used for oref0 master
         else
-            echo -n "Cloning mraa master: "
-            (cd ~/src && git clone -b master https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master"
+            echo -n "Cloning mraa "
+            #(echo -n "master branch. " && cd ~/src && git clone -b master https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 dev
+            (echo -n "stable release ${MRAA_RELEASE}. " && cd $HOME/src && git clone -b ${MRAA_RELEASE} https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 master
         fi
         ( cd $HOME/src/ && mkdir -p mraa/build && cd $_ && cmake .. -DBUILDSWIGNODE=OFF && \
         make && sudo make install && echo && touch /tmp/reboot-required && echo mraa installed. Please reboot before using. && echo ) || die "Could not compile mraa"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oref0",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",


### PR DESCRIPTION
For release 0.4.2 a github checkout of the master branch was used. Therefore a change in mraa could break openaps. For the master branch we
should always use a mraa release instead of a master branch checkout.

This fixes https://github.com/openaps/oref0/issues/500 and makes it possible again to install openaps.

Rigs that have already mraa installed were not affected with this issue and there is no immediate need to upgrade from 0.4.2 to 0.4.3.
