### PR TITLE
upload carb-only bolus wizard entries to NS again

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -247,7 +247,7 @@ function if_mdt_get_bg {
     echo -n
     if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
         echo \
-	&& echo Attempting to retrieve MDT CGM data from pump 
+        && echo Attempting to retrieve MDT CGM data from pump
 		#due to sometimes the pump is not in a state to give this command repeat until it completes
 		#"decocare.errors.DataTransferCorruptionError: Page size too short"
 		n=0

--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -117,9 +117,7 @@ function reduce (treatments) {
         state.eventType = 'Meal Bolus';
       } else {
         if (has_carbs && !has_insulin) {
-          // disallow carb-only records from the pump per https://github.com/openaps/oref0/issues/419
-          state.carbs = 0;
-          // state.eventType = 'Carb Correction';
+          state.eventType = 'Carb Correction';
         }
         if (!has_carbs && has_insulin) {
           state.eventType = 'Correction Bolus';


### PR DESCRIPTION
To fix #524, this reverts the portion of #512 that disabled the upload of carb-only bolus wizard entries, which looks to be independent of the changes to oref0-meal that ignore such entries for purposes of calculating COB.

We'll need to test that a carb-only bolus wizard entry when there's no COB does not end up contributing to COB via getting uploaded to NS and then downloaded again into carbhistory.json. 