### PR TITLE
remove autosens avgDelta-bgi < 6 check

### DIFF
--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -244,7 +244,7 @@ function detectSensitivity(inputs) {
         }
 
         // Exclude meal-related deviations (carb absorption) from autosens
-        if (type === "non-meal" && avgDelta-bgi < 6) {
+        if ( type === "non-meal" ) {
             if ( deviation > 0 ) {
                 //process.stderr.write(" "+bg.toString());
                 process.stderr.write("+");

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -259,7 +259,7 @@ function detectSensitivity(inputs) {
             deviations.push(deviation);
             deviationSum += parseFloat(deviation);
         } else {
-            process.stderr.write(">");
+            process.stderr.write("x");
             //console.error(bgTime);
         }
         // only keep the last 96 non-excluded data points (8h+ for any exclusions)


### PR DESCRIPTION
Per https://github.com/openaps/oref0/pull/629#issuecomment-327127003, now that autosens is properly excluding meals based on IOB and COB, we no longer need to exclude deltas >= 6 mg/dL from autosens calculations.