### PR TITLE
various oref0-pump-loop fixes affecting COB calculation

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -37,8 +37,8 @@ smb_main() {
         && wait_for_silence $upto30s \
         && preflight \
         && if_mdt_get_bg \
-        && refresh_old_pumphistory \
         && refresh_old_pumphistory_24h \
+        && refresh_old_pumphistory \
         && refresh_old_profile \
         && touch monitor/pump_loop_enacted -r monitor/glucose.json \
         && refresh_smb_temp_and_enact \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -73,7 +73,6 @@ function smb_reservoir_before {
     # Refresh reservoir.json and pumphistory.json
     gather \
     && cp monitor/reservoir.json monitor/lastreservoir.json \
-    && echo -n "pumphistory.json: " && cat monitor/pumphistory.json | jq -C .[0]._description \
     && openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1 \
     && echo -n "Checking pump clock: " && (cat monitor/clock-zoned.json; echo) | tr -d '\n' \
     && echo -n " is within 1m of current time: " && date \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -405,7 +405,8 @@ function refresh_old_pumphistory {
 # refresh pumphistory_24h if it's more than 2h old
 function refresh_old_pumphistory_24h {
     find settings/ -mmin -120 -size +100c | grep -q pumphistory-24h-zoned \
-    || ( echo -n Old pumphistory-24h refresh \
+    || ( echo -n "Old pumphistory-24h, waiting for $upto30s seconds of silence: " && wait_for_silence $upto30 \
+        && echo -n Old pumphistory-24h refresh \
         && openaps report invoke settings/pumphistory-24h.json settings/pumphistory-24h-zoned.json 2>&1 >/dev/null | tail -1 && echo ed )
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -124,7 +124,7 @@ function smb_check_everything {
 
 function smb_suggest {
     rm -rf enact/smb-suggested.json
-    ls enact/smb-suggested.json 2>/dev/null && die "enact/suggested.json present"
+    ls enact/smb-suggested.json 2>/dev/null >/dev/null && die "enact/suggested.json present"
     # Run determine-basal
     echo -n Temp refresh && openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json monitor/iob.json 2>&1 >/dev/null | tail -1 && echo ed \
     && openaps report invoke enact/smb-suggested.json 2>&1 >/dev/null \

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -959,7 +959,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [[ $ENABLE =~ microbolus ]]; then
             (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep bash | grep -q 'bin/oref0-pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep bash | grep -q 'bin/oref0-pump-loop' || oref0-pump-loop --microbolus ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
         else
-            (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'openaps pump-loop' || openaps pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
+            (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep bash | grep -q 'bin/oref0-pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep bash | grep -q 'bin/oref0-pump-loop' || oref0-pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
         fi
         if [[ ! -z "$BT_PEB" ]]; then
         (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB '" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep -q 'peb-urchin-status $BT_PEB' || peb-urchin-status $BT_PEB ) 2>&1 | tee -a /var/log/openaps/urchin-loop.log") | crontab -

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -196,7 +196,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         var adjustedTargetBG =round( Math.max(80, target_bg - (bg - target_bg)/3 ),0);
         var adjustedMaxBG = round(Math.max(80, max_bg - (bg - max_bg)/3 ),0);
         // if eventualBG, naive_eventualBG, and target_bg aren't all above adjustedMinBG, don’t use it
-        console.error("naive_eventualBG:",naive_eventualBG+", eventualBG:",eventualBG);
+        //console.error("naive_eventualBG:",naive_eventualBG+", eventualBG:",eventualBG);
         if (eventualBG > adjustedMinBG && naive_eventualBG > adjustedMinBG && min_bg > adjustedMinBG) {
             process.stderr.write("Adjusting targets for high BG: min_bg from "+min_bg+" to "+adjustedMinBG+"; ");
             min_bg = adjustedMinBG;

--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -57,7 +57,7 @@
   },
   {
     "ns-meal-carbs": {
-      "command": "! bash -c \"openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0\""
+      "command": "! bash -c \"openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0\""
     },
     "type": "alias",
     "name": "ns-meal-carbs"


### PR DESCRIPTION
This avoids a corner case where both pumphistory files are old and the pumphistory-merged.json gets created before pumphistory-24h.json is refreshed, and then the rig miscalculates COB for a few minutes until pumphistory is refreshed again.