### PR TITLE
fix &current_basal_safety_multiplier typo

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -547,12 +547,12 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 #fi
 
     cd $directory || die "Can't cd $directory"
-    if [[ "$max_iob" == "0" && -z "$max_daily_safety_multiplier" && -z "&current_basal_safety_multiplier" && -z "$bolussnooze_dia_divisor" && -z "$min_5m_carbimpact" ]]; then
+    if [[ "$max_iob" == "0" && -z "$max_daily_safety_multiplier" && -z "$current_basal_safety_multiplier" && -z "$bolussnooze_dia_divisor" && -z "$min_5m_carbimpact" ]]; then
         oref0-get-profile --exportDefaults > preferences.json || die "Could not run oref0-get-profile"
     else
         preferences_from_args=()
         if [[ "$max_iob" != "0" ]]; then
-        preferences_from_args+="\"max_iob\":$max_iob "
+            preferences_from_args+="\"max_iob\":$max_iob "
         fi
         if [[ ! -z "$max_daily_safety_multiplier" ]]; then
             preferences_from_args+="\"max_daily_safety_multiplier\":$max_daily_safety_multiplier "


### PR DESCRIPTION
Found this while looking for what might be causing the `SyntaxError: /root/myopenaps/preferences_from_args.json: Unexpected token .` error some people are reporting on FB. 

This might be contributing to it, or it might be unrelated, not sure.  Will need someone who can reproduce the original problem to test this as a possible fix.