### PR TITLE
workaround for #432 for CRs of 26-99 on x23 pumps

### DIFF
--- a/lib/profile/carbs.js
+++ b/lib/profile/carbs.js
@@ -14,9 +14,14 @@ function carbRatioLookup (inputs, profile) {
                 if ((now >= getTime(carbratio_data.schedule[i].offset)) && (now < getTime(carbratio_data.schedule[i + 1].offset))) {
                     carbRatio = carbratio_data.schedule[i];
                     // disallow impossibly high/low carbRatios due to bad decoding
-                    if (carbRatio < 3 || carbRatio > 150) {
-                        console.error("Error: carbRatio of " + carbRatio + " out of bounds.");
-                        return;
+                    if (carbRatio < 3 || carbRatio > 200) {
+                        // assume carbRatio < 1 is bad x23 decoding of a 26-99 CR, and * 100 to fix
+                        if (carbRatio < 1) {
+                            carbRatio.ratio = 100 * carbRatio.ratio;
+                        } else {
+                            console.error("Error: carbRatio of " + carbRatio + " out of bounds.");
+                            return;
+                        }
                     }
                     break;
                 }


### PR DESCRIPTION
Implements the https://github.com/openaps/oref0/issues/432#issuecomment-313968111 workaround for the #432 carb ratio decoding issue that decocare/openaps have with 723 pumps and CRs > 25.