### PR TITLE
Move Edison refs to Explorer IF/Then section

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -18,8 +18,16 @@ dpkg-reconfigure tzdata
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
 apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate
-adduser edison sudo
-adduser edison dialout
+#check if edison user exists before trying to add it to groups
+
+if  getent passwd edison > /dev/null; then
+  echo "Adding edison to sudo users"
+  adduser edison sudo
+  echo "Adding edison to dialout users"
+  adduser edison dialout
+ else
+  echo "User edison does not exist. Apparently, you are runnning a non-edison setup."
+fi
 
 sed -i "s/daily/hourly/g" /etc/logrotate.conf
 sed -i "s/#compress/compress/g" /etc/logrotate.conf

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script sets up an openaps environment by defining the required devices,
-# reports, and aliases, and optionally enabling it in cron, 
+# reports, and aliases, and optionally enabling it in cron,
 # plus editing other user-entered configuration settings.
 # Released under MIT license. See the accompanying LICENSE.txt file for
 # full terms and conditions
@@ -190,6 +190,29 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
         ttyport=/dev/spidev5.1
         echocolor "Ok, yay for Explorer Board! "
         echo
+        # Install EdisonVoltage
+        if egrep -i "edison" /etc/passwd 2>/dev/null; then
+            echo "Checking if EdisonVoltage is already installed"
+            if [ -d "$HOME/src/EdisonVoltage/" ]; then
+                echo "EdisonVoltage already installed"
+            else
+                echo "Installing EdisonVoltage"
+                cd $HOME/src && git clone -b master git://github.com/cjo20/EdisonVoltage.git || (cd EdisonVoltage && git checkout master && git pull)
+                cd $HOME/src/EdisonVoltage
+                make voltage
+            fi
+            # Add module needed for EdisonVoltage to work on jubilinux 0.2.0
+            grep iio_basincove_gpadc /etc/modules-load.d/modules.conf || echo iio_basincove_gpadc >> /etc/modules-load.d/modules.conf
+            cd $directory || die "Can't cd $directory"
+            for type in edisonbattery; do
+                echo importing $type file
+                cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
+            done
+        fi
+        # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
+        if egrep -i "edison" /etc/passwd 2>/dev/null; then
+        (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; cat $directory/monitor/edison-battery.json | json batteryVoltage | awk '{if (\$1<=3050)system(\"sudo shutdown -h now\")}'") | crontab -
+        fi
     else
         read -p 'Are you using mmeowlink (i.e. with a TI stick)? If not, press enter. If so, what TTY port (full port address, looks like "/dev/ttySOMETHING" without the quotes - you probably want to copy paste it)? ' -r
         ttyport=$REPLY
@@ -830,25 +853,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         touch /tmp/reboot-required
     fi
 
-    # Install EdisonVoltage
-    if egrep -i "edison" /etc/passwd 2>/dev/null; then
-        echo "Checking if EdisonVoltage is already installed"
-        if [ -d "$HOME/src/EdisonVoltage/" ]; then
-            echo "EdisonVoltage already installed"
-        else
-            echo "Installing EdisonVoltage"
-            cd $HOME/src && git clone -b master git://github.com/cjo20/EdisonVoltage.git || (cd EdisonVoltage && git checkout master && git pull)
-            cd $HOME/src/EdisonVoltage
-            make voltage
-        fi
-        # Add module needed for EdisonVoltage to work on jubilinux 0.2.0
-        grep iio_basincove_gpadc /etc/modules-load.d/modules.conf || echo iio_basincove_gpadc >> /etc/modules-load.d/modules.conf
-        cd $directory || die "Can't cd $directory"
-        for type in edisonbattery; do
-            echo importing $type file
-            cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
-        done
-    fi
+
     # Install Pancreabble
     echo Checking for BT Pebble Mac
     if [[ ! -z "$BT_PEB" ]]; then
@@ -997,10 +1002,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
         (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
         fi
-        # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
-        if egrep -i "edison" /etc/passwd 2>/dev/null; then
-        (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; cat $directory/monitor/edison-battery.json | json batteryVoltage | awk '{if (\$1<=3050)system(\"sudo shutdown -h now\")}'") | crontab -
-        fi
+
         (crontab -l; crontab -l | grep -q "cd $directory && oref0-delete-future-entries" || echo "@reboot cd $directory && oref0-delete-future-entries") | crontab -
         if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
             (crontab -l; crontab -l | grep -q "oref0-pushover" || echo "* * * * * cd $directory && oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log" ) | crontab -

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script sets up an openaps environment by defining the required devices,
-# reports, and aliases, and optionally enabling it in cron,
+# reports, and aliases, and optionally enabling it in cron, 
 # plus editing other user-entered configuration settings.
 # Released under MIT license. See the accompanying LICENSE.txt file for
 # full terms and conditions
@@ -190,29 +190,6 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
         ttyport=/dev/spidev5.1
         echocolor "Ok, yay for Explorer Board! "
         echo
-        # Install EdisonVoltage
-        if egrep -i "edison" /etc/passwd 2>/dev/null; then
-            echo "Checking if EdisonVoltage is already installed"
-            if [ -d "$HOME/src/EdisonVoltage/" ]; then
-                echo "EdisonVoltage already installed"
-            else
-                echo "Installing EdisonVoltage"
-                cd $HOME/src && git clone -b master git://github.com/cjo20/EdisonVoltage.git || (cd EdisonVoltage && git checkout master && git pull)
-                cd $HOME/src/EdisonVoltage
-                make voltage
-            fi
-            # Add module needed for EdisonVoltage to work on jubilinux 0.2.0
-            grep iio_basincove_gpadc /etc/modules-load.d/modules.conf || echo iio_basincove_gpadc >> /etc/modules-load.d/modules.conf
-            cd $directory || die "Can't cd $directory"
-            for type in edisonbattery; do
-                echo importing $type file
-                cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
-            done
-        fi
-        # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
-        if egrep -i "edison" /etc/passwd 2>/dev/null; then
-        (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; cat $directory/monitor/edison-battery.json | json batteryVoltage | awk '{if (\$1<=3050)system(\"sudo shutdown -h now\")}'") | crontab -
-        fi
     else
         read -p 'Are you using mmeowlink (i.e. with a TI stick)? If not, press enter. If so, what TTY port (full port address, looks like "/dev/ttySOMETHING" without the quotes - you probably want to copy paste it)? ' -r
         ttyport=$REPLY
@@ -853,7 +830,25 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         touch /tmp/reboot-required
     fi
 
-
+    # Install EdisonVoltage
+    if egrep -i "edison" /etc/passwd 2>/dev/null; then
+        echo "Checking if EdisonVoltage is already installed"
+        if [ -d "$HOME/src/EdisonVoltage/" ]; then
+            echo "EdisonVoltage already installed"
+        else
+            echo "Installing EdisonVoltage"
+            cd $HOME/src && git clone -b master git://github.com/cjo20/EdisonVoltage.git || (cd EdisonVoltage && git checkout master && git pull)
+            cd $HOME/src/EdisonVoltage
+            make voltage
+        fi
+        # Add module needed for EdisonVoltage to work on jubilinux 0.2.0
+        grep iio_basincove_gpadc /etc/modules-load.d/modules.conf || echo iio_basincove_gpadc >> /etc/modules-load.d/modules.conf
+        cd $directory || die "Can't cd $directory"
+        for type in edisonbattery; do
+            echo importing $type file
+            cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
+        done
+    fi
     # Install Pancreabble
     echo Checking for BT Pebble Mac
     if [[ ! -z "$BT_PEB" ]]; then
@@ -1002,7 +997,10 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
         (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
         fi
-
+        # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
+        if egrep -i "edison" /etc/passwd 2>/dev/null; then
+        (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; cat $directory/monitor/edison-battery.json | json batteryVoltage | awk '{if (\$1<=3050)system(\"sudo shutdown -h now\")}'") | crontab -
+        fi
         (crontab -l; crontab -l | grep -q "cd $directory && oref0-delete-future-entries" || echo "@reboot cd $directory && oref0-delete-future-entries") | crontab -
         if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
             (crontab -l; crontab -l | grep -q "oref0-pushover" || echo "* * * * * cd $directory && oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log" ) | crontab -


### PR DESCRIPTION
An attmept to reduce problems on Pi based rigs by moving Edison references to the Explorer If/Then section of the setup.  Also edited openaps-install.sh to add a user check for user edison before attempting to adduser edison to sudo and dialout groups.  Please take a close look at this as this is my first attempt at modifying code and using the Github workflow. 