### PR TITLE
check pump clock after pumphistory to alleviate #477 race condition

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -80,6 +80,7 @@ function smb_reservoir_before {
     gather \
     && cp monitor/reservoir.json monitor/lastreservoir.json \
     && echo -n "pumphistory.json: " && cat monitor/pumphistory.json | jq -C .[0]._description \
+    && openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1
     && echo -n "Checking pump clock: " && (cat monitor/clock-zoned.json; echo) | tr -d '\n' \
     && echo -n " is within 1m of current time: " && date \
     && if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -60 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 60 )); then

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -80,7 +80,7 @@ function smb_reservoir_before {
     gather \
     && cp monitor/reservoir.json monitor/lastreservoir.json \
     && echo -n "pumphistory.json: " && cat monitor/pumphistory.json | jq -C .[0]._description \
-    && openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1
+    && openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1 \
     && echo -n "Checking pump clock: " && (cat monitor/clock-zoned.json; echo) | tr -d '\n' \
     && echo -n " is within 1m of current time: " && date \
     && if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -60 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 60 )); then

--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -43,7 +43,7 @@
   },
   {
     "monitor-pump": {
-      "command": "report invoke monitor/temp_basal.json monitor/pumphistory.json monitor/clock.json monitor/pumphistory-zoned.json monitor/clock-zoned.json monitor/iob.json monitor/meal.json monitor/reservoir.json monitor/battery.json monitor/status.json"
+      "command": "report invoke monitor/clock.json monitor/temp_basal.json monitor/pumphistory.json monitor/pumphistory-zoned.json monitor/clock-zoned.json monitor/iob.json monitor/meal.json monitor/reservoir.json monitor/battery.json monitor/status.json"
     },
     "type": "alias",
     "name": "monitor-pump"

--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -43,7 +43,7 @@
   },
   {
     "monitor-pump": {
-      "command": "report invoke monitor/clock.json monitor/temp_basal.json monitor/pumphistory.json monitor/pumphistory-zoned.json monitor/clock-zoned.json monitor/iob.json monitor/meal.json monitor/reservoir.json monitor/battery.json monitor/status.json"
+      "command": "report invoke monitor/temp_basal.json monitor/pumphistory.json monitor/clock.json monitor/pumphistory-zoned.json monitor/clock-zoned.json monitor/iob.json monitor/meal.json monitor/reservoir.json monitor/battery.json monitor/status.json"
     },
     "type": "alias",
     "name": "monitor-pump"


### PR DESCRIPTION
If the pumphistory pull (plus everything else in between the clock pull and the pump clock check in oref0-pump-loop) takes longer than 1 minutes, the pump clock check will fail per #477.  This should help alleviate that, hopefully eliminated the repeated NewTimeSet condition even with slow rigs or flaky pump comms.