### PR TITLE
Allow nonzero low temps for SMB

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -458,7 +458,7 @@ function refresh_smb_temp_and_enact {
         echo "pump_loop_completed more than 7m ago: setting temp before refreshing pumphistory. "
         smb_enact_temp
     else
-        echo -n "pump_loop_completed less than 5m ago. "
+        echo -n "pump_loop_completed less than 7m ago. "
     fi
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -452,11 +452,10 @@ function refresh_old_profile {
 function refresh_smb_temp_and_enact {
     # set mtime of monitor/glucose.json to the time of its most recent glucose value
     setglucosetimestamp
-    if ( find monitor/ -newer monitor/pump_loop_completed | grep -q glucose.json ); then
-        echo "glucose.json newer than pump_loop_completed. "
-        smb_enact_temp
-    elif ( find monitor/ -mmin -5 -size +5c | grep -q monitor/pump_loop_completed ); then
-        echo "pump_loop_completed more than 5m ago. "
+    # only smb_enact_temp if we haven't successfully completed a pump_loop recently
+    # (no point in enacting a temp that's going to get changed after we see our last SMB)
+    if ( find monitor/ -mmin -7 | grep -q monitor/pump_loop_completed ); then
+        echo "pump_loop_completed more than 7m ago: setting temp before refreshing pumphistory. "
         smb_enact_temp
     else
         echo -n "pump_loop_completed less than 5m ago. "

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -454,7 +454,7 @@ function refresh_smb_temp_and_enact {
     setglucosetimestamp
     # only smb_enact_temp if we haven't successfully completed a pump_loop recently
     # (no point in enacting a temp that's going to get changed after we see our last SMB)
-    if ( find monitor/ -mmin -7 | grep -q monitor/pump_loop_completed ); then
+    if ( find monitor/ -mmin +7 | grep -q monitor/pump_loop_completed ); then
         echo "pump_loop_completed more than 7m ago: setting temp before refreshing pumphistory. "
         smb_enact_temp
     else

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -454,11 +454,11 @@ function refresh_smb_temp_and_enact {
     setglucosetimestamp
     # only smb_enact_temp if we haven't successfully completed a pump_loop recently
     # (no point in enacting a temp that's going to get changed after we see our last SMB)
-    if ( find monitor/ -mmin +7 | grep -q monitor/pump_loop_completed ); then
-        echo "pump_loop_completed more than 7m ago: setting temp before refreshing pumphistory. "
+    if ( find monitor/ -mmin +10 | grep -q monitor/pump_loop_completed ); then
+        echo "pump_loop_completed more than 10m ago: setting temp before refreshing pumphistory. "
         smb_enact_temp
     else
-        echo -n "pump_loop_completed less than 7m ago. "
+        echo -n "pump_loop_completed less than 10m ago. "
     fi
 }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -846,7 +846,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
             //console.error(durationReq, worstCaseInsulinReq, smbTarget, naive_eventualBG, minIOBPredBG);
             var smbLowTempReq = 0;
-            if (durationReq < 0) {
+            if (durationReq <= 0) {
                 durationReq = 0;
             // don't set a temp longer than 120 minutes
             } else if (durationReq <= 30) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -844,19 +844,24 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 durationReq = 0;
             }
 
+            var smbLowTempReq = 0;
             if (durationReq < 0) {
                 durationReq = 0;
             // don't set a temp longer than 120 minutes
-            } else {
+            } else if (durationReq >= 30) {
                 durationReq = round(durationReq/30)*30;
                 durationReq = Math.min(120,Math.max(0,durationReq));
+            } else {
+                // if SMB durationReq is less than 30m, set a nonzero low temp
+                smbLowTempReq = round( basal * durationReq/30 ,2);
+                durationReq = 30;
             }
             rT.reason += " insulinReq " + insulinReq;
             if (microBolus >= maxBolus) {
                 rT.reason +=  "; maxBolus " + maxBolus;
             }
             if (durationReq > 0) {
-                rT.reason += "; setting " + durationReq + "m zero temp";
+                rT.reason += "; setting " + durationReq + "m low temp of " + smbLowTempReq + "U/h";
             }
             rT.reason += ". ";
 
@@ -876,7 +881,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
             // if no zero temp is required, don't return yet; allow later code to set a high temp
             if (durationReq > 0) {
-                rT.rate = 0;
+                rT.rate = smbLowTempReq;
                 rT.duration = durationReq;
                 return rT;
             }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -844,12 +844,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 durationReq = 0;
             }
 
-            //console.error(durationReq, worstCaseInsulinReq, smbTarget, naive_eventualBG, minIOBPredBG);
             var smbLowTempReq = 0;
             if (durationReq <= 0) {
                 durationReq = 0;
             // don't set a temp longer than 120 minutes
-            } else if (durationReq <= 30) {
+            } else if (durationReq >= 30) {
                 durationReq = round(durationReq/30)*30;
                 durationReq = Math.min(120,Math.max(0,durationReq));
             } else {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -844,11 +844,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 durationReq = 0;
             }
 
+            //console.error(durationReq, worstCaseInsulinReq, smbTarget, naive_eventualBG, minIOBPredBG);
             var smbLowTempReq = 0;
             if (durationReq < 0) {
                 durationReq = 0;
             // don't set a temp longer than 120 minutes
-            } else if (durationReq >= 30) {
+            } else if (durationReq <= 30) {
                 durationReq = round(durationReq/30)*30;
                 durationReq = Math.min(120,Math.max(0,durationReq));
             } else {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -868,7 +868,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             //allow SMBs every 2 minutes
             var nextBolusMins = round(2-lastBolusAge,1);
             //console.error(naive_eventualBG, insulinReq, worstCaseInsulinReq, durationReq);
-            console.error("naive_eventualBG",naive_eventualBG+",",durationReq+"m zero temp needed; last bolus",lastBolusAge+"m ago; maxBolus: "+maxBolus);
+            console.error("naive_eventualBG",naive_eventualBG+",",durationReq+"m "+smbLowTempReq+"U/h temp needed; last bolus",lastBolusAge+"m ago; maxBolus: "+maxBolus);
             if (lastBolusAge > 2) {
                 if (microBolus > 0) {
                     rT.units = microBolus;


### PR DESCRIPTION
Rather than oscillating back and forth between a 30m zero temp and a neutral temp, this allows SMB to set an intermediate low temp when less than 30m of zero temping is required.