### PR TITLE
if currentDeviation is null or maxDeviation is 0, set mealCOB to 0

### DIFF
--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -67,6 +67,17 @@ function diaCarbs(opts, time) {
     // set a hard upper limit on COB to mitigate impact of erroneous or malicious carb entry
     mealCOB = Math.min( profile.maxCOB, mealCOB );
 
+    // if currentDeviation is null or maxDeviation is 0, set mealCOB to 0 for zombie-carb safety
+    if (typeof(c.currentDeviation) === 'undefined' || c.currentDeviation === null) {
+        console.error("Warning: setting mealCOB to 0 because currentDeviation is null/undefined");
+        mealCOB = 0;
+    }
+    if (typeof(c.maxDeviation) === 'undefined' || c.maxDeviation === null) {
+        console.error("Warning: setting mealCOB to 0 because maxDeviation is 0 or undefined");
+        mealCOB = 0;
+    }
+
+
     return {
         carbs: Math.round( carbs * 1000 ) / 1000
     ,   boluses: Math.round( boluses * 1000 ) / 1000


### PR DESCRIPTION
This should help eliminate one source of zombie carbs by forcing mealCOB to 0 until we have enough data to properly calculate deviations.