### PR TITLE
model remainingCarbs as a /\ shaped bilinear curve

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -328,7 +328,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     //5m data points = g * (1U/10g) * (40mg/dL/1U) / (mg/dL/5m)
     // duration (in 5m data points) = COB (g) * CSF (mg/dL/g) / ci (mg/dL/5m)
     // limit cid to 4 hours: the reset goes to remainingCI
-    cid = Math.min(4*60/5,Math.max(0, meal_data.mealCOB * csf / ci ));
+    cid = Math.min(4*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
     acid = Math.max(0, meal_data.mealCOB * csf / aci );
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
     console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (2h peak):",round(remainingCIpeak,1),"mg/dL per 5m");

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -311,9 +311,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var remainingCarbsIgnore = 1 - remainingCarbsFraction;
     var remainingCarbs = Math.max(0, meal_data.mealCOB - totalCA - meal_data.carbs*remainingCarbsIgnore);
     remainingCarbs = Math.min(remainingCarbsCap,remainingCarbs);
-    // assume remainingCarbs will absorb over 4h
+    // assume remainingCarbs will absorb in a /\ shaped bilinear curve peaking at 2h and ending at 4h
+    // area of the /\ triangle is the same as a remainingCIpeak-height rectangle out to 2h
+    // remainingCIpeak (mg/dL/5m) = remainingCarbs (g) * CSF (mg/dL/g) * 5 (m/5m) * 1h/60m / 2 (h)
+    var remainingCIpeak = remainingCarbs * csf * 5 / 60 / 2;
     // remainingCI (mg/dL/5m) = remainingCarbs (g) * CSF (mg/dL/g) * 5 (m/5m) * 1h/60m / 4 (h)
-    var remainingCI = remainingCarbs * csf * 5 / 60 / 4;
+    //var remainingCI = remainingCarbs * csf * 5 / 60 / 4;
     //console.error(profile.min_5m_carbimpact,ci,totalCI,totalCA,remainingCarbs,remainingCI);
     //if (meal_data.mealCOB * 3 > meal_data.carbs) { }
 
@@ -327,7 +330,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     cid = Math.max(0, meal_data.mealCOB * csf / ci );
     acid = Math.max(0, meal_data.mealCOB * csf / aci );
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
-    console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining 4h+ CI:",round(remainingCI,1),"mg/dL per 5m");
+    console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (2h peak):",round(remainingCIpeak,1),"mg/dL per 5m");
     console.error("Accel. Carb Impact:",aci,"mg/dL per 5m; ACI Duration:",round(acid*5/60*2,1),"hours");
     var minIOBPredBG = 999;
     var minCOBPredBG = 999;
@@ -357,10 +360,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // eventually accounting for all carbs (if they can be absorbed over DIA)
             predCI = Math.max(0, Math.max(0,ci) * ( 1 - COBpredBGs.length/Math.max(cid*2,1) ) );
             predACI = Math.max(0, Math.max(0,aci) * ( 1 - COBpredBGs.length/Math.max(acid*2,1) ) );
-            // if any carbs aren't absorbed after 4 hours, assume they'll absorb at a constant rate for next 4h
+            // if any carbs aren't absorbed after 4 hours, assume they'll absorb in a /\ shaped
+            // bilinear curve peaking at remainingCIpeak at 2h (24*5m) and ending at 4h (48*5m intervals)
+            var intervals = Math.min( COBpredBGs.length, 48-COBpredBGs.length );
+            var remainingCI = Math.max(0, intervals / 24 * remainingCIpeak );
             COBpredBG = COBpredBGs[COBpredBGs.length-1] + predBGI + Math.min(0,predDev) + predCI + remainingCI;
-            // stop adding remainingCI after 4h
-            if (COBpredBGs.length > 4 * 60 / 5) { remainingCI = 0; }
             aCOBpredBG = aCOBpredBGs[aCOBpredBGs.length-1] + predBGI + Math.min(0,predDev) + predACI;
             // for UAMpredBGs, predicted carb impact drops at minDeviationSlope
             // calculate predicted CI from UAM based on minDeviationSlope
@@ -386,8 +390,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if ( IOBpredBGs.length > 18 && (IOBpredBG < minIOBPredBG) ) { minIOBPredBG = round(IOBpredBG); }
             if ( IOBpredBG > maxIOBPredBG ) { maxIOBPredBG = IOBpredBG; }
             // wait 60m before setting COB and UAM minPredBGs
-            if ( (cid || remainingCI > 0) && COBpredBGs.length > 12 && (COBpredBG < minCOBPredBG) ) { minCOBPredBG = round(COBpredBG); }
-            if ( (cid || remainingCI > 0) && COBpredBG > maxIOBPredBG ) { maxCOBPredBG = COBpredBG; }
+            if ( (cid || reaminingCIpeak > 0) && COBpredBGs.length > 12 && (COBpredBG < minCOBPredBG) ) { minCOBPredBG = round(COBpredBG); }
+            if ( (cid || reaminingCIpeak > 0) && COBpredBG > maxIOBPredBG ) { maxCOBPredBG = COBpredBG; }
             if ( enableUAM && UAMpredBGs.length > 12 && (UAMpredBG < minUAMPredBG) ) { minUAMPredBG = round(UAMpredBG); }
             if ( enableUAM && UAMpredBG > maxIOBPredBG ) { maxUAMPredBG = UAMpredBG; }
         });
