### PR TITLE
speed up COB calculation

### DIFF
--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -148,7 +148,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
         iob_inputs.clock=bgTime;
         iob_inputs.profile.current_basal = basal.basalLookup(basalprofile, bgTime);
         //console.log(JSON.stringify(iob_inputs.profile));
-        var iob = get_iob(iob_inputs)[0];
+        var iob = get_iob(iob_inputs, true)[0];
         //console.log(JSON.stringify(iob));
 
         var bgi = Math.round(( -iob.activity * sens * 5 )*100)/100;

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -1,5 +1,6 @@
 var basal = require('oref0/lib/profile/basal');
 var get_iob = require('oref0/lib/iob');
+var find_insulin = require('oref0/lib/iob/history');
 var isf = require('../profile/isf');
 
 function detectSensitivityandCarbAbsorption(inputs) {
@@ -35,6 +36,9 @@ function detectSensitivityandCarbAbsorption(inputs) {
             }
         }
     }
+
+    // get treatments from pumphistory once, not every time we get_iob()
+    var treatments = find_insulin(inputs.iob_inputs);
 
     var avgDeltas = [];
     var bgis = [];
@@ -148,7 +152,9 @@ function detectSensitivityandCarbAbsorption(inputs) {
         iob_inputs.clock=bgTime;
         iob_inputs.profile.current_basal = basal.basalLookup(basalprofile, bgTime);
         //console.log(JSON.stringify(iob_inputs.profile));
-        var iob = get_iob(iob_inputs, true)[0];
+        //console.error("Before: ", new Date().getTime());
+        var iob = get_iob(iob_inputs, true, treatments)[0];
+        //console.error("After: ", new Date().getTime());
         //console.log(JSON.stringify(iob));
 
         var bgi = Math.round(( -iob.activity * sens * 5 )*100)/100;

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -4,7 +4,7 @@ var find_insulin = require('./history');
 var calculate = require('./calculate');
 var sum = require('./total');
 
-function generate (inputs) {
+function generate (inputs, currentIOBOnly) {
 
     var treatments = find_insulin(inputs);
 
@@ -30,8 +30,15 @@ function generate (inputs) {
         }
         //if (treatment.insulin && treatment.started_at) { console.error(treatment.insulin,treatment.started_at,lastBolusTime); }
     });
-    // predict IOB out to DIA plus 30m to account for any running temp basals
-    for (i=0; i<((inputs.profile.dia*60)+30); i+=5){
+    var iStop;
+    if (currentIOBOnly) {
+        // for COB calculation, we only need the zeroth element of iobArray
+        iStop=1
+    } else {
+        // predict IOB out to DIA plus 30m to account for any running temp basals
+        iStop=(inputs.profile.dia*60)+30;
+    }
+    for (i=0; i<iStop; i+=5){
         t = new Date(clock.getTime() + i*60000);
         //console.error(t);
         var iob = sum(opts, t);

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -4,9 +4,11 @@ var find_insulin = require('./history');
 var calculate = require('./calculate');
 var sum = require('./total');
 
-function generate (inputs, currentIOBOnly) {
+function generate (inputs, currentIOBOnly, treatments) {
 
-    var treatments = find_insulin(inputs);
+    if (!treatments) {
+        var treatments = find_insulin(inputs);
+    }
 
     var opts = {
         treatments: treatments


### PR DESCRIPTION
We have been doing a bunch of unnecessary future IOB calculations in the COB calculation subroutine when all we really need at that point is the current IOB.  This passes a flag to get_iob() to tell it not to bother with all that when we're just going to throw away the results anyway.

My `time openaps report invoke monitor/meal.json` run (on an Edison with lots of treatments) went from 1m59s to 1m17s with this change.  Everything still seems to be working normally after a few completed loops.