### PR TITLE
Fix missing fi

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -695,15 +695,15 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             #echo Installing spi_serial && sudo pip install --upgrade git+https://github.com/EnhancedRadioDevices/spi_serial || die "Couldn't install spi_serial"
         fi
 
-      # from 0.5.0 the subg-ww-radio-parameters script will be run from oref0_init_pump_comms.py
-      # this will be called when mmtune is use with a WW pump.
-      # See https://github.com/oskarpearson/mmeowlink/issues/51 or https://github.com/oskarpearson/mmeowlink/wiki/Non-USA-pump-settings for details
-      # use --ww_ti_usb_reset=yes if using a TI USB stick and a WW pump. This will reset the USB subsystem if the TI USB device is not found.
-      # TODO: remove this workaround once https://github.com/oskarpearson/mmeowlink/issues/60 has been fixed
-      if [[ ${ww_ti_usb_reset,,} =~ "yes" ]]; then
-        openaps alias remove mmtune
-        openaps alias add mmtune "! bash -c \"oref0_init_pump_comms.py --ww_ti_usb_reset=yes -v; find monitor/ -size +5c | grep -q mmtune && cp monitor/mmtune.json mmtune_old.json; echo {} > monitor/mmtune.json; echo -n \"mmtune: \" && openaps report invoke monitor/mmtune.json; grep -v setFreq monitor/mmtune.json | grep -A2 $(json -a setFreq -f monitor/mmtune.json) | while read line; do echo -n \"$line \"; done\""
-      fi
+        # from 0.5.0 the subg-ww-radio-parameters script will be run from oref0_init_pump_comms.py
+        # this will be called when mmtune is use with a WW pump.
+        # See https://github.com/oskarpearson/mmeowlink/issues/51 or https://github.com/oskarpearson/mmeowlink/wiki/Non-USA-pump-settings for details
+        # use --ww_ti_usb_reset=yes if using a TI USB stick and a WW pump. This will reset the USB subsystem if the TI USB device is not found.
+        # TODO: remove this workaround once https://github.com/oskarpearson/mmeowlink/issues/60 has been fixed
+        if [[ ${ww_ti_usb_reset,,} =~ "yes" ]]; then
+                openaps alias remove mmtune
+                openaps alias add mmtune "! bash -c \"oref0_init_pump_comms.py --ww_ti_usb_reset=yes -v; find monitor/ -size +5c | grep -q mmtune && cp monitor/mmtune.json mmtune_old.json; echo {} > monitor/mmtune.json; echo -n \"mmtune: \" && openaps report invoke monitor/mmtune.json; grep -v setFreq monitor/mmtune.json | grep -A2 $(json -a setFreq -f monitor/mmtune.json) | while read line; do echo -n \"$line \"; done\""
+        fi
         echo Checking kernel for mraa installation
         if uname -r 2>&1 | egrep "^4.1[0-9]"; then # don't install mraa on 4.10+ kernels
         echo "Skipping mraa install for kernel 4.10+"
@@ -803,34 +803,34 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 
     # Install EdisonVoltage
     if egrep -i "edison" /etc/passwd 2>/dev/null; then
-    echo "Checking if EdisonVoltage is already installed"
-    if [ -d "$HOME/src/EdisonVoltage/" ]; then
-        echo "EdisonVoltage already installed"
-    else
-        echo "Installing EdisonVoltage"
-        cd $HOME/src && git clone -b master git://github.com/cjo20/EdisonVoltage.git || (cd EdisonVoltage && git checkout master && git pull)
-        cd $HOME/src/EdisonVoltage
-        make voltage
-    fi
-    cd $directory || die "Can't cd $directory"
-    for type in edisonbattery; do
-        echo importing $type file
-        cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
-    done
+        echo "Checking if EdisonVoltage is already installed"
+        if [ -d "$HOME/src/EdisonVoltage/" ]; then
+            echo "EdisonVoltage already installed"
+        else
+            echo "Installing EdisonVoltage"
+            cd $HOME/src && git clone -b master git://github.com/cjo20/EdisonVoltage.git || (cd EdisonVoltage && git checkout master && git pull)
+            cd $HOME/src/EdisonVoltage
+            make voltage
+        fi
+        cd $directory || die "Can't cd $directory"
+        for type in edisonbattery; do
+            echo importing $type file
+            cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
+        done
     fi
     # Install Pancreabble
     echo Checking for BT Pebble Mac
     if [[ ! -z "$BT_PEB" ]]; then
