### PR TITLE
simply calculate biobContrib using 2t instead of t

### DIFF
--- a/lib/iob/calculate.js
+++ b/lib/iob/calculate.js
@@ -136,22 +136,12 @@ function iobCalc(treatment, time, dia, profile) {
 
         activityContrib = treatment.insulin * (S / Math.pow(tau, 2)) * t * (1 - t / td) * Math.exp(-t / tau);
         iobContrib = treatment.insulin * (1 - S * (1 - a) * ((Math.pow(t, 2) / (tau * td * (1 - a)) - t / tau - 1) * Math.exp(-t / tau) + 1));
+        // calculate bolus snooze insulin in the same pass
+        t = t * profile.bolussnooze_dia_divisor;
+        var biobContrib = treatment.insulin * (1 - S * (1 - a) * ((Math.pow(t, 2) / (tau * td * (1 - a)) - t / tau - 1) * Math.exp(-t / tau) + 1));
 
         //console.error('DIA: ' + dia + ' t: ' + t + ' td: ' + td + ' tp: ' + tp + ' tau: ' + tau + ' a: ' + a + ' S: ' + S + ' activityContrib: ' + activityContrib + ' iobContrib: ' + iobContrib);
 
-        // calculate bolus snooze insulin in the same pass
-
-        td = td / profile.bolussnooze_dia_divisor;
-        if (t > td) {
-            t = td;
-        }
-        if (tp > (td / 2.5)) {
-            tp = Math.floor(td / 2.5);
-        }
-        tau = tp * (1 - tp / td) / (1 - 2 * tp / td);
-        a = 2 * tau / td;
-        S = 1 / (1 - a + (1 + a) * Math.exp(-td / tau));
-        var biobContrib = treatment.insulin * (1 - S * (1 - a) * ((Math.pow(t, 2) / (tau * td * (1 - a)) - t / tau - 1) * Math.exp(-t / tau) + 1));
     }
 
     results = {

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -191,9 +191,9 @@ describe('IOB', function() {
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.77);
-        hourLater.bolussnooze.should.be.lessThan(0.77);
+        hourLater.bolussnooze.should.be.lessThan(0.36);
         hourLater.iob.should.be.greaterThan(0.72);
-        hourLater.bolussnooze.should.be.greaterThan(0.5);
+        hourLater.bolussnooze.should.be.greaterThan(0.354);
 
         hourLater.activity.should.be.greaterThan(0.0055);
         hourLater.activity.should.be.lessThan(0.007);
@@ -243,9 +243,9 @@ describe('IOB', function() {
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.81);
-        hourLater.bolussnooze.should.be.lessThan(0.81);
+        hourLater.bolussnooze.should.be.lessThan(0.5);
         hourLater.iob.should.be.greaterThan(0.76);
-        hourLater.bolussnooze.should.be.greaterThan(0.56);
+        hourLater.bolussnooze.should.be.greaterThan(0.40);
         
         hourLater.iob.should.be.greaterThan(0);
         hourLater.activity.should.be.greaterThan(0.0047);
@@ -296,10 +296,10 @@ describe('IOB', function() {
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.59);
-        hourLater.bolussnooze.should.be.lessThan(0.59);
+        hourLater.bolussnooze.should.be.lessThan(0.23);
         
         hourLater.iob.should.be.greaterThan(0.57);
-        hourLater.bolussnooze.should.be.greaterThan(0.51);
+        hourLater.bolussnooze.should.be.greaterThan(0.21);
         
         hourLater.activity.should.be.greaterThan(0.007);
         hourLater.activity.should.be.lessThan(0.0085);


### PR DESCRIPTION
Rather than figure out how to modify the IOB formula, we can simply set t = t * profile.bolussnooze_dia_divisor and then use the same formula again with the new value of t.  This will cause us to find the point twice as far along the IOB curve, achieving the same things as we currently do for the bilinear curves, of making bolus snooze IOB decay twice as fast as "real" IOB.

Needs testing.