### PR TITLE
don't SMB unless bg > threshold

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -796,7 +796,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //console.error(profile.temptargetSet, target_bg, rT.COB);
         // only allow microboluses with COB or low temp targets, or within DIA hours of a bolus
         // only microbolus if 0.1U SMB represents 20m or less of basal (0.3U/hr or higher)
-        if (microBolusAllowed && enableSMB && profile.current_basal >= 0.3) {
+        if (microBolusAllowed && enableSMB && profile.current_basal >= 0.3 && bg > threshold) {
             // never bolus more than 30m worth of basal
             maxBolus = round(profile.current_basal/2,1);
             // bolus 1/3 the insulinReq, up to maxBolus


### PR DESCRIPTION
https://github.com/openaps/oref0/blob/smb-lgs/lib/determine-basal/determine-basal.js#L564-L568 skips low glucose suspend if IOB is already super negative and BG is rising faster than predicted.  However, while it's useful to be able to avoid extended zero temping in that situation, it's best to avoid SMBs until BG has risen above the LGS threshold.