### PR TITLE
Calling out the number one beginner error

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -32,7 +32,7 @@ smb_main() {
     prep
     if ! ( \
         prep
-	# checking to see if the log reports out that it's on % basal type, which blocks remote temps being set
+        # checking to see if the log reports out that it is on % basal type, which blocks remote temps being set
         if grep -q '"Temp":"percent"' monitor/temp_basal.json; then
             echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
     	fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -32,6 +32,10 @@ smb_main() {
     prep
     if ! ( \
         prep
+	# checking to see if the log reports out that it's on % basal type, which blocks remote temps being set
+        if grep -q '"Temp":"percent"' monitor/temp_basal.json; then
+            echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
+    	fi
         echo && echo Starting supermicrobolus pump-loop at $(date) with $upto30s second wait_for_silence: \
         && wait_for_bg \
         && wait_for_silence $upto30s \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -20,7 +20,10 @@ main() {
         && touch monitor/pump_loop_completed -r monitor/pump_loop_enacted \
         && echo); do
 
-            # On a random subset of failures, wait 45s and mmtune
+            if grep -q "percent" monitor/temp_basal.json; then
+                echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
+            fi
+            # On a random subset of failures, mmtune
             echo Error, retrying \
             && maybe_mmtune
             sleep 5
@@ -33,9 +36,6 @@ smb_main() {
     if ! ( \
         prep
         # checking to see if the log reports out that it is on % basal type, which blocks remote temps being set
-        if grep -q "percent" monitor/temp_basal.json; then
-            echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
-    	fi
         echo && echo Starting supermicrobolus pump-loop at $(date) with $upto30s second wait_for_silence: \
         && wait_for_bg \
         && wait_for_silence $upto30s \
@@ -68,6 +68,10 @@ smb_main() {
             && touch monitor/pump_loop_completed -r monitor/pump_loop_enacted \
             && echo \
     ); then
+        echo -n "SMB pump-loop failed. "
+        if grep -q "percent" monitor/temp_basal.json; then
+            echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
+    	fi
         maybe_mmtune
         echo Unsuccessful supermicrobolus pump-loop at $(date)
     fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -33,7 +33,7 @@ smb_main() {
     if ! ( \
         prep
         # checking to see if the log reports out that it is on % basal type, which blocks remote temps being set
-        if grep -q '"Temp":"percent"' monitor/temp_basal.json; then
+        if grep -q "percent" monitor/temp_basal.json; then
             echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
     	fi
         echo && echo Starting supermicrobolus pump-loop at $(date) with $upto30s second wait_for_silence: \


### PR DESCRIPTION
Number one error for beginners that blocks looping is when people don't have the pump set to absolute u/hr (in % basal type instead), which prevents the rig from being able to set temp basals.

(Note: needs testing)