### PR TITLE
only pull 2h of pumphistory now that we merge it with pumphistory-24h

### DIFF
--- a/lib/oref0-setup/report.json
+++ b/lib/oref0-setup/report.json
@@ -159,7 +159,7 @@
     "type": "report",
     "name": "monitor/pumphistory.json",
     "monitor/pumphistory.json": {
-      "hours": "5.0",
+      "hours": "2.0",
       "device": "pump",
       "use": "iter_pump_hours",
       "reporter": "JSON"


### PR DESCRIPTION
This should allow the pumphistory refresh to complete more quickly and more reliably without missing any data (since pumphistory-24h can never be more than 2h old).