### PR TITLE
Add MDT to pump-loop.sh

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -247,9 +247,66 @@ function prep {
 }
 
 function if_mdt_get_bg {
-    if grep "MDT cgm" openaps.ini; then
-        openaps get-bg
+    echo -n
+    if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
+        echo \
+		&& echo -n MDT cgm data retrieve
+		#due to sometimes the pump is not in a state to give this command repeat till it completes
+		#"decocare.errors.DataTransferCorruptionError: Page size too short"
+		n=0
+		until [ $n -ge 3 ]; do
+			openaps report invoke monitor/cgm-mm-glucosedirty.json 2>&1 >/dev/null && break
+			echo
+			echo cgm data from pump disrupted, retrying in 5 seconds...
+			n=$[$n+1]
+			sleep 5;
+			echo -n MDT cgm data retrieve
+		done
+		if [ -f "monitor/cgm-mm-glucosedirty.json" ]; then			
+			if [ -f "cgm/glucose.json" ]; then
+				if [ $(date -d $(jq .[1].date monitor/cgm-mm-glucosedirty.json | tr -d '"') +%s) == $(date -d $(jq .[0].display_time monitor/glucose.json | tr -d '"') +%s) ]; then		
+					echo d \
+					&& echo MDT No New cgm data to reformat \
+					&& echo
+					# if you want to wait for new bg uncomment next lines add backslash after echo above
+					#&& wait_for_mdt_get_bg \
+					#&& mdt_get_bg
+				else			
+					mdt_get_bg
+				fi
+			else
+				mdt_get_bg
+			fi
+		else
+			echo " unable to get cgm data from pump"
+		fi
     fi
+}
+function wait_for_mdt_get_bg {	
+	# This might not really be needed since very seldom does Loop take less time to run than CGM Data takes to refresh. 
+	until [ $(date --date="@$(($(date -d $(jq .[1].date monitor/cgm-mm-glucosedirty.json| tr -d '"') +%s) + 300))" +%s) -lt $(date +%s) ]; do
+		CGMDIFFTIME=$(( $(date --date="@$(($(date -d $(jq .[1].date monitor/cgm-mm-glucosedirty.json| tr -d '"') +%s) + 300))" +%s) - $(date +%s) ))
+		echo "Last CGM Time was $(date -d $(jq .[1].date monitor/cgm-mm-glucosedirty.json| tr -d '"') +"%r") wait untill $(date --date="@$(($(date #-d $(jq .[1].date monitor/cgm-mm-glucosedirty.json| tr -d '"') +%s) + 300))" +"%r")to continue"
+		echo "waiting for $CGMDIFFTIME seconds before continuing"
+		sleep $CGMDIFFTIME
+		until openaps report invoke monitor/cgm-mm-glucosedirty.json 2>&1 >/dev/null; do
+			echo cgm data from pump disrupted, retrying in 5 seconds...
+			sleep 5;
+			echo -n MDT cgm data retrieve
+		done
+	done	
+}
+function mdt_get_bg {
+    openaps report invoke monitor/cgm-mm-glucosetrend.json 2>&1 >/dev/null \
+	&& openaps report invoke cgm/cgm-glucose.json 2>&1 >/dev/null \
+	&& grep -q glucose cgm/cgm-glucose.json \
+	&& echo d \
+	&& cp -pu cgm/cgm-glucose.json cgm/glucose.json \
+	&& cp -pu cgm/glucose.json monitor/glucose-unzoned.json \
+	&& echo -n MDT New cgm data reformat \
+	&& openaps report invoke monitor/glucose.json 2>&1 >/dev/null \
+	&& openaps report invoke nightscout/glucose.json 2>&1 >/dev/null \
+	&& echo ted
 }
 # make sure we can talk to the pump and get a valid model number
 function preflight {
@@ -414,7 +471,7 @@ function low_battery_wait {
 }
 
 function wait_for_bg {
-    if grep "MDT cgm" openaps.ini; then
+    if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
         echo "MDT CGM configured; not waiting"
     else
         echo -n "Waiting up to 4 minutes for new BG: "
@@ -453,7 +510,7 @@ function refresh_pumphistory_24h {
 }
 
 function setglucosetimestamp {
-    if grep "MDT cgm" openaps.ini; then
+    if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
       touch -d "$(date -R -d @$(jq .[0].date/1000 nightscout/glucose.json))" monitor/glucose.json
     else
       touch -d "$(date -R -d @$(jq .[0].date/1000 monitor/glucose.json))" monitor/glucose.json


### PR DESCRIPTION
add the get CGM data from MDT into pump-loop.sh

removes the Alias calls for getting the cgm data from the pump

fixed the grep for MDT so that it does not show the Printout of the Alias every time the script checks for MDT 

I made it so that when it does get the data from the pump, if it fails due to a decocare error
"decocare.errors.DataTransferCorruptionError: Page size too short"
I did never realize this before while it was in the Alias that this happens a lot, normally when it does fail if you just try to run it again it fixes and works fine, So I've made it so it can fail 3 times. I've never seen it have to run more than twice. 

Also have the loop check the time stamp on monitor/cgm-mm-glucosedirty.json after getting data if it is not any newer than the data already received, there is no reason to do the whole reformatting of the data again.
I've also made a function to wait for new CGM Data, but I don't think this is really necessary as it takes a while for the pump-loop to complete anyways, so very seldom when it runs do you not have new cgm data.  But I really would like some feedback if I should just get rid of it or not. as of right now, I do not have it being called. 

Was also debating taking all of this and making it's own bash script, but I don't think that is the best idea since it really does need to be run in the certain order in the Pump-loop. but I'm open to suggestions.  