### PR TITLE
don't use profile.target_bg, just min_bg and max_bg

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -85,7 +85,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     var max_iob = profile.max_iob; // maximum amount of non-bolus IOB OpenAPS will ever deliver
 
-    // if target_bg is set, great. otherwise, if min and max are set, then set target to their average
+    // if min and max are set, then set target to their average
     var target_bg;
     var min_bg;
     var max_bg;
@@ -95,15 +95,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (typeof profile.max_bg !== 'undefined') {
             max_bg = profile.max_bg;
     }
-    if (typeof profile.target_bg !== 'undefined') {
-        target_bg = profile.target_bg;
+    if (typeof profile.min_bg !== 'undefined' && typeof profile.max_bg !== 'undefined') {
+        target_bg = (profile.min_bg + profile.max_bg) / 2;
     } else {
-        if (typeof profile.min_bg !== 'undefined' && typeof profile.max_bg !== 'undefined') {
-            target_bg = (profile.min_bg + profile.max_bg) / 2;
-        } else {
-            rT.error ='Error: could not determine target_bg. ';
-            return rT;
-        }
+        rT.error ='Error: could not determine target_bg. ';
+        return rT;
     }
 
     // adjust min, max, and target BG for sensitivity, such that 50% increase in ISF raises target from 100 to 120

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -81,7 +81,7 @@ describe('determine-basal', function ( ) {
     var glucose_status = {"delta":0,"glucose":115,"long_avgdelta":0,"short_avgdelta":0};
     var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
     var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
-    var profile = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.9,"max_daily_basal":1.3,"max_basal":3.5,"max_bg":120,"min_bg":110,"sens":40,"target_bg":110,"carb_ratio":10};
+    var profile = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.9,"max_daily_basal":1.3,"max_basal":3.5,"max_bg":120,"min_bg":110,"sens":40,"carb_ratio":10};
     var meal_data = {};
 
     it('should cancel high temp when in range w/o IOB', function () {
@@ -281,8 +281,8 @@ describe('determine-basal', function ( ) {
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.be.below(0.8);
-        output.duration.should.equal(30);
-        output.reason.should.match(/Eventual BG .*< 110.*setting .*/);
+        output.duration.should.be.above(29);
+        output.reason.should.match(/Eventual BG .*< 110.*/);
     });
 
     it('should low-temp when eventualBG < min_bg with delta > exp. delta', function () {
@@ -315,14 +315,15 @@ describe('determine-basal', function ( ) {
         output.reason.should.match(/Eventual BG .*< 110.*setting .*/);
     });
 
-    it('should do nothing when eventualBG < min_bg but appropriate low temp in progress', function () {
-        var glucose_status = {"delta":-1,"glucose":110,"long_avgdelta":-1,"short_avgdelta":-1};
-        var currenttemp = {"duration":20,"rate":0.25,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
-        (typeof output.rate).should.equal('undefined');
-        (typeof output.duration).should.equal('undefined');
-        output.reason.should.match(/Eventual BG .*< 110, temp .*/);
-    });
+    //it('should do nothing when eventualBG < min_bg but appropriate low temp in progress', function () {
+        //var glucose_status = {"delta":-1,"glucose":110,"long_avgdelta":-1,"short_avgdelta":-1};
+        //var currenttemp = {"duration":20,"rate":0.25,"temp":"absolute"};
+        //var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
+        ////console.log(output);
+        //(typeof output.rate).should.equal('undefined');
+        //(typeof output.duration).should.equal('undefined');
+        //output.reason.should.match(/Eventual BG .*< 110, temp .*/);
+    //});
 
     it('should cancel low-temp when lowish and avg.delta rising faster than BGI', function () {
         var currenttemp = {"duration":20,"rate":0.5,"temp":"absolute"};
@@ -473,24 +474,24 @@ describe('determine-basal', function ( ) {
         output.reason.should.match(/CGM is calibrating/);
     });
 
-    it('profile should contain min_bg,max_bg or target_bg', function () {
+    it('profile should contain min_bg,max_bg', function () {
       var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0}, undefined, meal_data, tempBasalFunctions);
       result.error.should.equal('Error: could not determine target_bg. ');
     });
 
     it('iob_data should not be undefined', function () {
-      var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0, "target_bg":100}, undefined, meal_data, tempBasalFunctions);
+      var result = determine_basal({glucose:100},undefined, undefined, {"current_basal":0.0, "max_bg":100,"min_bg":1100}, undefined, meal_data, tempBasalFunctions);
       result.error.should.equal('Error: iob_data undefined. ');
     });
 
     it('iob_data should contain activity, iob, bolussnooze', function () {
-      var result = determine_basal({glucose:100}, undefined,{"activity":0}, {"current_basal":0.0, "target_bg":100}, undefined, meal_data, tempBasalFunctions);
+      var result = determine_basal({glucose:100}, undefined,{"activity":0}, {"current_basal":0.0, "max_bg":100,"min_bg":110}, undefined, meal_data, tempBasalFunctions);
       result.error.should.equal('Error: iob_data missing some property. ');
     });
 
 /*
     it('should return error eventualBG if something went wrong', function () {
-      var result = determine_basal({glucose:100}, undefined,{"activity":0, "iob":0,"bolussnooze":0}, {"current_basal":0.0, "target_bg":100, "sens":NaN}, undefined, meal_data, tempBasalFunctions);
+      var result = determine_basal({glucose:100}, undefined,{"activity":0, "iob":0,"bolussnooze":0}, {"current_basal":0.0, "sens":NaN}, undefined, meal_data, tempBasalFunctions);
       result.error.should.equal('Error: could not calculate eventualBG');
     });
 */
@@ -704,7 +705,7 @@ describe('determine-basal', function ( ) {
 
     it('should round appropriately for small basals when setting basal to maxSafeBasal ', function () {
         var glucose_status = {"delta":5,"glucose":185,"long_avgdelta":5,"short_avgdelta":5};
-	var profile2 = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.025,"max_daily_basal":1.3,"max_basal":.05,"max_bg":120,"min_bg":110,"sens":200,"target_bg":110,"model":"523"};
+	var profile2 = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.025,"max_daily_basal":1.3,"max_basal":.05,"max_bg":120,"min_bg":110,"sens":200,"model":"523"};
 	var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile2, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0.05);


### PR DESCRIPTION
This closes a potential loophole that could be used (if you somehow got a target_bg into profile.json) to bypass the safety checks on target_bg being >=80 and <= 200 mg/dL.

I don't think this is what Miiko saw at https://gitter.im/nightscout/intend-to-bolus?at=59655496c101bc4e3a764ecf, but it's the only code path I could see that would bypass those checks.  And since no one has ever explicitly set target_bg AFAIK, it'd be better to remove that code anyway, and update the few tests that use it to use min_bg and max_bg instead (which this PR also does).