@@ -416,7 +420,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
         rT.predBGs.aCOB = aCOBpredBGs;
     }
-    if (meal_data.mealCOB > 0 && ( ci > 0 || remainingCI > 0 )) {
+    if (meal_data.mealCOB > 0 && ( ci > 0 || reaminingCIpeak > 0 )) {
         COBpredBGs.forEach(function(p, i, theArray) {
             theArray[i] = round(Math.min(401,Math.max(39,p)));
         });
@@ -428,7 +432,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         lastCOBpredBG=round(COBpredBGs[COBpredBGs.length-1]);
         eventualBG = Math.max(eventualBG, round(COBpredBGs[COBpredBGs.length-1]) );
     }
-    if (ci > 0 || remainingCI > 0) {
+    if (ci > 0 || reaminingCIpeak > 0) {
         if (enableUAM) {
             UAMpredBGs.forEach(function(p, i, theArray) {
                 theArray[i] = round(Math.min(401,Math.max(39,p)));
@@ -533,7 +537,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var bgUndershoot = target_bg - Math.max( naive_eventualBG, eventualBG, lastIOBpredBG );
     // calculate how long until COB (or IOB) predBGs drop below min_bg
     var minutesAboveMinBG = 240;
-    if (meal_data.mealCOB > 0 && ( ci > 0 || remainingCI > 0 )) {
+    if (meal_data.mealCOB > 0 && ( ci > 0 || reaminingCIpeak > 0 )) {
         for (var i=0; i<COBpredBGs.length; i++) {
             //console.error(COBpredBGs[i], min_bg);
             if ( COBpredBGs[i] < min_bg ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -290,7 +290,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     ci = round((minDelta - bgi),1);
     uci = round((minAvgDelta - bgi),1);
     // ISF (mg/dL/U) / CR (g/U) = CSF (mg/dL/g)
-    var csf = sens / profile.carb_ratio
+    // use profile.sens instead of autosens-adjusted sens to avoid counteracting
+    // autosens meal insulin dosing adjustmenst when sensitive/resistant
+    var csf = profile.sens / profile.carb_ratio
     // set meal_carbimpact high enough to absorb all meal carbs over 6 hours
     // total_impact (mg/dL) = CSF (mg/dL/g) * carbs (g)
     //console.error(csf * meal_data.carbs);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -327,7 +327,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     aci = 10;
     //5m data points = g * (1U/10g) * (40mg/dL/1U) / (mg/dL/5m)
     // duration (in 5m data points) = COB (g) * CSF (mg/dL/g) / ci (mg/dL/5m)
-    cid = Math.max(0, meal_data.mealCOB * csf / ci );
+    // limit cid to 4 hours: the reset goes to remainingCI
+    cid = Math.min(4*60/5,Math.max(0, meal_data.mealCOB * csf / ci ));
     acid = Math.max(0, meal_data.mealCOB * csf / aci );
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
     console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (2h peak):",round(remainingCIpeak,1),"mg/dL per 5m");

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -381,11 +381,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
             UAMpredBG = UAMpredBGs[UAMpredBGs.length-1] + predBGI + Math.min(0, predDev) + predUCI;
             //console.error(predBGI, predCI, predUCI);
-            // truncate all BG predictions at 3.5 hours
-            if ( IOBpredBGs.length < 42) { IOBpredBGs.push(IOBpredBG); }
-            if ( COBpredBGs.length < 42) { COBpredBGs.push(COBpredBG); }
-            if ( aCOBpredBGs.length < 42) { aCOBpredBGs.push(aCOBpredBG); }
-            if ( UAMpredBGs.length < 42) { UAMpredBGs.push(UAMpredBG); }
+            // truncate all BG predictions at 4 hours
+            if ( IOBpredBGs.length < 48) { IOBpredBGs.push(IOBpredBG); }
+            if ( COBpredBGs.length < 48) { COBpredBGs.push(COBpredBG); }
+            if ( aCOBpredBGs.length < 48) { aCOBpredBGs.push(aCOBpredBG); }
+            if ( UAMpredBGs.length < 48) { UAMpredBGs.push(UAMpredBG); }
             // wait 90m before setting minIOBPredBG
             if ( IOBpredBGs.length > 18 && (IOBpredBG < minIOBPredBG) ) { minIOBPredBG = round(IOBpredBG); }
             if ( IOBpredBG > maxIOBPredBG ) { maxIOBPredBG = IOBpredBG; }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -389,8 +389,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // wait 90m before setting minIOBPredBG
             if ( IOBpredBGs.length > 18 && (IOBpredBG < minIOBPredBG) ) { minIOBPredBG = round(IOBpredBG); }
             if ( IOBpredBG > maxIOBPredBG ) { maxIOBPredBG = IOBpredBG; }
-            // wait 60m before setting COB and UAM minPredBGs
-            if ( (cid || remainingCIpeak > 0) && COBpredBGs.length > 12 && (COBpredBG < minCOBPredBG) ) { minCOBPredBG = round(COBpredBG); }
+            // wait 90m before setting COB and 60m for UAM minPredBGs
+            if ( (cid || remainingCIpeak > 0) && COBpredBGs.length > 18 && (COBpredBG < minCOBPredBG) ) { minCOBPredBG = round(COBpredBG); }
             if ( (cid || remainingCIpeak > 0) && COBpredBG > maxIOBPredBG ) { maxCOBPredBG = COBpredBG; }
             if ( enableUAM && UAMpredBGs.length > 12 && (UAMpredBG < minUAMPredBG) ) { minUAMPredBG = round(UAMpredBG); }
             if ( enableUAM && UAMpredBG > maxIOBPredBG ) { maxUAMPredBG = UAMpredBG; }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -390,8 +390,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if ( IOBpredBGs.length > 18 && (IOBpredBG < minIOBPredBG) ) { minIOBPredBG = round(IOBpredBG); }
             if ( IOBpredBG > maxIOBPredBG ) { maxIOBPredBG = IOBpredBG; }
             // wait 60m before setting COB and UAM minPredBGs
-            if ( (cid || reaminingCIpeak > 0) && COBpredBGs.length > 12 && (COBpredBG < minCOBPredBG) ) { minCOBPredBG = round(COBpredBG); }
-            if ( (cid || reaminingCIpeak > 0) && COBpredBG > maxIOBPredBG ) { maxCOBPredBG = COBpredBG; }
+            if ( (cid || remainingCIpeak > 0) && COBpredBGs.length > 12 && (COBpredBG < minCOBPredBG) ) { minCOBPredBG = round(COBpredBG); }
+            if ( (cid || remainingCIpeak > 0) && COBpredBG > maxIOBPredBG ) { maxCOBPredBG = COBpredBG; }
             if ( enableUAM && UAMpredBGs.length > 12 && (UAMpredBG < minUAMPredBG) ) { minUAMPredBG = round(UAMpredBG); }
             if ( enableUAM && UAMpredBG > maxIOBPredBG ) { maxUAMPredBG = UAMpredBG; }
         });
@@ -420,7 +420,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
         rT.predBGs.aCOB = aCOBpredBGs;
     }
-    if (meal_data.mealCOB > 0 && ( ci > 0 || reaminingCIpeak > 0 )) {
+    if (meal_data.mealCOB > 0 && ( ci > 0 || remainingCIpeak > 0 )) {
         COBpredBGs.forEach(function(p, i, theArray) {
             theArray[i] = round(Math.min(401,Math.max(39,p)));
         });
@@ -432,7 +432,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         lastCOBpredBG=round(COBpredBGs[COBpredBGs.length-1]);
         eventualBG = Math.max(eventualBG, round(COBpredBGs[COBpredBGs.length-1]) );
     }
-    if (ci > 0 || reaminingCIpeak > 0) {
+    if (ci > 0 || remainingCIpeak > 0) {
         if (enableUAM) {
             UAMpredBGs.forEach(function(p, i, theArray) {
                 theArray[i] = round(Math.min(401,Math.max(39,p)));
@@ -537,7 +537,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var bgUndershoot = target_bg - Math.max( naive_eventualBG, eventualBG, lastIOBpredBG );
     // calculate how long until COB (or IOB) predBGs drop below min_bg
     var minutesAboveMinBG = 240;
-    if (meal_data.mealCOB > 0 && ( ci > 0 || reaminingCIpeak > 0 )) {
+    if (meal_data.mealCOB > 0 && ( ci > 0 || remainingCIpeak > 0 )) {
         for (var i=0; i<COBpredBGs.length; i++) {
             //console.error(COBpredBGs[i], min_bg);
             if ( COBpredBGs[i] < min_bg ) {

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -37,8 +37,8 @@ function generate (inputs, currentIOBOnly, treatments) {
         // for COB calculation, we only need the zeroth element of iobArray
         iStop=1
     } else {
-        // predict IOB out to DIA plus 30m to account for any running temp basals
-        iStop=(inputs.profile.dia*60)+30;
+        // predict IOB out to 4h, regardless of DIA
+        iStop=4*60;
     }
     for (i=0; i<iStop; i+=5){
         t = new Date(clock.getTime() + i*60000);


### PR DESCRIPTION
Per https://github.com/openaps/oref0/issues/619#issuecomment-323494069, current oref0 code models any carb absorption that hasn't yet begun as a constant value over the next 4 hours, such that, for example, a 120g meal would have a remainingCI equivalent to a constant 30g/hr for the next 4 hours.

This changes remainingCI from a constant to a bilinear curve that increases from 0 to a peak absorption rate (in g/h) of remainingCarbs/2, and then symmetrically decreases back to 0 at the 4h mark.

So if you entered 120g of carbs and had zero absorption so far, this change would cause oref0 to model absorption starting at 0, increasing to 30 g/h after 60m (1h), 60 g/h after 120m (2h), then back to 30 g/h after 180m (3h), and 0 g/h after 240m (4h). The average carb absorption over hours 1 and 4 would therefore be 15 g/h, and 45 g/h for hours 2 and 3.

As actual carb absorption is observed, the extrapolation of the current rate of carb absorption, linearly decreasing just fast enough to use up all the carbs by the time absorption hits zero, would gradually take over, and the future predicted carb absorption dominated by the /\ shaped remainingCI bilinear curve would transition to a \ shaped linear one.

This change would have a few main benefits. Firstly, it would eliminate the sudden jumps and drop-offs we see with a constant remainingCI. Today, if a 120g meal is entered w/o observed carb impact, we assume that carb absorption will instantly ramp up from 0 to 30 g/h, and then instantly drop off from 30g/h to zero after 4h. That is obviously unrealistic. Secondly, it would better match predicted CI to what we actually would expect to observe from a typical meal, resulting in more accurate cobPredBGs. And thirdly, it would continue to allow us to "push out" the predicted remainingCI past 4 hours when current CI is not rising as fast as predicted, while allowing CI predictions to be "pulled in" when carb absorption is actually observed.

One other effect of this change is that it predicts a slower rise from newly-entered carbs than the previous constant remainingCI.  Since insulinReq is currently based on the insulin required to get the minimum predicted BG (from 60m out to ~4h into the future) down to target, this means that this change actually decreases the insulinReq immediately after meal carb entry.  To counteract this, I've changed the start time for calculating minCOBpredBG from 60m to 90m.