### PR TITLE
Fix unsuspend

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -56,10 +56,6 @@ smb_main() {
                     && echo Completed pump-loop at $(date) \
                     && echo \
                     ))
-            fi \
-            || if grep -q '"suspended": true' monitor/status.json; then
-                echo -n "Pump suspended; "
-                unsuspend_if_no_temp
             fi
             ) \
             && refresh_profile \
@@ -146,6 +142,10 @@ function smb_enact_temp {
         echo -n "No smb_enact needed. "
     fi \
     && smb_verify_enacted
+    || if grep -q '"suspended": true' monitor/status.json; then
+        echo -n "Pump suspended; "
+        unsuspend_if_no_temp
+    fi && smb_verify_enacted
 }
 
 function smb_verify_enacted {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -141,11 +141,7 @@ function smb_enact_temp {
     else
         echo -n "No smb_enact needed. "
     fi \
-    && smb_verify_enacted \
-    || if grep -q '"suspended": true' monitor/status.json; then
-        echo -n "Pump suspended; "
-        unsuspend_if_no_temp
-    fi && smb_verify_enacted
+    && smb_verify_enacted
 }
 
 function smb_verify_enacted {
@@ -197,7 +193,10 @@ function smb_verify_status {
     && cat monitor/status.json | jq -C -c . \
     && grep -q '"status": "normal"' monitor/status.json \
     && grep -q '"bolusing": false' monitor/status.json \
-    && grep -q '"suspended": false' monitor/status.json
+    && if grep -q '"suspended": true' monitor/status.json; then
+        echo -n "Pump suspended; "
+        unsuspend_if_no_temp
+    fi
 }
 
 function smb_bolus {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -141,7 +141,7 @@ function smb_enact_temp {
     else
         echo -n "No smb_enact needed. "
     fi \
-    && smb_verify_enacted
+    && smb_verify_enacted \
     || if grep -q '"suspended": true' monitor/status.json; then
         echo -n "Pump suspended; "
         unsuspend_if_no_temp

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -141,7 +141,7 @@ function smb_enact_temp {
     else
         echo -n "No smb_enact needed. "
     fi \
-    && smb_verify_enacted
+    && ( smb_verify_enacted || ( smb_verify_status; smb_verify_enacted) )
 }
 
 function smb_verify_enacted {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -56,6 +56,10 @@ smb_main() {
                     && echo Completed pump-loop at $(date) \
                     && echo \
                     ))
+            fi \
+            || if grep -q '"suspended": true' monitor/status.json; then
+                echo -n "Pump suspended; "
+                unsuspend_if_no_temp
             fi
             ) \
             && refresh_profile \
@@ -106,12 +110,8 @@ function smb_check_everything {
         && smb_verify_status \
         || ( echo Retrying SMB checks
             wait_for_silence 10
-            if grep -q '"suspended": true' monitor/status.json; then
-                echo -n "Pump suspended; "
-                unsuspend_if_no_temp
-            fi
-            smb_verify_status
-            smb_reservoir_before \
+            smb_verify_status \
+            && smb_reservoir_before \
             && smb_enact_temp \
             && ( smb_verify_suggested || smb_suggest ) \
             && smb_verify_reservoir \


### PR DESCRIPTION
This moves unsuspend_if_no_temp somewhere it can actually be executed.  Prior to this change, zero-duration (finished) zero temps were causing smb_verify_enacted to fail before it ever got to smb_check_everything.

