### PR TITLE
Fix for Some openAPS treatments appearing as future dated in Nightscout reports for Australia timezone 

### DIFF
--- a/bin/mm-format-ns-treatments.sh
+++ b/bin/mm-format-ns-treatments.sh
@@ -27,7 +27,7 @@ model=$(json -f $MODEL)
 
 oref0-normalize-temps $HISTORY  \
   | json -e "this.medtronic = 'mm://openaps/$self/' + (this._type || this.eventType);" \
-    -e "this.created_at = this.created_at ? this.created_at : this.timestamp" \
+    -e "this.created_at = new Date(Date.parse(this.created_at ? this.created_at : this.timestamp)).toISOString()"\
     -e "this.enteredBy = 'openaps://medtronic/$model'" \
     -e "if (this.glucose && !this.glucoseType && this.glucose > 0) { this.glucoseType = this.enteredBy }" \
     -e "this.eventType = (this.eventType ?  this.eventType : 'Note')" \

--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -292,11 +292,11 @@ ns)
     ;;
     temp_targets)
     expr=${1--24hours}
-    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes)&find[eventType]=Temporary+Target"
+    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes -u)&find[eventType]=Temporary+Target"
     ;;
     carb_history)
     expr=${1--24hours}
-    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes)&find[carbs][\$exists]=true"
+    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes -u)&find[carbs][\$exists]=true"
     ;;
     *)
     echo "Unknown request:" $OP


### PR DESCRIPTION
Fix for https://github.com/openaps/oref0/issues/600

Nightscout stores treatments in UTC format. Nightscout find uses string compare for $gte, so:
- all treatments `created_at` fields must be set in UTC format
- all treatments must be queried in UTC format

I noticed also that `settings/temptargets.json` is queried in local time and not using a UTC, which I believe is a bug, because Nightscouts stores the `created_at` for temp targets in UTC format and Mongo `$gte` compare compares strings (and doesn't use the timezone).

This also fixes problems with false positive future treatments in Nightscout.

Installation
```
cd ~/src
mv oref0 oref0.openaps
git clone https://github.com/PieterGit/oref0.git
cd oref0
git checkout 201708_treatments
npm run global-install
rerun oref0-setup.sh or ~/myopenaps/oref0-runagain.sh
```

Please test on a seperate spare rig. 

The branch is based on the dev / 0.5.3 branch.

Pleas test: `openaps ns-meal-carbs`, and temp targets and Nightscout pump events.
Please check carb entries.