### PR TITLE
Stop using ~/myopenaps/.git/

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oref0",
-  "version": "0.5.2",
+  "version": "0.6.0-dev",
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",


### PR DESCRIPTION
Since day 1, the `openaps` toolkit has used `git` to provide full auditability of every file whose contents are controlled by `openaps`. This has definitely been useful, especially in the early years when we were troubleshooting lots of bugs in the openaps toolkit and with peoples' custom aliases and reports. Since we've standardized everyone's openaps setups with oref0-setup, though, we've found that the need for json-file auditability has greatly diminished, to the point where I think it's been almost a year since we relied on the openaps git history for troubleshooting an issue. Instead, we either run openaps commands manually to reproduce an issue, or look at the pump-loop.log or other log output to see what was happening if there was an issue that is no longer occurring. This approach is serving us well enough that I don't think git is really needed any longer for most OpenAPS users.

In addition, we routinely (multiple times a week) have someone complaining on Gitter or (usually) Facebook that their rig has stopped working due to some sort of git error. We've automated fixes for most of these (up to and including automatically deleting the ~/myopenaps/.git repo), but would prefer to eliminate the problem entirely for average users by having oref0-setup configure their myopenaps directory with --nogit. Anyone setting up openaps manually can still instantiate their aps directory without the flag, of course, and will still get all the benefits of git auditability.

This branch has been tested on a single rig.  Test procedure was:
 - clone and checkout https://github.com/openaps/openaps/tree/nogit, and install using `python setup.py develop`
 - clone and checkout https://github.com/openaps/oref0/tree/nogit, and install using `npm run global-install`
 - remove ~/myopenaps and ~/myopenaps-cgm-loop
 - re-run oref0-setup via oref0-runagain.sh

We still need to test other upgrade paths, ensure that a version of `openaps` with --nogit support is installed, etc., and then do more extensive testing to make sure nothing else breaks.

Requires https://github.com/openaps/openaps/pull/130