### PR TITLE
ignore bolusing status if pump is suspended

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -375,7 +375,8 @@ function wait_for_silence {
 function gather {
     openaps report invoke monitor/status.json 2>&1 >/dev/null | tail -1 \
     && echo -n Ref \
-    && test $(cat monitor/status.json | json bolusing) == false \
+    && ( test $(cat monitor/status.json | json suspended) == true || \
+         test $(cat monitor/status.json | json bolusing) == false ) \
     && echo -n resh \
     && ( openaps monitor-pump || openaps monitor-pump ) 2>&1 >/dev/null | tail -1 \
     && echo -n ed \


### PR DESCRIPTION
If the pump gets suspended while an SMB is being delivered, the pump remains in bolusing status until the pump is resumed, at which time the bolus delivery is completed.  This state caused our pumphistory Refresh check to fail, which meant that the rig would have been unable to unsuspend the pump if necessary.  By ignoring the bolusing status if the pump is suspended, we can proceed to pull pumphistory and check temp basal duration, and unsuspend the pump if the temp basal expires.