### PR TITLE
upgrade to mmeowlink v0.11.1 for clearer pump comms messaging

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -513,7 +513,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 
     echo Checking mmeowlink installation
 #if openaps vendor add --path . mmeowlink.vendors.mmeowlink 2>&1 | grep "No module"; then
-    pip show mmeowlink | egrep "Version: 0.11." || (
+    pip show mmeowlink | egrep "Version: 0.11.1" || (
         echo Installing latest mmeowlink
         sudo pip install -U mmeowlink || die "Couldn't install mmeowlink"
     )


### PR DESCRIPTION
In order to reduce confusion around people thinking that "no pump comms detected" is an error (rather than a good thing), I'd like to do a mmeowlink release and then upgrade everyone to mmeowlink v0.11.1  when they next run oref0-setup.

https://github.com/oskarpearson/mmeowlink/pull/63 needs to be merged (and released for `pip`) before this PR should be merged.