### PR TITLE
Update default preferences

### DIFF
--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -22,7 +22,7 @@ function usage ( ) {
 }
 
 function exportDefaults () {
-	var defaults = generate.defaults();
+	var defaults = generate.displayedDefaults();
 	console.log(JSON.stringify(defaults, null, '\t'));
 }
 
@@ -57,7 +57,7 @@ if (!module.parent) {
       .strict(true)
       .help('help')
       .option('exportDefaults', {
-        describe: "Show default preference values",
+        describe: "Show typically-adjusted default preference values",
         default: false
       })
       .option('updatePreferences', {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -297,8 +297,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // totalCI (mg/dL) / CSF (mg/dL/g) = total carbs absorbed (g)
     var totalCA = totalCI / csf;
     // exclude the last 1/3 of carbs from remainingCarbs, and then cap it at 90
-    var remainingCarbsCap = 0; // default to zero
-    var remainingCarbsFraction = 2/3;
+    var remainingCarbsCap = 90; // default to zero
+    var remainingCarbsFraction = 1;
     if (profile.remainingCarbsCap) { remainingCarbsCap = Math.min(90,profile.remainingCarbsCap); }
     if (profile.remainingCarbsFraction) { remainingCarbsFraction = Math.min(1,profile.remainingCarbsFraction); }
     var remainingCarbsIgnore = 1 - remainingCarbsFraction;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -26,8 +26,8 @@ function defaults ( ) {
     , min_5m_carbimpact: 8 // mg/dL per 5m (8 mg/dL/5m corresponds to 24g/hr at a CSF of 4 mg/dL/g (x/5*60/4))
     , carbratio_adjustmentratio: 1 // if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
     , autotune_isf_adjustmentFraction: 0.5 // keep autotune ISF closer to pump ISF via a weighted average of fullNewISF and pumpISF.  1.0 allows full adjustment, 0 is no adjustment from pump ISF.
-    , remainingCarbsFraction: 0.7 // fraction of carbs we'll assume will absorb over 4h if we don't yet see carb absorption
-    , remainingCarbsCap: 0 // max carbs we'll assume will absorb over 4h if we don't yet see carb absorption
+    , remainingCarbsFraction: 1.0 // fraction of carbs we'll assume will absorb over 4h if we don't yet see carb absorption
+    , remainingCarbsCap: 90 // max carbs we'll assume will absorb over 4h if we don't yet see carb absorption
     // WARNING: the following are advanced oref1 features, and are not yet tested for general use
     , enableUAM: false // enable detection of unannounced meal carb absorption
     , enableSMB_with_bolus: false // enable supermicrobolus for DIA hours after a manual bolus

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -37,6 +37,27 @@ function defaults ( ) {
   return profile;
 }
 
+function displayedDefaults () {
+    var allDefaults = defaults();
+    var profile = { };
+
+    profile.max_iob = allDefaults.max_iob;
+    profile.max_daily_safety_multiplier = allDefaults.max_daily_safety_multiplier;
+    profile.current_basal_safety_multiplier= allDefaults.current_basal_safety_multiplier;
+    profile.autosens_max = allDefaults.autosens_max;
+    profile.autosens_min = allDefaults.autosens_min;
+    profile.rewind_resets_autosens = allDefaults.rewind_resets_autosens;
+    profile.adv_target_adjustments = allDefaults.adv_target_adjustments;
+    profile.unsuspend_if_no_temp = allDefaults.unsuspend_if_no_temp;
+    profile.enableSMB_with_bolus = allDefaults.enableSMB_with_bolus;
+    profile.enableSMB_with_COB = allDefaults.enableSMB_with_COB;
+    profile.enableSMB_with_temptarget = allDefaults.enableSMB_with_temptarget;
+    profile.enableUAM = allDefaults.enableUAM;
+
+    console.error(profile);
+    return profile
+}
+
 function generate (inputs, opts) {
   var profile = opts && opts.type ? opts : defaults( );
 
@@ -117,5 +138,6 @@ function generate (inputs, opts) {
 
 
 generate.defaults = defaults;
+generate.displayedDefaults = displayedDefaults;
 exports = module.exports = generate;
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -12,9 +12,9 @@ function defaults ( ) {
     , current_basal_safety_multiplier: 4
     , autosens_max: 1.2
     , autosens_min: 0.7
-    , rewind_resets_autosens: false // reset autosensitivity to neutral for awhile after each pump rewind
+    , rewind_resets_autosens: true // reset autosensitivity to neutral for awhile after each pump rewind
     , autosens_adjust_targets: true // when autosens detects sensitivity/resistance, also adjust BG target accordingly
-    , adv_target_adjustments: false // lower target automatically when BG and eventualBG are high
+    , adv_target_adjustments: true // lower target automatically when BG and eventualBG are high
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.
     // Essentially, this just limits AMA as a safety cap against weird COB calculations)

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -23,7 +23,7 @@ function defaults ( ) {
     , skip_neutral_temps: false // if true, don't set neutral temps
     , unsuspend_if_no_temp: false // if true, pump will un-suspend after a zero temp finishes
     , bolussnooze_dia_divisor: 2 // bolus snooze decays after 1/2 of DIA
-    , min_5m_carbimpact: 5 // mg/dL per 5m (corresponds to 15g/hr at a CSF of 4 mg/dL/g)
+    , min_5m_carbimpact: 8 // mg/dL per 5m (8 mg/dL/5m corresponds to 24g/hr at a CSF of 4 mg/dL/g (x/5*60/4))
     , carbratio_adjustmentratio: 1 // if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
     , autotune_isf_adjustmentFraction: 0.5 // keep autotune ISF closer to pump ISF via a weighted average of fullNewISF and pumpISF.  1.0 allows full adjustment, 0 is no adjustment from pump ISF.
     , remainingCarbsFraction: 0.7 // fraction of carbs we'll assume will absorb over 4h if we don't yet see carb absorption


### PR DESCRIPTION
In oref1 testing so far, nearly all complaints have been about it not dosing enough insulin after meals, and almost everyone has ended up raising remainingCarbsCap and remainingCarbsFraction.  This would change the defaults there to be the same as the max limits: 100% of 90g.

Also incorporates #511 