### PR TITLE
Use MRAA master on oref0 dev branch again

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -658,16 +658,17 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if ! ldconfig -p | grep -q mraa; then # if not installed, install it
             echo Installing swig etc.
             sudo apt-get install -y libpcre3-dev git cmake python-dev swig || die "Could not install swig etc."
-            # TODO: Due to mraa bug https://github.com/intel-iot-devkit/mraa/issues/771 we're not using the master branch of mraa on dev, but the v1.7.0 version
+            # TODO: Due to mraa bug https://github.com/intel-iot-devkit/mraa/issues/771 we were not using the master branch of mraa on dev. 
+            # TODO: Decide whether to use MRAA 1.7.0 for 0.5.0 release, or if there is a newer MRAA release that is of interest for the OpenAPS community
             MRAA_RELEASE="v1.7.0" # GitHub hash 8ddbcde84e2d146bc0f9e38504d6c89c14291480
             if [ -d "$HOME/src/mraa/" ]; then
                 echo -n "$HOME/src/mraa/ already exists; "
-                #(echo "Pulling latest master branch" && cd ~/src/mraa && git fetch && git checkout master && git pull) || die "Couldn't pull latest mraa master" # used for oref0 dev
-                (echo "Updating mraa source to stable release ${MRAA_RELEASE}" && cd $HOME/src/mraa && git fetch && git checkout ${MRAA_RELEASE} && git pull) || die "Couldn't pull latest mraa ${MRAA_RELEASE}  release" # used for oref0 master
+                (echo "Pulling latest master branch" && cd ~/src/mraa && git fetch && git checkout master && git pull) || die "Couldn't pull latest mraa master" # used for oref0 dev
+                #(echo "Updating mraa source to stable release ${MRAA_RELEASE}" && cd $HOME/src/mraa && git fetch && git checkout ${MRAA_RELEASE} && git pull) || die "Couldn't pull latest mraa ${MRAA_RELEASE} release" # used for oref0 master
             else
                 echo -n "Cloning mraa "
-                #(echo -n "master branch. " && cd ~/src && git clone -b master https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 dev
-                (echo -n "stable release ${MRAA_RELEASE}. " && cd $HOME/src && git clone -b ${MRAA_RELEASE} https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 master
+                (echo -n "master branch. " && cd ~/src && git clone -b master https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 dev
+                #(echo -n "stable release ${MRAA_RELEASE}. " && cd $HOME/src && git clone -b ${MRAA_RELEASE} https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa release ${MRAA_RELEASE}" # used for oref0 master
             fi
             # build mraa from source
             ( cd $HOME/src/ && mkdir -p mraa/build && cd $_ && cmake .. -DBUILDSWIGNODE=OFF && \


### PR DESCRIPTION
Needed for testing MRAA fix to see if their master branch works again with OpenAPS

Todo: decide which version we will use on OpenAPS dev and for the 0.5.0 release.