### PR TITLE
Speed up COB calculation by only converting pumphistory to treatments once

### DIFF
--- a/lib/determine-basal/cob-autosens.js
+++ b/lib/determine-basal/cob-autosens.js
@@ -1,5 +1,6 @@
 var basal = require('oref0/lib/profile/basal');
 var get_iob = require('oref0/lib/iob');
+var find_insulin = require('oref0/lib/iob/history');
 var isf = require('../profile/isf');
 
 function detectSensitivityandCarbAbsorption(inputs) {
@@ -35,6 +36,9 @@ function detectSensitivityandCarbAbsorption(inputs) {
             }
         }
     }
+
+    // get treatments from pumphistory once, not every time we get_iob()
+    var treatments = find_insulin(inputs.iob_inputs);
 
     var avgDeltas = [];
     var bgis = [];
@@ -148,7 +152,9 @@ function detectSensitivityandCarbAbsorption(inputs) {
         iob_inputs.clock=bgTime;
         iob_inputs.profile.current_basal = basal.basalLookup(basalprofile, bgTime);
         //console.log(JSON.stringify(iob_inputs.profile));
-        var iob = get_iob(iob_inputs, true)[0];
+        //console.error("Before: ", new Date().getTime());
+        var iob = get_iob(iob_inputs, true, treatments)[0];
+        //console.error("After: ", new Date().getTime());
         //console.log(JSON.stringify(iob));
 
         var bgi = Math.round(( -iob.activity * sens * 5 )*100)/100;

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -4,9 +4,11 @@ var find_insulin = require('./history');
 var calculate = require('./calculate');
 var sum = require('./total');
 
-function generate (inputs, currentIOBOnly) {
+function generate (inputs, currentIOBOnly, treatments) {
 
-    var treatments = find_insulin(inputs);
+    if (!treatments) {
+        var treatments = find_insulin(inputs);
+    }
 
     var opts = {
         treatments: treatments


### PR DESCRIPTION
Profiling lib/meal showed that most of the multiple minutes required to calculate IOB was spent in lib/iob/history continually re-parsing pumphistory into treatments for every 5m BG data point and for every carb treatment.  Since the contents of pumphistory are unchanged no matter which treatment or entry we're considering, we can instead just parse pumphistory into treatments once and then pass the result on each get_iob run.

This reduces time spent calculating meal.json by a factor of 5x 

pi@pi2-erf ~/myopenaps $ cd ~/src/oref0/ && git checkout 0.6.0-dev && cd ~/myopenaps && time openaps report invoke monitor/meal.json && cat monitor/meal.json && cd ~/src/oref0/ && git checkout optimized-cob && cd ~/myopenaps && time openaps report invoke monitor/meal.json && cat monitor/meal.json
Switched to branch '0.6.0-dev'
Your branch is up-to-date with 'origin/0.6.0-dev'.
meal://text/shell/monitor/meal.json
reporting monitor/meal.json

real    1m12.280s
user    1m11.030s
sys     0m2.050s
{"carbs":120,"boluses":10.9,"mealCOB":0,"currentDeviation":2.61,"maxDeviation":8.61,"minDeviationSlope":-13.846}
Switched to branch 'optimized-cob'
Your branch is up-to-date with 'origin/optimized-cob'.
meal://text/shell/monitor/meal.json
reporting monitor/meal.json

real    0m12.392s
user    0m9.210s
sys     0m1.160s
{"carbs":120,"boluses":10.9,"mealCOB":0,"currentDeviation":2.61,"maxDeviation":8.61,"minDeviationSlope":-13.846}