### PR TITLE
only updatePreferences with displayedDefaults

### DIFF
--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -27,9 +27,9 @@ function exportDefaults () {
 }
 
 function updatePreferences (prefs) {
-	var defaults = generate.defaults();
+	var defaults = generate.displayedDefaults();
 	
-	// check for any keys missing from current prefs and add from defaults
+	// check for any displayedDefaults missing from current prefs and add from defaults
 	
     for (var pref in defaults) {
       if (defaults.hasOwnProperty(pref) && !prefs.hasOwnProperty(pref)) {


### PR DESCRIPTION
Per https://github.com/openaps/oref0/issues/590, preferences.json is still displaying all defaults in some cases.  This would force it to only add in displayedDefaults.  If someone wants to change a non-displayed default, they'll have to add it to preferences.json manually.