### PR TITLE
enable SMB/UAM for a full 6 hours after any carb entry

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -261,14 +261,18 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // disable SMB when a high temptarget is set
     if (profile.temptargetSet && target_bg > 100) {
         enableSMB=false;
-    // enable SMB (if enabled in preferences) for DIA hours after bolus
+    // enable SMB/UAM (if enabled in preferences) for DIA hours after bolus
     } else if (profile.enableSMB_with_bolus && bolusiob > 0.1) {
         enableSMB=true;
-    // enable SMB (if enabled in preferences) while we have COB
+    // enable SMB/UAM (if enabled in preferences) while we have COB
     } else if (profile.enableSMB_with_COB && meal_data.mealCOB) {
         enableSMB=true;
-    // enable SMB (if enabled in preferences) if a low temptarget is set
+    // enable SMB/UAM (if enabled in preferences) if a low temptarget is set
     } else if (profile.enableSMB_with_temptarget && (profile.temptargetSet && target_bg < 100)) {
+        enableSMB=true;
+    // enable SMB/UAM (if enabled in preferences) for a full 6 hours after any carb entry
+    // (6 hours is defined in carbWindow in lib/meal/total.js)
+    } else if (profile.enableSMB_after_carbs && meal_data.carbs) {
         enableSMB=true;
     }
     // enable UAM (if enabled in preferences) for DIA hours after bolus, or if SMB is enabled

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -33,6 +33,7 @@ function defaults ( ) {
     , enableSMB_with_bolus: false // enable supermicrobolus for DIA hours after a manual bolus
     , enableSMB_with_COB: false // enable supermicrobolus while COB is positive
     , enableSMB_with_temptarget: false // enable supermicrobolus for eating soon temp targets
+    , enableSMB_after_carbs: false // enable supermicrobolus for 6h after carbs, even with 0 COB
   };
   return profile;
 }


### PR DESCRIPTION
With shorter DIAs and large meals with undercounted carbs, COB often decays to 0 before carb absorption finishes, and UAM cuts off after DIA hours.  This preference, if enabled, would allow UAM to remain active and allow oref1 to SMB if needed for 6 hours after any carb entry, unless disabled by a high temp target.