### PR TITLE
carbs: should only include carbs actually used in calculating COB

### DIFF
--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -35,6 +35,7 @@ function recentCarbs(opts, time) {
         return bDate.getTime() - aDate.getTime();
     });
 
+    var carbsToRemove = 0;
     treatments.forEach(function(treatment) {
         var now = time.getTime();
         // consider carbs from up to 6 hours ago in calculating COB
@@ -49,6 +50,13 @@ function recentCarbs(opts, time) {
                 var myCarbsAbsorbed = calcMealCOB(COB_inputs).carbsAbsorbed;
                 var myMealCOB = Math.max(0, carbs - myCarbsAbsorbed);
                 mealCOB = Math.max(mealCOB, myMealCOB);
+                //console.error(myMealCOB, mealCOB, carbs);
+                if (myMealCOB < mealCOB) {
+                    carbsToRemove += parseFloat(treatment.carbs);
+                } else {
+                    carbsToRemove = 0;
+                }
+                //console.error(carbs, carbsToRemove);
                 //console.error("COB:",mealCOB);
             }
             if (treatment.bolus >= 0.1) {
@@ -56,6 +64,8 @@ function recentCarbs(opts, time) {
             }
         }
     });
+    // only include carbs actually used in calculating COB
+    carbs -= carbsToRemove;
 
     // calculate the current deviation and steepest deviation downslope over the last hour
     COB_inputs.ciTime = time.getTime();

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -8,7 +8,6 @@ function recentCarbs(opts, time) {
         var glucose_data = opts.glucose;
     }
     var carbs = 0;
-    var boluses = 0;
     var carbDelay = 20 * 60 * 1000;
     var maxCarbs = 0;
     var mealCarbTime = time.getTime();
@@ -59,9 +58,6 @@ function recentCarbs(opts, time) {
                 //console.error(carbs, carbsToRemove);
                 //console.error("COB:",mealCOB);
             }
-            if (treatment.bolus >= 0.1) {
-                boluses += parseFloat(treatment.bolus);
-            }
         }
     });
     // only include carbs actually used in calculating COB
@@ -90,7 +86,6 @@ function recentCarbs(opts, time) {
 
     return {
         carbs: Math.round( carbs * 1000 ) / 1000
-    ,   boluses: Math.round( boluses * 1000 ) / 1000
     ,   mealCOB: Math.round( mealCOB )
     ,   currentDeviation: Math.round( c.currentDeviation * 100 ) / 100
     ,   maxDeviation: Math.round( c.maxDeviation * 100 ) / 100


### PR DESCRIPTION
Since the original mealAssist days, the `carbs` value in meal.json, also known as `mealCarbs` in some files, has contained the total number of carbs seen in the last 6 hours or so.  When using this value in determine-basal to blend COB and UAM, it would be better if `carbs` value only contained those carbs used in calculating the current COB value, and ignored carbs from previous meals that had fully expired before the current meal (and weren't stacked on top of it).

This change removes from `carbs` any carb values that don't end up getting used in COB calculation.