### PR TITLE
use pumphistory-merged.json for IOB calculations

### DIFF
--- a/lib/oref0-setup/report.json
+++ b/lib/oref0-setup/report.json
@@ -212,7 +212,7 @@
       "clock": "monitor/clock-zoned.json",
       "reporter": "text",
       "json_default": "True",
-      "pumphistory": "monitor/pumphistory-zoned.json",
+      "pumphistory": "monitor/pumphistory-merged.json",
       "device": "iob",
       "remainder": ""
     }


### PR DESCRIPTION
Dunno how we missed this in dev, but without this change it looks like everyone's IOB calculations are being truncated at 2h per https://github.com/openaps/oref0/issues/554, so we'll need to test this and release it to master as a patch release.