### PR TITLE
don't allow maxSMBBasalMinutes > 30 unless IOB (and COB) are > 0

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -809,7 +809,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 maxBolus = round( profile.current_basal * 30 / 60 ,1);
                 console.error("profile.maxSMBBasalMinutes undefined: defaulting to 30m");
             // if IOB covers more than COB, limit maxBolus to 30m of basal
-            } else if (iob_data.iob > mealInsulinReq) {
+            } else if ( iob_data.iob > mealInsulinReq && iob_data.iob > 0 ) {
                 console.error("IOB",iob_data.iob,"> COB",meal_data.mealCOB+"; mealInsulinReq =",mealInsulinReq);
                 maxBolus = round( profile.current_basal * 30 / 60 ,1);
             } else {


### PR DESCRIPTION
After a long period of zero temping and rescue carb rebound, COB had decayed to zero, but BG was still rising sharply and IOB was still < 0 when the rescue carb temp target expired and SMBs kicked back in.  As a result, an SMB of 1U was given, rather than being limited to 0.6U, contributing slightly to a later low.

This change would keep the maxSMBBasalMinutes at 30 any time IOB (and COB) are <= 0, thereby preventing large microboluses solely based on UAM when IOB is negative.