### PR TITLE
honor autosens-adjusted ISF at meal-times

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -290,7 +290,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     ci = round((minDelta - bgi),1);
     uci = round((minAvgDelta - bgi),1);
     // ISF (mg/dL/U) / CR (g/U) = CSF (mg/dL/g)
-    var csf = sens / profile.carb_ratio
+    // use profile.sens instead of autosens-adjusted sens to avoid counteracting
+    // autosens meal insulin dosing adjustmenst when sensitive/resistant
+    var csf = profile.sens / profile.carb_ratio
     // set meal_carbimpact high enough to absorb all meal carbs over 6 hours
     // total_impact (mg/dL) = CSF (mg/dL/g) * carbs (g)
     //console.error(csf * meal_data.carbs);


### PR DESCRIPTION
We currently calculate CSF in determine-basal using autosens-adjusted ISF divided by carb ratio.  This means that we end up mostly counteracting the autosens ISF adjustments when doing OpenAPS-controlled meal dosing (via SMBs or high temps).  For example, if ISF is 40 mg/dL and CR is 10 g/U, normal CSF would be 4 mg/dL/g.  If the PWD is running sensitive and has an autosens-adjusted ISF of 60, then recalculating CSF to be 6 mg/dL/g would result in us trying to deliver 1U of insulin for every 10g of carbs (CR of 10 g/U) despite the higher ISF.  Only as COB starts to decay would we back off and start honoring the higher ISF by trying to reduce IOB.

This change should result in OpenAPS dosing more conservatively (high-temping and SMBing less, and/or low-temping more) after meals when autosens detects increased sensitivity, and dosing more aggressively (high-temping and SMBing more and low-temping less) when autosens detects resistance, as it already does at other times.