### PR TITLE
don't overreact to negative deviations from a big negative delta

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -170,6 +170,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // don't overreact to a big negative delta: use minAvgDelta if deviation is negative
     if (deviation < 0) {
         deviation = round( (30 / 5) * ( minAvgDelta - bgi ) );
+        // and if deviation is still negative, use long_avgdelta
+        if (deviation < 0) {
+            deviation = round( (30 / 5) * ( glucose_status.long_avgdelta - bgi ) );
+        }
     }
 
     // calculate the naive (bolus calculator math) eventual BG based on net IOB and sensitivity


### PR DESCRIPTION
When deviations are high after a meal and BG ticks downward due to CGM noise, we'll often see an immediate carbsReq notification (and aggressive zero temping) from the now-negative deviations.  Rather than (encouraging the user to) overreact to negative deviations from a single data point, I think it would be better to use a longer averaging interval in that case.  We already do this by switching to the minAvgDelta (the lower of short_avgdelta and long_avgdelta): this further extends that logic to use long_avgdelta if minAvgDelta results in a negative deviation.

As a result of this change, oref0 will also be slightly slower to zero temp when BG unexpectedly starts dropping, but will still stop SMBing / high temping immediately (and will still zero temp if in SMB mode).  And if it isn't already zero temping from SMBs, it will still zero temp after another 5-15 minutes if BG doesn't tick back up or flatten out.