### PR TITLE
Fix handling of closely-timed boluses

### DIFF
--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -9,7 +9,7 @@ function reduce (treatments) {
   function in_previous (ev) {
     var found = false;
     previous.forEach(function (elem) {
-      if (elem.timestamp == ev.timestamp && ev._type == elem._type) {
+      if (elem.timestamp === ev.timestamp && ev._type === elem._type) {
         found = true;
       }
     });
@@ -30,7 +30,7 @@ function reduce (treatments) {
 
   function bolus (ev, remaining) {
     if (!ev) { console.error('XXX', ev, remaining); return; }
-    if (ev._type == 'BolusWizard') {
+    if (ev._type === 'BolusWizard') {
       state.carbs = ev.carb_input.toString( );
       state.ratio = ev.carb_ratio.toString( );
       if (ev.bg) {
@@ -43,19 +43,21 @@ function reduce (treatments) {
       previous.push(ev);
     }
 
-    if (ev._type == 'Bolus') {
+    if (ev._type === 'Bolus') {
       state.duration = ev.duration.toString( );
       // if (state.square || state.bolus) { }
       // state.insulin = (state.insulin ? state.insulin : 0) + ev.amount;
       if (ev.duration && ev.duration > 0) {
         state.square = ev;
       } else {
-        state.bolus = ev;
+        if (state.bolus) {
+          state.bolus.amount = state.bolus.amount + ev.amount;
+        } else
+          state.bolus = ev;
       }
       state.created_at = state.timestamp = ev.timestamp;
       previous.push(ev);
     }
-
 
     if (remaining && remaining.length > 0) {
       if (state.bolus && state.wizard) {
@@ -69,9 +71,8 @@ function reduce (treatments) {
       // console.error("remaining", remaining);
       state.eventType = '<none>';
 
-      state.insulin = (state.square ? state.square.amount : 0) +
-                      (state.bolus ? state.bolus.amount : 0);
-      var has_insulin = state.insulin && state.insulin > 0;
+      state.insulin = (state.insulin ? state.insulin : 0) + (state.square ? state.square.amount : 0) +
+            (state.bolus ? state.bolus.amount : 0);      var has_insulin = state.insulin && state.insulin > 0;
       var has_carbs = state.carbs && state.carbs > 0;
       var has_wizard = state.wizard ? true : false;
       var has_bolus = state.bolus ? true : false;
@@ -151,7 +152,7 @@ function reduce (treatments) {
     switch (current._type) {
       case 'Bolus':
       case 'BolusWizard':
-        var tail = within_minutes_from(current, treatments.slice(index+1), 4);
+        var tail = within_minutes_from(current, treatments.slice(index+1), 2);
         bolus(current, tail);
         break;
       default:

--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -72,7 +72,8 @@ function reduce (treatments) {
       state.eventType = '<none>';
 
       state.insulin = (state.insulin ? state.insulin : 0) + (state.square ? state.square.amount : 0) +
-            (state.bolus ? state.bolus.amount : 0);      var has_insulin = state.insulin && state.insulin > 0;
+            (state.bolus ? state.bolus.amount : 0);
+      var has_insulin = state.insulin && state.insulin > 0;
       var has_carbs = state.carbs && state.carbs > 0;
       var has_wizard = state.wizard ? true : false;
       var has_bolus = state.bolus ? true : false;

--- a/tests/bolus.test.js
+++ b/tests/bolus.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var should = require('should');
+
+describe('bolus', function () {
+    var bolushistory = [
+        {
+            "_type": "Bolus",
+            "_description": "Bolus 2017-04-12T12:49:49 head[4], body[0] op[0x01]",
+            "timestamp": "2017-04-12T12:49:49-05:00",
+            "_body": "",
+            "programmed": 3.0,
+            "_head": "011e1e00",
+            "amount": 3.0,
+            "duration": 0,
+            "type": "normal",
+            "_date": "71314c0c11"
+        },
+        {
+            "_type": "Bolus",
+            "_description": "Bolus 2017-04-12T12:47:53 head[4], body[0] op[0x01]",
+            "timestamp": "2017-04-12T12:47:53-05:00",
+            "_body": "",
+            "programmed": 0.2,
+            "_head": "01020200",
+            "amount": 0.2,
+            "duration": 0,
+            "type": "normal",
+            "_date": "752f4c4c11"
+        }
+    ];
+    it('should not skip closely-timed boluses', function () {
+        var reduce_boluses = require('../lib/bolus');
+        var vals = reduce_boluses(bolushistory);
+        vals.length.should.equal(1);
+        vals[0].insulin.should.equal('3.2');
+    })
+});


### PR DESCRIPTION
**Why is this needed?**
Boluses, especially with SMB, may arrive spaced very closely together.  The current bolus pre-processing will combine these with bolus wizard records to generate synthetic records containing portions of the various records.  Instead of adding additional boluses that occur with a bolus wizard matching window (5 minutes), it simply uses the first that occurred after a bolus wizard record.  That was incorrect behavior.
**What is this doing?**
The bolus-wizard matching window is being shortened to 2 minutes, which is long enough to avoid some nightscout deduplication behavior that can lead to missed records.  Within the 2-minute window, any boluses are added together so the totals match reality, even if the event sequence doesn't exactly match pump history.  The total amount of insulin delivered will be correct.
**Fixes: [#443](https://github.com/openaps/oref0/issues/443)**