### PR TITLE
raise default min_5m_carbimpact from 5 to 8

### DIFF
--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -23,7 +23,7 @@ function defaults ( ) {
     , skip_neutral_temps: false // if true, don't set neutral temps
     , unsuspend_if_no_temp: false // if true, pump will un-suspend after a zero temp finishes
     , bolussnooze_dia_divisor: 2 // bolus snooze decays after 1/2 of DIA
-    , min_5m_carbimpact: 5 // mg/dL per 5m (corresponds to 15g/hr at a CSF of 4 mg/dL/g)
+    , min_5m_carbimpact: 8 // mg/dL per 5m (8 mg/dL/5m corresponds to 24g/hr at a CSF of 4 mg/dL/g (x/5*60/4))
     , carbratio_adjustmentratio: 1 // if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
     , autotune_isf_adjustmentFraction: 0.5 // keep autotune ISF closer to pump ISF via a weighted average of fullNewISF and pumpISF.  1.0 allows full adjustment, 0 is no adjustment from pump ISF.
     , remainingCarbsFraction: 0.7 // fraction of carbs we'll assume will absorb over 4h if we don't yet see carb absorption


### PR DESCRIPTION
This should help reduce the impact of carbs that don't show up in BG deviations, and minimize the impact of any zombie carbs that reappear.