### PR TITLE
Separate out meal calcs from monitor-pump alias

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -372,7 +372,7 @@ function gather {
     && ( openaps monitor-pump || openaps monitor-pump ) 2>&1 >/dev/null | tail -1 \
     && echo -n ed \
     && merge_pumphistory \
-    && echo " pumphistory" \
+    && echo -n " pumphistory" \
     && openaps report invoke monitor/meal.json 2>&1 >/dev/null | tail -1 \
     && echo " and meal.json" \
     || (echo; exit 1) 2>/dev/null

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -372,7 +372,10 @@ function gather {
     && ( openaps monitor-pump || openaps monitor-pump ) 2>&1 >/dev/null | tail -1 \
     && echo -n ed \
     && merge_pumphistory \
-    && echo " pumphistory" || (echo; exit 1) 2>/dev/null
+    && echo " pumphistory" \
+    && openaps report invoke monitor/meal.json 2>&1 >/dev/null | tail -1 \
+    && echo " and meal.json" \
+    || (echo; exit 1) 2>/dev/null
 }
 
 function merge_pumphistory {

--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -106,7 +106,7 @@ function detectSensitivityandCarbAbsorption(inputs) {
                 //console.error(gapDelta, lastbg, elapsed_minutes);
                 nextbg = lastbg + (5/elapsed_minutes * gapDelta);
                 bucketed_data[j].glucose = Math.round(nextbg);
-                console.error("Interpolated", bucketed_data[j]);
+                //console.error("Interpolated", bucketed_data[j]);
 
                 elapsed_minutes = elapsed_minutes - 5;
                 lastbg = nextbg;

--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -43,7 +43,7 @@
   },
   {
     "monitor-pump": {
-      "command": "report invoke monitor/clock.json monitor/temp_basal.json monitor/pumphistory.json monitor/pumphistory-zoned.json monitor/clock-zoned.json monitor/iob.json monitor/meal.json monitor/reservoir.json monitor/battery.json monitor/status.json"
+      "command": "report invoke monitor/clock.json monitor/temp_basal.json monitor/pumphistory.json monitor/pumphistory-zoned.json monitor/clock-zoned.json monitor/iob.json monitor/reservoir.json monitor/battery.json monitor/status.json"
     },
     "type": "alias",
     "name": "monitor-pump"


### PR DESCRIPTION
Currently oref0-meal takes a long and variable amount of time to run.  Running as part of the monitor-pump alias, the meal.json report also runs after merge_pumphistory, which means it's working with old data.  We should instead run it separately.  For now I'm leaving it as part of the gather function, but at some point we may want to pull it out into ns-loop or something.
