### PR TITLE
use sudo to install it decocare with easy_install. This is required for installing it on rpi. 

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -523,7 +523,8 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     fi
 
     # install decocare with setuptools since 0.0.31 (with the 6.4U/h fix) isn't published properly to pypi
-    easy_install -U decocare
+	
+    sudo easy_install -U decocare || die "Can't easy_install decocare"
 
     mkdir -p $HOME/src/
     if [ -d "$HOME/src/oref0/" ]; then


### PR DESCRIPTION
small fix. make decocare work on a rpi.
tested ok.
please merge.