### PR TITLE
Trust COB a bit more until it decays

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -461,9 +461,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     minUAMPredBG = Math.max(39,minUAMPredBG);
     minPredBG = round(minIOBPredBG);
 
+    var fractionCarbsLeft = meal_data.mealCOB/meal_data.carbs;
     // if we have COB and UAM is enabled, average all three
     if ( minUAMPredBG < 400 && minCOBPredBG < 400 ) {
-        avgPredBG = round( (IOBpredBG + UAMpredBG + COBpredBG)/3 );
+        // weight COBpredBG vs. UAMpredBG based on how many carbs remain as COB
+        avgPredBG = round( (IOBpredBG/3 + (1-fractionCarbsLeft)*UAMpredBG*2/3 + fractionCarbsLeft*COBpredBG*2/3) );
     // if UAM is disabled, average IOB and COB
     } else if ( minCOBPredBG < 400 ) {
         avgPredBG = round( (IOBpredBG + COBpredBG)/2 );
@@ -492,7 +494,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // if we have COB, use minCOBPredBG, or blendedMinPredBG if it's higher
         } else if ( minCOBPredBG < 400 ) {
             // calculate blendedMinPredBG based on how many carbs remain as COB
-            fractionCarbsLeft = meal_data.mealCOB/meal_data.carbs;
             blendedMinPredBG = fractionCarbsLeft*minCOBPredBG + (1-fractionCarbsLeft)*avgMinPredBG;
             // if blendedMinPredBG > minCOBPredBG, use that instead
             minPredBG = round(Math.max(minIOBPredBG, minCOBPredBG, blendedMinPredBG));


### PR DESCRIPTION
We currently calculate avgPredBG as the straight average of IOBpredBG + UAMpredBG + COBpredBG when all three are available.  In order to be a bit more aggressive at dosing more insulin up front when COB is entered, and then a bit less trusting of the COBpredBGs once COB has decayed a bit, this change would weight COBpredBG vs. UAMpredBG based on how many carbs remain as COB, as we do for blendedMinPredBG.