### PR TITLE
mmtune on failure if pump_loop_completed > 15m old

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -348,7 +348,7 @@ function mmtune {
 }
 
 function maybe_mmtune {
-    if ( find monitor/ -mmin -15 -size | egrep -q "mmtune|pump_loop_completed" ); then
+    if ( find monitor/ -mmin -15 | egrep -q "mmtune|pump_loop_completed" ); then
         # mmtune ~ 25% of the time
         [[ $(( ( RANDOM % 100 ) )) > 75 ]] \
         && echo "Waiting for 30s silence before mmtuning" \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -348,16 +348,16 @@ function mmtune {
 }
 
 function maybe_mmtune {
-    if (find monitor/ -mmin +15 -size +5c | grep -q mmtune); then
-        echo "mmtune.json more than 15m old; waiting for 30s silence before mmtuning"
-        wait_for_silence 30
-        mmtune
-    else
+    if ( find monitor/ -mmin -15 -size +5c | egrep -q "mmtune|pump_loop_completed" ); then
         # mmtune ~ 25% of the time
         [[ $(( ( RANDOM % 100 ) )) > 75 ]] \
         && echo "Waiting for 30s silence before mmtuning" \
         && wait_for_silence 30 \
         && mmtune
+    else
+        echo "mmtune.json and pump_loop_completed more than 15m old; waiting for 30s silence before mmtuning"
+        wait_for_silence 30
+        mmtune
     fi
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -348,14 +348,14 @@ function mmtune {
 }
 
 function maybe_mmtune {
-    if ( find monitor/ -mmin -15 | egrep -q "mmtune|pump_loop_completed" ); then
+    if ( find monitor/ -mmin -15 | egrep -q "pump_loop_completed" ); then
         # mmtune ~ 25% of the time
         [[ $(( ( RANDOM % 100 ) )) > 75 ]] \
         && echo "Waiting for 30s silence before mmtuning" \
         && wait_for_silence 30 \
         && mmtune
     else
-        echo "mmtune.json and pump_loop_completed more than 15m old; waiting for 30s silence before mmtuning"
+        echo "pump_loop_completed more than 15m old; waiting for 30s silence before mmtuning"
         wait_for_silence 30
         mmtune
     fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -348,7 +348,7 @@ function mmtune {
 }
 
 function maybe_mmtune {
-    if ( find monitor/ -mmin -15 -size +5c | egrep -q "mmtune|pump_loop_completed" ); then
+    if ( find monitor/ -mmin -15 -size | egrep -q "mmtune|pump_loop_completed" ); then
         # mmtune ~ 25% of the time
         [[ $(( ( RANDOM % 100 ) )) > 75 ]] \
         && echo "Waiting for 30s silence before mmtuning" \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -348,11 +348,17 @@ function mmtune {
 }
 
 function maybe_mmtune {
-    # mmtune ~ 25% of the time
-    [[ $(( ( RANDOM % 100 ) )) > 75 ]] \
-    && echo "Waiting for 30s silence before mmtuning" \
-    && wait_for_silence 30 \
-    && mmtune
+    if (find monitor/ -mmin +15 -size +5c | grep -q mmtune); then
+        echo "mmtune.json more than 15m old; waiting for 30s silence before mmtuning"
+        wait_for_silence 30
+        mmtune
+    else
+        # mmtune ~ 25% of the time
+        [[ $(( ( RANDOM % 100 ) )) > 75 ]] \
+        && echo "Waiting for 30s silence before mmtuning" \
+        && wait_for_silence 30 \
+        && mmtune
+    fi
 }
 
 # listen for $1 seconds of silence (no other rigs talking to pump) before continuing


### PR DESCRIPTION
If a rig hasn't mmtuned or completed a pump-loop recently and fails to loop, it's probably best to do an mmtune.  Setting "recently" to 15m for now.