### PR TITLE
Fix for missing temp targets and carb treatments for timezones east of UTC

### DIFF
--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -292,11 +292,11 @@ ns)
     ;;
     temp_targets)
     expr=${1--24hours}
-    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes)&find[eventType]=Temporary+Target"
+    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes -u)&find[eventType]=Temporary+Target"
     ;;
     carb_history)
     expr=${1--24hours}
-    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes)&find[carbs][\$exists]=true"
+    exec ns-get host $NIGHTSCOUT_HOST treatments.json "find[created_at][\$gte]=$(date -d $expr -Iminutes -u)&find[carbs][\$exists]=true"
     ;;
     *)
     echo "Unknown request:" $OP

--- a/lib/oref0-setup/report.json
+++ b/lib/oref0-setup/report.json
@@ -18,7 +18,7 @@
       "use": "shell",
       "reporter": "JSON",
       "device": "ns",
-      "remainder": "-6hours",
+      "remainder": "-18hours",
       "json_default": "True"
     },
     "name": "monitor/carbhistory.json"


### PR DESCRIPTION
This PR is a temporary fix to address an issue with temp targets and carb histories extracted from NS. There is an inconsistency with the `created_at` field where entries made through Care Portal have `created_at` in UTC, while entries uploaded from oref0 have `created_at` in local time. The simple string compare used in the query is not timezone aware. (See https://github.com/openaps/oref0/issues/600 for discussion on this.)

 - `bin/nightscout.sh` has been modified to use UTC time in the query string for both `temp_targets` and `carb_history`
 - `lib/oref0-setup/report.json` has been modified to use a lookback of 18 hours for `monitor/carb_history.json` (so that users at UTC -12 will still get 6 hours of data for entries with `created_at` in local time)

Note that I'm assuming temp targets are all entered through care portal and don't need the 18 hours treatment. This is a temporary fix; the more robust solution is to ensure that `created_at` is always in UTC.

Needs testing for various timezones.