-    sudo apt-get -y install jq
-    sudo pip install libpebble2
-    sudo pip install --user git+git://github.com/mddub/pancreabble.git
-    oref0-bluetoothup
-    sudo rfcomm bind hci0 $BT_PEB
-    for type in pancreabble; do
-        echo importing $type file
-        cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
-    done
-    sudo cp $HOME/src/oref0/lib/oref0-setup/pancreoptions.json $directory/pancreoptions.json
+        sudo apt-get -y install jq
+        sudo pip install libpebble2
+        sudo pip install --user git+git://github.com/mddub/pancreabble.git
+        oref0-bluetoothup
+        sudo rfcomm bind hci0 $BT_PEB
+        for type in pancreabble; do
+            echo importing $type file
+            cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
+        done
+        sudo cp $HOME/src/oref0/lib/oref0-setup/pancreoptions.json $directory/pancreoptions.json
     fi
     # configure optional features passed to enact/suggested.json report
     if [[ $ENABLE =~ autosens && $ENABLE =~ meal ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -728,27 +728,28 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         fi
         echo Checking kernel for mraa installation
         if uname -r 2>&1 | egrep "^4.1[0-9]"; then # don't install mraa on 4.10+ kernels
-        echo "Skipping mraa install for kernel 4.10+"
+            echo "Skipping mraa install for kernel 4.10+"
         else # check if mraa is installed
-        if ! ldconfig -p | grep -q mraa; then # if not installed, install it
-            echo Installing swig etc.
-            sudo apt-get install -y libpcre3-dev git cmake python-dev swig || die "Could not install swig etc."
-            # TODO: Due to mraa bug https://github.com/intel-iot-devkit/mraa/issues/771 we were not using the master branch of mraa on dev.
-            # TODO: After each oref0 release, check whether there is a new stable MRAA release that is of interest for the OpenAPS community
-            MRAA_RELEASE="v1.7.0" # GitHub hash 8ddbcde84e2d146bc0f9e38504d6c89c14291480
-            if [ -d "$HOME/src/mraa/" ]; then
-                echo -n "$HOME/src/mraa/ already exists; "
-                #(echo "Pulling latest master branch" && cd ~/src/mraa && git fetch && git checkout master && git pull) || die "Couldn't pull latest mraa master" # used for oref0 dev
-                (echo "Updating mraa source to stable release ${MRAA_RELEASE}" && cd $HOME/src/mraa && git fetch && git checkout ${MRAA_RELEASE} && git pull) || die "Couldn't pull latest mraa ${MRAA_RELEASE} release" # used for oref0 master
-            else
-                echo -n "Cloning mraa "
-                #(echo -n "master branch. " && cd ~/src && git clone -b master https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 dev
-                (echo -n "stable release ${MRAA_RELEASE}. " && cd $HOME/src && git clone -b ${MRAA_RELEASE} https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa release ${MRAA_RELEASE}" # used for oref0 master
+            if ! ldconfig -p | grep -q mraa; then # if not installed, install it
+                echo Installing swig etc.
+                sudo apt-get install -y libpcre3-dev git cmake python-dev swig || die "Could not install swig etc."
+                # TODO: Due to mraa bug https://github.com/intel-iot-devkit/mraa/issues/771 we were not using the master branch of mraa on dev.
+                # TODO: After each oref0 release, check whether there is a new stable MRAA release that is of interest for the OpenAPS community
+                MRAA_RELEASE="v1.7.0" # GitHub hash 8ddbcde84e2d146bc0f9e38504d6c89c14291480
+                if [ -d "$HOME/src/mraa/" ]; then
+                    echo -n "$HOME/src/mraa/ already exists; "
+                    #(echo "Pulling latest master branch" && cd ~/src/mraa && git fetch && git checkout master && git pull) || die "Couldn't pull latest mraa master" # used for oref0 dev
+                    (echo "Updating mraa source to stable release ${MRAA_RELEASE}" && cd $HOME/src/mraa && git fetch && git checkout ${MRAA_RELEASE} && git pull) || die "Couldn't pull latest mraa ${MRAA_RELEASE} release" # used for oref0 master
+                else
+                    echo -n "Cloning mraa "
+                    #(echo -n "master branch. " && cd ~/src && git clone -b master https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa master" # used for oref0 dev
+                    (echo -n "stable release ${MRAA_RELEASE}. " && cd $HOME/src && git clone -b ${MRAA_RELEASE} https://github.com/intel-iot-devkit/mraa.git) || die "Couldn't clone mraa release ${MRAA_RELEASE}" # used for oref0 master
+                fi
+                # build mraa from source
+                ( cd $HOME/src/ && mkdir -p mraa/build && cd $_ && cmake .. -DBUILDSWIGNODE=OFF && \
+                make && sudo make install && echo && touch /tmp/reboot-required && echo mraa installed. Please reboot before using. && echo ) || die "Could not compile mraa"
+                sudo bash -c "grep -q i386-linux-gnu /etc/ld.so.conf || echo /usr/local/lib/i386-linux-gnu/ >> /etc/ld.so.conf && ldconfig" || die "Could not update /etc/ld.so.conf"
             fi
-            # build mraa from source
-            ( cd $HOME/src/ && mkdir -p mraa/build && cd $_ && cmake .. -DBUILDSWIGNODE=OFF && \
-            make && sudo make install && echo && touch /tmp/reboot-required && echo mraa installed. Please reboot before using. && echo ) || die "Could not compile mraa"
-            sudo bash -c "grep -q i386-linux-gnu /etc/ld.so.conf || echo /usr/local/lib/i386-linux-gnu/ >> /etc/ld.so.conf && ldconfig" || die "Could not update /etc/ld.so.conf"
         fi
     fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -163,7 +163,9 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
     echo "where the myopenaps directory is involved. Type in a directory name and/or just hit enter:"
     read -r
     DIR=$REPLY
-    if [[ -z $DIR ]]; then DIR="myopenaps"; fi
+    if [[ -z $DIR ]]; then
+        DIR="myopenaps"
+    fi
     echocolor "Ok, $DIR it is."
     directory="$(readlink -m $DIR)"
     echo
@@ -413,7 +415,9 @@ if [[ -z "$ttyport" ]]; then
 else
     echo -n TTY $ttyport
 fi
-if [[ "$max_iob" != "0" ]]; then echo -n ", max_iob $max_iob"; fi
+if [[ "$max_iob" != "0" ]]; then
+    echo -n ", max_iob $max_iob";
+fi
 if [[ ! -z "$max_daily_safety_multiplier" ]]; then
     echo -n ", max_daily_safety_multiplier $max_daily_safety_multiplier";
 fi
@@ -426,7 +430,9 @@ fi
 if [[ ! -z "$min_5m_carbimpact" ]]; then
     echo -n ", min_5m_carbimpact $min_5m_carbimpact";
 fi
-if [[ ! -z "$ENABLE" ]]; then echo -n ", advanced features $ENABLE"; fi
+if [[ ! -z "$ENABLE" ]]; then
+    echo -n ", advanced features $ENABLE";
+fi
 echo
 echo
 
@@ -458,14 +464,30 @@ fi
 if [[ ! -z "$min_5m_carbimpact" ]]; then
     echo -n " --min_5m_carbimpact=$min_5m_carbimpact" | tee -a $OREF0_RUNAGAIN
 fi
-if [[ ! -z "$ENABLE" ]]; then echo -n " --enable='$ENABLE'" | tee -a $OREF0_RUNAGAIN; fi
-if [[ ! -z "$radio_locale" ]]; then echo -n " --radio_locale='$radio_locale'" | tee -a $OREF0_RUNAGAIN; fi
-if [[ ${ww_ti_usb_reset,,} =~ "yes" ]]; then echo -n " --ww_ti_usb_reset='$ww_ti_usb_reset'" | tee -a $OREF0_RUNAGAIN; fi
-if [[ ! -z "$BLE_MAC" ]]; then echo -n " --blemac='$BLE_MAC'" | tee -a $OREF0_RUNAGAIN; fi
-if [[ ! -z "$BT_MAC" ]]; then echo -n " --btmac='$BT_MAC'" | tee -a $OREF0_RUNAGAIN; fi
-if [[ ! -z "$BT_PEB" ]]; then echo -n " --btpeb='$BT_PEB'" | tee -a $OREF0_RUNAGAIN; fi
-if [[ ! -z "$PUSHOVER_TOKEN" ]]; then echo -n " --pushover_token='$PUSHOVER_TOKEN'" | tee -a $OREF0_RUNAGAIN; fi
-if [[ ! -z "$PUSHOVER_USER" ]]; then echo -n " --pushover_user='$PUSHOVER_USER'" | tee -a $OREF0_RUNAGAIN; fi
+if [[ ! -z "$ENABLE" ]]; then
+    echo -n " --enable='$ENABLE'" | tee -a $OREF0_RUNAGAIN
+fi
+if [[ ! -z "$radio_locale" ]]; then
+    echo -n " --radio_locale='$radio_locale'" | tee -a $OREF0_RUNAGAIN
+fi
+if [[ ${ww_ti_usb_reset,,} =~ "yes" ]]; then
+    echo -n " --ww_ti_usb_reset='$ww_ti_usb_reset'" | tee -a $OREF0_RUNAGAIN
+fi
+if [[ ! -z "$BLE_MAC" ]]; then
+    echo -n " --blemac='$BLE_MAC'" | tee -a $OREF0_RUNAGAIN
+fi
+if [[ ! -z "$BT_MAC" ]]; then
+    echo -n " --btmac='$BT_MAC'" | tee -a $OREF0_RUNAGAIN
+fi
+if [[ ! -z "$BT_PEB" ]]; then
+    echo -n " --btpeb='$BT_PEB'" | tee -a $OREF0_RUNAGAIN
+fi
+if [[ ! -z "$PUSHOVER_TOKEN" ]]; then
+    echo -n " --pushover_token='$PUSHOVER_TOKEN'" | tee -a $OREF0_RUNAGAIN
+fi
+if [[ ! -z "$PUSHOVER_USER" ]]; then
+    echo -n " --pushover_user='$PUSHOVER_USER'" | tee -a $OREF0_RUNAGAIN
+fi
 echo; echo | tee -a $OREF0_RUNAGAIN
 chmod 755 $OREF0_RUNAGAIN
 


### PR DESCRIPTION
This fixes a missing `fi` that is breaking oref0-setup, and all the messed-up indentation whitespace that contributed to my thinking it wasn't needed when I did the merge conflict resolution (plus some other indentation stuff that was making it hard to find the missing `fi`).

Will need to do a patch release of this.