### PR TITLE
merge_pumphistory to fix zombie carbs

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -313,7 +313,7 @@ function gather {
     && test $(cat monitor/status.json | json bolusing) == false \
     && echo -n resh \
     && ( openaps monitor-pump || openaps monitor-pump ) 2>&1 >/dev/null | tail -1 \
-    && echo ed \
+    && echo -n ed \
     && merge_pumphistory \
     && echo pumphistory || (echo; exit 1) 2>/dev/null
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -313,7 +313,13 @@ function gather {
     && test $(cat monitor/status.json | json bolusing) == false \
     && echo -n resh \
     && ( openaps monitor-pump || openaps monitor-pump ) 2>&1 >/dev/null | tail -1 \
-    && echo ed pumphistory || (echo; exit 1) 2>/dev/null
+    && echo ed \
+    && merge_pumphistory \
+    && echo pumphistory || (echo; exit 1) 2>/dev/null
+}
+
+function merge_pumphistory {
+    jq -s '.[0] + .[1]|unique|sort_by(.timestamp)|reverse' monitor/pumphistory-zoned.json settings/pumphistory-24h-zoned.json > monitor/pumphistory-merged.json
 }
 
 # Calculate new suggested temp basal and enact it

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -37,10 +37,11 @@ function diaCarbs(opts, time) {
 
     treatments.forEach(function(treatment) {
         var now = time.getTime();
-        var dia_ago = now - profile_data.dia*60*60*1000;
+        // consider carbs from up to 6 hours ago in calculating COB
+        var carbWindow = now - 6 * 60*60*1000;
         var treatmentDate = new Date(tz(treatment.timestamp));
         var treatmentTime = treatmentDate.getTime();
-        if (treatmentTime > dia_ago && treatmentTime <= now) {
+        if (treatmentTime > carbWindow && treatmentTime <= now) {
             if (treatment.carbs >= 1) {
                 //console.error(treatment.carbs, maxCarbs, treatmentDate);
                 carbs += parseFloat(treatment.carbs);

--- a/lib/oref0-setup/report.json
+++ b/lib/oref0-setup/report.json
@@ -227,7 +227,7 @@
       "reporter": "text",
       "json_default": "True",
       "use": "shell",
-      "pumphistory": "monitor/pumphistory-zoned.json",
+      "pumphistory": "monitor/pumphistory-merged.json",
       "carbs": "monitor/carbhistory.json",
       "device": "meal",
       "remainder": "",


### PR DESCRIPTION
and use pumphistory-merged.json for COB calculations in meal.json

This should help ensure that the insulin dosing history used to calculate historical carb absorption is always complete, which hopefully will eliminate zombie reappearing carbs.