### PR TITLE
URL encoding for autotune filters

### DIFF
--- a/bin/ns-get.sh
+++ b/bin/ns-get.sh
@@ -8,7 +8,7 @@ NIGHTSCOUT_HOST=${NIGHTSCOUT_HOST-${2-localhost:1337}}
 QUERY=${3}
 OUTPUT=${4-/dev/fd/1}
 
-CURL_FLAGS="--compressed -s"
+CURL_FLAGS="--compressed -g -s"
 NIGHTSCOUT_FORMAT=${NIGHTSCOUT_FORMAT-json}
 test "$NIGHTSCOUT_DEBUG" = "1" && CURL_FLAGS="${CURL_FLAGS} -iv"
 test "$NIGHTSCOUT_DEBUG" = "1" && set -x

--- a/bin/ns-get.sh
+++ b/bin/ns-get.sh
@@ -8,7 +8,7 @@ NIGHTSCOUT_HOST=${NIGHTSCOUT_HOST-${2-localhost:1337}}
 QUERY=${3}
 OUTPUT=${4-/dev/fd/1}
 
-CURL_FLAGS="--compressed -g -s"
+CURL_FLAGS="--compressed -s"
 NIGHTSCOUT_FORMAT=${NIGHTSCOUT_FORMAT-json}
 test "$NIGHTSCOUT_DEBUG" = "1" && CURL_FLAGS="${CURL_FLAGS} -iv"
 test "$NIGHTSCOUT_DEBUG" = "1" && set -x

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -161,7 +161,7 @@ fi
 echo "Grabbing NIGHTSCOUT treatments.json for date range..."
 
 # Get Nightscout carb and insulin Treatments
-query="find\[created_at\]\[\$gte\]=`date --date="$START_DATE -4 hours" -Iminutes`&find\[created_at\]\[\$lte\]=`date --date="$END_DATE +1 days" -Iminutes`"
+query="find%5Bcreated_at%5D%5B%24gte%5D=`date --date="$START_DATE -4 hours" -Iminutes`&find%5Bcreated_at%5D%5B%24lte%5D=`date --date="$END_DATE +1 days" -Iminutes`"
 echo Query: $NIGHTSCOUT_HOST/$query
 ns-get host $NIGHTSCOUT_HOST treatments.json $query > ns-treatments.json || die "Couldn't download ns-treatments.json"
 ls -la ns-treatments.json || die "No ns-treatments.json downloaded"
@@ -184,7 +184,7 @@ echo "Grabbing NIGHTSCOUT entries/sgv.json for date range..."
 # Get Nightscout BG (sgv.json) Entries
 for i in "${date_list[@]}"
 do 
-  query="find\[date\]\[\$gte\]=`(date -d $i +%s | tr -d '\n'; echo 000)`&find\[date\]\[\$lte\]=`(date --date="$i +1 days" +%s | tr -d '\n'; echo 000)`&count=1000"
+  query="find%5Bdate%5D%5B%24gte%5D=`(date -d $i +%s | tr -d '\n'; echo 000)`&find%5Bdate%5D%5B%24lte%5D=`(date --date="$i +1 days" +%s | tr -d '\n'; echo 000)`&count=1000"
   echo Query: $NIGHTSCOUT_HOST $query
   ns-get host $NIGHTSCOUT_HOST entries/sgv.json $query > ns-entries.$i.json || die "Couldn't download ns-entries.$i.json"
   ls -la ns-entries.$i.json || die "No ns-entries.$i.json downloaded"


### PR DESCRIPTION
The change in #578 to use ns-get instead of directly using curl broke the time based filters that autotune uses to limit its data download, because ns-get uses curl's `-g` flag.  This caused autotune in 0.5.3 dev to run extremely slowly (due to all the extra treatments) and to erroneously autotune with multiple days' worth of data each day. 