### PR TITLE
per #419, ignore bolus wizard carb entries without a bolus

### DIFF
--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -117,7 +117,9 @@ function reduce (treatments) {
         state.eventType = 'Meal Bolus';
       } else {
         if (has_carbs && !has_insulin) {
-          state.eventType = 'Carb Correction';
+          // disallow carb-only records from the pump per https://github.com/openaps/oref0/issues/419
+          state.carbs = 0;
+          // state.eventType = 'Carb Correction';
         }
         if (!has_carbs && has_insulin) {
           state.eventType = 'Correction Bolus';

--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -52,7 +52,11 @@ function findMealInputs (inputs) {
             // don't enter the treatment if there's another treatment with the same exact timestamp
             // to prevent duped carb entries from multiple sources
             if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"carbs")) {
-                mealInputs.push(temp);
+                if (arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"bolus")) {
+                    mealInputs.push(temp);
+                } else {
+                    console.error("skipping bolus wizard entry with",current.carb_input,"g carbs and no insulin");
+                }
             } else {
                 duplicates += 1;
             }

--- a/tests/cobhistory.test.js
+++ b/tests/cobhistory.test.js
@@ -28,16 +28,17 @@ describe('cobhistory', function ( ) {
    //function determine_basal(glucose_status, currenttemp, iob_data, profile)
 
     it('should dedupe entries', function () {
-		var inputs = {};
-		inputs.history = pumpHistory;
-		inputs.carbs = carbHistory;
-		inputs.profile = {};
-		
-		var output = find_cob_iob_entries(inputs);
-		
-		//console.log(output);
-		
-		output.length.should.equal(7);
+        var inputs = {};
+        inputs.history = pumpHistory;
+        inputs.carbs = carbHistory;
+        inputs.profile = {};
+
+        var output = find_cob_iob_entries(inputs);
+
+        console.log(output);
+
+        // BolusWizard carb_input without a timestamp-matched Bolus will be ignored
+        output.length.should.equal(5);
     });
 
 });


### PR DESCRIPTION
This needs to be tested by someone with a pump that is capable of writing carb-only bolus wizard records when you cancel out of the bolus wizard or enter a zero bolus.

Test procedure:

 - Enter a small number of carbs via the bolus wizard.  Cancel out or enter a zero bolus.  Make sure that the carbs show up in NS and in meal.json.
 - Check out this branch: `cd ~/src/oref0 && git fetch && git checkout ignore-carb-corrections && git pull`
 - Enter another small number of carbs the exact same way as before.  Make sure the carbs do *not* show up in NS or in meal.json.
 - Enter a small number of carbs with a minimal bolus (0.1U or whatever your pump supports).  Make sure those show up normally.
 - Test out other normal scenarios and make sure they all still work.