### PR TITLE
Autotune: calculate CR directly

### DIFF
--- a/bin/oref0-autotune-recommends-report.sh
+++ b/bin/oref0-autotune-recommends-report.sh
@@ -64,7 +64,7 @@ csf_new=$(cat $directory/autotune/profile.json | jq '.csf')
 carb_ratio_new=$(cat $directory/autotune/profile.json | jq '.carb_ratio')
 
 # Print Header Info
-printf "%-${parameter_width}s| %-${data_width}s| %-${data_width}s\n" "Parameter" "Current" "Autotune" >> $report_file
+printf "%-${parameter_width}s| %-${data_width}s| %-${data_width}s\n" "Parameter" "Pump" "Autotune" >> $report_file
 printf "%s\n" "-------------------------------------" >> $report_file
 
 # Print ISF, CSF and Carb Ratio Recommendations
@@ -74,10 +74,10 @@ if [ $csf_current != null ]; then
 else
   printf "%-${parameter_width}s| %-${data_width}s| %-${data_width}.3f\n" "CSF [mg/dL/g]" "n/a" $csf_new >> $report_file
 fi
-printf "%-${parameter_width}s| %-${data_width}.3f| %-${data_width}.3f\n" "Carb Ratio [g]" $carb_ratio_current $carb_ratio_new >> $report_file
+printf "%-${parameter_width}s| %-${data_width}.3f| %-${data_width}.3f\n" "Carb Ratio[g/U]" $carb_ratio_current $carb_ratio_new >> $report_file
 
 # Print Basal Profile Recommendations
-printf "%-${parameter_width}s| %-${data_width}s|\n" "Basal Profile  [unit/hour]" "-" >> $report_file
+printf "%-${parameter_width}s| %-${data_width}s|\n" "Basals [U/hr]" "-" >> $report_file
 
 # Build time_list array of H:M in 30 minute increments to mirror pump basal schedule
 time_list=()

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -204,8 +204,8 @@ do
     cp profile.json profile.$run_number.$i.json
     # Autotune Prep (required args, <pumphistory.json> <profile.json> <glucose.json>), output prepped glucose 
     # data or <autotune/glucose.json> below
-    echo "oref0-autotune-prep ns-treatments.json profile.json ns-entries.$i.json > autotune.$run_number.$i.json"
-    oref0-autotune-prep ns-treatments.json profile.json ns-entries.$i.json > autotune.$run_number.$i.json \
+    echo "oref0-autotune-prep ns-treatments.json profile.json ns-entries.$i.json profile.pump.json > autotune.$run_number.$i.json"
+    oref0-autotune-prep ns-treatments.json profile.json ns-entries.$i.json profile.pump.json > autotune.$run_number.$i.json \
         || die "Could not run oref0-autotune-prep ns-treatments.json profile.json ns-entries.$i.json"
     
     # Autotune  (required args, <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>), 

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script sets up an easy test environment for autotune, allowing the user to vary parameters 
-# like start/end date and number of runs.
+# like start/end date.
 # 
 # Required Inputs: 
 #   DIR, (--dir=<OpenAPS Directory>)
@@ -10,8 +10,6 @@
 # Optional Inputs:
 #   END_DATE, (--end-date=<YYYY-MM-DD>) 
 #     if no end date supplied, assume we want a months worth or until day before current day
-#   NUMBER_OF_RUNS (--runs=<integer, number of runs desired>)
-#     if no number of runs designated, then default to 5
 #   EXPORT_EXCEL (--xlsx=<filenameofexcel>)
 #     export to excel. Disabled by default
 #   TERMINAL_LOGGING (--log <true/false(true)>
@@ -39,7 +37,8 @@ DIR=""
 NIGHTSCOUT_HOST=""
 START_DATE=""
 END_DATE=""
-NUMBER_OF_RUNS=1  # Default to a single run if not otherwise specified
+START_DAYS_AGO=1  # Default to yesterday if not otherwise specified
+END_DAYS_AGO=1  # Default to yesterday if not otherwise specified
 EXPORT_EXCEL="" # Default is to not export to Microsoft Excel
 TERMINAL_LOGGING=true
 RECOMMENDS_REPORT=true
@@ -96,8 +95,12 @@ case $i in
     END_DATE=`date --date="$END_DATE" +%Y-%m-%d`
     shift # past argument=value
     ;;
-    -r=*|--runs=*)
-    NUMBER_OF_RUNS="${i#*=}"
+    -t=*|--start-days-ago=*)
+    START_DAYS_AGO="${i#*=}"
+    shift # past argument=value
+    ;;
+    -d=*|--end-days-ago=*)
+    END_DAYS_AGO="${i#*=}"
     shift # past argument=value
     ;;
     -x=*|--xlsx=*)
@@ -120,21 +123,21 @@ done
 NIGHTSCOUT_HOST=$(echo $NIGHTSCOUT_HOST | sed 's/\/$//g')
 
 if [[ -z "$DIR" || -z "$NIGHTSCOUT_HOST" ]]; then
-    echo "Usage: oref0-autotune <--dir=myopenaps_directory> <--ns-host=https://mynightscout.azurewebsites.net> [--start-date=YYYY-MM-DD] [--end-date=YYYY-MM-DD] [--runs=number_of_runs] [--xlsx=autotune.xlsx] [--log=(true)|false]"
+    echo "Usage: oref0-autotune <--dir=myopenaps_directory> <--ns-host=https://mynightscout.azurewebsites.net> [--start-days-ago=number_of_days] [--end-days-ago=number_of_days] [--start-date=YYYY-MM-DD] [--end-date=YYYY-MM-DD] [--xlsx=autotune.xlsx] [--log=(true)|false]"
 exit 1
 fi
 if [[ -z "$START_DATE" ]]; then
     # Default start date of yesterday
-    START_DATE=`date --date="1 day ago" +%Y-%m-%d`
+    START_DATE=`date --date="$START_DAYS_AGO days ago" +%Y-%m-%d`
 fi
 if [[ -z "$END_DATE" ]]; then
     # Default end-date as this morning at midnight in order to not get partial day samples for now
     # (ISF/CSF adjustments are still single values across each day)
-    END_DATE=`date --date="1 day ago" +%Y-%m-%d`
+    END_DATE=`date --date="$END_DAYS_AGO days ago" +%Y-%m-%d`
 fi
 
 if [[ -z "$UNKNOWN_OPTION" ]] ; then # everything is ok
-  echo "Running oref0-autotune --dir=$DIR --ns-host=$NIGHTSCOUT_HOST --start-date=$START_DATE --runs=$NUMBER_OF_RUNS --end-date=$END_DATE"
+  echo "Running oref0-autotune --dir=$DIR --ns-host=$NIGHTSCOUT_HOST --start-date=$START_DATE --end-date=$END_DATE"
 else
   echo "Unknown options. Exiting"
   exit 1
@@ -184,74 +187,63 @@ do
     ls -la ns-entries.$i.json || die "No ns-entries.$i.json downloaded"
 
     # Get Nightscout carb and insulin Treatments
-    echo $i $START_DATE;
+    # echo $i $START_DATE;
     #query="find%5Bdate%5D%5B%24gte%5D=`(date -d $i +%s | tr -d'\n'; echo 000)`&find%5Bdate%5D%5B%24lte%5D=`(date --date="$i +1 days" +%s | tr -d '\n'; echo 000)`&count=1000"
-    query="find%5Bcreated_at%5D%5B%24gte%5D=`date --date="$i -5 hours" -Iminutes`&find%5Bcreated_at%5D%5B%24lte%5D=`date --date="$END_DATE +1 days" -Iminutes`"
+    query="find%5Bcreated_at%5D%5B%24gte%5D=`date --date="$i -5 hours" -Iminutes`&find%5Bcreated_at%5D%5B%24lte%5D=`date --date="$i +1 days" -Iminutes`"
     echo Query: $NIGHTSCOUT_HOST/$query
     ns-get host $NIGHTSCOUT_HOST treatments.json $query > ns-treatments.$i.json || die "Couldn't download ns-treatments.$i.json"
     ls -la ns-treatments.$i.json || die "No ns-treatments.$i.json downloaded"
 
-done
 
-echo "Running $NUMBER_OF_RUNS runs from $START_DATE to $END_DATE"
-sleep 2
-
-# Do iterative runs over date range, save autotune.json (prepped data) and input/output 
-# profile.json
-# Loop 1: Run 1 to Number of Runs specified by user or by default (1)
-for run_number in $(seq 1 $NUMBER_OF_RUNS)
-do
-  # Loop 2: Iterate through Date Range
-  for i in "${date_list[@]}"
-  do
-    cp profile.json profile.$run_number.$i.json
+    # Do iterative runs over date range, save autotune.json (prepped data) and input/output profile.json
+    cp profile.json profile.$i.json
     # Autotune Prep (required args, <pumphistory.json> <profile.json> <glucose.json>), output prepped glucose 
     # data or <autotune/glucose.json> below
-    echo "oref0-autotune-prep ns-treatments.$i.json profile.json ns-entries.$i.json profile.pump.json > autotune.$run_number.$i.json"
-    oref0-autotune-prep ns-treatments.$i.json profile.json ns-entries.$i.json profile.pump.json > autotune.$run_number.$i.json \
+    echo "oref0-autotune-prep ns-treatments.$i.json profile.json ns-entries.$i.json profile.pump.json > autotune.$i.json"
+    oref0-autotune-prep ns-treatments.$i.json profile.json ns-entries.$i.json profile.pump.json > autotune.$i.json \
         || die "Could not run oref0-autotune-prep ns-treatments.$i.json profile.json ns-entries.$i.json"
     
     # Autotune  (required args, <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>), 
     # output autotuned profile or what will be used as <autotune/autotune.json> in the next iteration
-    echo "oref0-autotune-core autotune.$run_number.$i.json profile.json profile.pump.json > newprofile.$run_number.$i.json"
-    if ! oref0-autotune-core autotune.$run_number.$i.json profile.json profile.pump.json > newprofile.$run_number.$i.json; then
+    echo "oref0-autotune-core autotune.$i.json profile.json profile.pump.json > newprofile.$i.json"
+    if ! oref0-autotune-core autotune.$i.json profile.json profile.pump.json > newprofile.$i.json; then
         if cat profile.json | jq --exit-status .carb_ratio==null; then
             echo "ERROR: profile.json contains null carb_ratio: using profile.pump.json"
             cp profile.pump.json profile.json
             exit
         else
-            die "Could not run oref0-autotune-core autotune.$run_number.$i.json profile.json profile.pump.json"
+            die "Could not run oref0-autotune-core autotune.$i.json profile.json profile.pump.json"
         fi
     else
         # Copy tuned profile produced by autotune to profile.json for use with next day of data
-        cp newprofile.$run_number.$i.json profile.json
+        cp newprofile.$i.json profile.json
     fi
 
-  done # End Date Range Iteration
-done # End Number of Runs Loop
 
-if ! [[ -z "$EXPORT_EXCEL" ]]; then
-  echo Exporting to $EXPORT_EXCEL
-  oref0-autotune-export-to-xlsx --dir $DIR --output $EXPORT_EXCEL
-fi
+    if ! [[ -z "$EXPORT_EXCEL" ]]; then
+        echo Exporting to $EXPORT_EXCEL
+        oref0-autotune-export-to-xlsx --dir $DIR --output $EXPORT_EXCEL
+    fi
 
-# Create Summary Report of Autotune Recommendations and display in the terminal
-if [[ $RECOMMENDS_REPORT == "true" ]]; then
-  # Set the report file name, so we can let the user know where it is and cat
-  # it to the screen
-  report_file=$directory/autotune/autotune_recommendations.log
+    # Create Summary Report of Autotune Recommendations and display in the terminal
+    if [[ $RECOMMENDS_REPORT == "true" ]]; then
+        # Set the report file name, so we can let the user know where it is and cat
+        # it to the screen
+        report_file=$directory/autotune/autotune_recommendations.log
 
-  echo
-  echo "Autotune pump profile recommendations:"
-  echo "---------------------------------------------------------"
+        echo
+        echo "Autotune pump profile recommendations:"
+        echo "---------------------------------------------------------"
 
-  # Let the user know where the Autotune Recommendations are logged
-  echo "Recommendations Log File: $report_file"
-  echo
+        # Let the user know where the Autotune Recommendations are logged
+        echo "Recommendations Log File: $report_file"
+        echo
 
-  # Run the Autotune Recommends Report
-  oref0-autotune-recommends-report $directory
+        # Run the Autotune Recommends Report
+        oref0-autotune-recommends-report $directory
 
-  # Go ahead and echo autotune_recommendations.log to the terminal, minus blank lines
-  cat $report_file | egrep -v "\| *\| *$"
-fi
+        # Go ahead and echo autotune_recommendations.log to the terminal, minus blank lines
+        cat $report_file | egrep -v "\| *\| *$"
+    fi
+
+done # End Date Range Iteration

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -116,6 +116,9 @@ case $i in
 esac
 done
 
+# remove any trailing / from NIGHTSCOUT_HOST
+NIGHTSCOUT_HOST=$(echo $NIGHTSCOUT_HOST | sed 's/\/$//g')
+
 if [[ -z "$DIR" || -z "$NIGHTSCOUT_HOST" ]]; then
     echo "Usage: oref0-autotune <--dir=myopenaps_directory> <--ns-host=https://mynightscout.azurewebsites.net> [--start-date=YYYY-MM-DD] [--end-date=YYYY-MM-DD] [--runs=number_of_runs] [--xlsx=autotune.xlsx] [--log=(true)|false]"
 exit 1

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -330,10 +330,10 @@ function mmtune {
         reset_spi_serial.py 2>/dev/null
     fi
     oref0_init_pump_comms.py
-    echo -n "Listening for 30s silence before mmtuning: "
+    echo -n "Listening for 40s silence before mmtuning: "
     for i in $(seq 1 800); do
         echo -n .
-        any_pump_comms 30 2>/dev/null | egrep -v subg | egrep No \
+        any_pump_comms 40 2>/dev/null | egrep -v subg | egrep No \
         && break
     done
     echo {} > monitor/mmtune.json
@@ -353,12 +353,12 @@ function maybe_mmtune {
     if ( find monitor/ -mmin -15 | egrep -q "pump_loop_completed" ); then
         # mmtune ~ 25% of the time
         [[ $(( ( RANDOM % 100 ) )) > 75 ]] \
-        && echo "Waiting for 30s silence before mmtuning" \
-        && wait_for_silence 30 \
+        && echo "Waiting for 40s silence before mmtuning" \
+        && wait_for_silence 40 \
         && mmtune
     else
-        echo "pump_loop_completed more than 15m old; waiting for 30s silence before mmtuning"
-        wait_for_silence 30
+        echo "pump_loop_completed more than 15m old; waiting for 40s silence before mmtuning"
+        wait_for_silence 40
         mmtune
     fi
 }
@@ -370,7 +370,7 @@ function any_pump_comms {
 # listen for $1 seconds of silence (no other rigs talking to pump) before continuing
 function wait_for_silence {
     if [ -z $1 ]; then
-        waitfor=30
+        waitfor=40
     else
         waitfor=$1
     fi

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -97,7 +97,7 @@ function categorizeBGDatums(opts) {
             }
         }
     }
-    console.error(treatments);
+    //console.error(treatments);
     var calculatingCR = false;
     var absorbing = 0;
     var uam = 0; // unannounced meal
@@ -228,10 +228,10 @@ function categorizeBGDatums(opts) {
                 ,   CREndTime: CREndTime
                 ,   CRCarbs: CRCarbs
                 };
-                console.error(CRDatum);
+                //console.error(CRDatum);
 
                 var CRElapsedMinutes = Math.round((CREndTime - CRInitialCarbTime) / 1000 / 60);
-                console.error(CREndTime - CRInitialCarbTime, CRElapsedMinutes);
+                //console.error(CREndTime - CRInitialCarbTime, CRElapsedMinutes);
                 if ( CRElapsedMinutes < 60 ) {
                     console.error("Ignoring",CRElapsedMinutes,"m CR period.");
                 } else {
@@ -338,7 +338,7 @@ function categorizeBGDatums(opts) {
         };
         var insulinDosed = dosed(dosedOpts);
         CRDatum.CRInsulin = insulinDosed.insulin;
-        console.error(CRDatum);
+        //console.error(CRDatum);
     });
 
 

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -42,6 +42,7 @@ function categorizeBGDatums(opts) {
     var CSFGlucoseData = [];
     var ISFGlucoseData = [];
     var basalGlucoseData = [];
+    var UAMGlucoseData = [];
     var CRData = [];
 
     var bucketedData = [];
@@ -209,9 +210,9 @@ function categorizeBGDatums(opts) {
                 console.error("CRInitialIOB:",CRInitialIOB,"CRInitialBG:",CRInitialBG,"CRInitialCarbTime:",CRInitialCarbTime);
             }
             // keep calculatingCR as long as we have COB or enough IOB
-            if ( mealCOB > 0 ) {
+            if ( mealCOB > 0 && i>1 ) {
                 calculatingCR = true;
-            } else if ( iob.iob > currentBasal/2 ) {
+            } else if ( iob.iob > currentBasal/2 && i>1 ) {
                 calculatingCR = true;
             // when COB=0 and IOB drops low enough, record end values and be done calculatingCR
             } else {
@@ -247,7 +248,11 @@ function categorizeBGDatums(opts) {
         // If mealCOB is zero but all deviations since hitting COB=0 are positive, assign those data points to CSFGlucoseData
         // Once deviations go negative for at least one data point after COB=0, we can use the rest of the data to tune ISF or basals
         if (mealCOB > 0 || absorbing || mealCarbs > 0) {
-            if (deviation > 0) {
+            // if meal IOB has decayed, then end absorption after this data point unless COB > 0
+            if ( iob.iob < currentBasal/2 ) {
+                absorbing = 0;
+            // otherwise, as long as deviations are positive, keep tracking carb deviations
+            } else if (deviation > 0) {
                 absorbing = 1;
             } else {
                 absorbing = 0;
@@ -272,7 +277,8 @@ function categorizeBGDatums(opts) {
             console.error(CSFGlucoseData[CSFGlucoseData.length-1].mealAbsorption,"carb absorption");
           }
 
-          if (iob.iob > currentBasal || uam) {
+          // check that we have a decent amount of basal tuning data before excluding data as UAM
+          if ((iob.iob > currentBasal || uam) ) {
             if (deviation > 0) {
                 uam = 1;
             } else {
@@ -283,6 +289,7 @@ function categorizeBGDatums(opts) {
                 console.error(glucoseDatum.uamAbsorption,"uannnounced meal absorption");
             }
             type="uam";
+            UAMGlucoseData.push(glucoseDatum);
           } else {
             if ( type === "uam" ) {
                 console.error("end unannounced meal absorption");
@@ -298,12 +305,12 @@ function categorizeBGDatums(opts) {
                 // attempting to prevent basal from being calculated as negative; should help prevent basals from going below 0
                 var minPossibleDeviation = -( basalBGI + Math.max(0,BGI) );
                 //var minPossibleDeviation = -basalBGI;
-                if ( deviation < minPossibleDeviation ) {
-                    console.error("Adjusting deviation",deviation,"to",minPossibleDeviation.toFixed(2));
-                    deviation = minPossibleDeviation;
-                    deviation = deviation.toFixed(2);
-                    glucoseDatum.deviation = deviation;
-                }
+                //if ( deviation < minPossibleDeviation ) {
+                    //console.error("Adjusting deviation",deviation,"to",minPossibleDeviation.toFixed(2));
+                    //deviation = minPossibleDeviation;
+                    //deviation = deviation.toFixed(2);
+                    //glucoseDatum.deviation = deviation;
+                //}
                 type="basal";
                 basalGlucoseData.push(glucoseDatum);
             } else {
@@ -341,6 +348,29 @@ function categorizeBGDatums(opts) {
         //console.error(CRDatum);
     });
 
+    var CSFLength = CSFGlucoseData.length;
+    var ISFLength = ISFGlucoseData.length;
+    var UAMLength = UAMGlucoseData.length;
+    var basalLength = basalGlucoseData.length;
+
+    if (4*basalLength < CSFLength) {
+        console.error("Warning: too many deviations categorized as meals");
+        //console.error("Adding",CSFLength,"CSF deviations to",basalLength,"basal ones");
+        //var basalGlucoseData = basalGlucoseData.concat(CSFGlucoseData);
+        console.error("Adding",CSFLength,"CSF deviations to",ISFLength,"ISF ones");
+        var ISFGlucoseData = ISFGlucoseData.concat(CSFGlucoseData);
+        CSFGlucoseData = [];
+    }
+
+    if (2*basalLength < UAMLength) {
+        //console.error(basalGlucoseData, UAMGlucoseData);
+        console.error("Warning: too many deviations categorized as UnAnnounced Meals");
+        console.error("Adding",UAMLength,"UAM deviations to",basalLength,"basal ones");
+        var basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
+        console.error("Adding",UAMLength,"UAM deviations to",ISFLength,"ISF ones");
+        var ISFGlucoseData = ISFGlucoseData.concat(UAMGlucoseData);
+        //console.error(ISFGlucoseData.length, UAMLength);
+    }
 
     return {
         CRData: CRData,

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -2,6 +2,8 @@ var tz = require('moment-timezone');
 var basal = require('oref0/lib/profile/basal');
 var getIOB = require('oref0/lib/iob');
 var ISF = require('../profile/isf');
+var find_insulin = require('oref0/lib/iob/history');
+var dosed = require('./dosed');
 
 // main function categorizeBGDatums. ;) categorize to ISF, CSF, or basals.
 
@@ -37,10 +39,10 @@ function categorizeBGDatums(opts) {
         profile: profileData
     ,   history: opts.pumpHistory
     };
-    var mealCOB = 0;
     var CSFGlucoseData = [];
     var ISFGlucoseData = [];
     var basalGlucoseData = [];
+    var CRData = [];
 
     var bucketedData = [];
     bucketedData[0] = glucoseData[0];
@@ -95,11 +97,13 @@ function categorizeBGDatums(opts) {
             }
         }
     }
-    //console.error(treatments);
-    absorbing = 0;
-    uam = 0; // unannounced meal
-    mealCOB = 0;
-    mealCarbs = 0;
+    console.error(treatments);
+    var calculatingCR = false;
+    var absorbing = 0;
+    var uam = 0; // unannounced meal
+    var mealCOB = 0;
+    var mealCarbs = 0;
+    var CRCarbs = 0;
     var type="";
     // main for loop
     for (var i=bucketedData.length-5; i > 0; --i) {
@@ -110,6 +114,7 @@ function categorizeBGDatums(opts) {
         // As we're processing each data point, go through the treatment.carbs and see if any of them are older than
         // the current BG data point.  If so, add those carbs to COB.
         var treatment = treatments[treatments.length-1];
+        var myCarbs = 0;
         if (treatment) {
             var treatmentDate = new Date(tz(treatment.timestamp));
             var treatmentTime = treatmentDate.getTime();
@@ -118,6 +123,7 @@ function categorizeBGDatums(opts) {
                 if (treatment.carbs >= 1) {
                     mealCOB += parseFloat(treatment.carbs);
                     mealCarbs += parseFloat(treatment.carbs);
+                    myCarbs = treatment.carbs;
                 }
                 treatments.pop();
             }
@@ -141,12 +147,12 @@ function categorizeBGDatums(opts) {
 
         avgDelta = avgDelta.toFixed(2);
         glucoseDatum.avgDelta = avgDelta;
-        
+
         //sens = ISF
         var sens = ISF.isfLookup(IOBInputs.profile.isfProfile,BGDate);
         IOBInputs.clock=BGDate.toISOString();
-        // use the average of the last 4 hours' basals to help convergence; 
-        // this helps since the basal this hour could be different from previous, especially if with autotune they start to diverge. 
+        // use the average of the last 4 hours' basals to help convergence;
+        // this helps since the basal this hour could be different from previous, especially if with autotune they start to diverge.
         currentBasal = basal.basalLookup(opts.basalprofile, BGDate);
         BGDate1hAgo = new Date(BGTime-1*60*60*1000);
         BGDate2hAgo = new Date(BGTime-2*60*60*1000);
@@ -159,7 +165,7 @@ function categorizeBGDatums(opts) {
 
         //console.error(currentBasal,basal1hAgo,basal2hAgo,basal3hAgo,IOBInputs.profile.currentBasal);
         // basalBGI is BGI of basal insulin activity.
-        basalBGI = Math.round(( currentBasal * sens / 60 * 5 )*100)/100; // U/hr * mg/dL/U * 1 hr / 60 minutes * 5 = mg/dL/5m 
+        basalBGI = Math.round(( currentBasal * sens / 60 * 5 )*100)/100; // U/hr * mg/dL/U * 1 hr / 60 minutes * 5 = mg/dL/5m
         //console.log(JSON.stringify(IOBInputs.profile));
         // call iob since calculated elsewhere
         var iob = getIOB(IOBInputs)[0];
@@ -182,9 +188,61 @@ function categorizeBGDatums(opts) {
             var profile = profileData;
             ci = Math.max(deviation, profile.min_5m_carbimpact);
             absorbed = ci * profile.carb_ratio / sens;
+            // Store the COB, and use it as the starting point for the next data point.
             mealCOB = Math.max(0, mealCOB-absorbed);
         }
-        // Store the COB, and use it as the starting point for the next data point.
+
+
+        // Calculate carb ratio (CR) independently of CSF and ISF
+        // Use the time period from meal bolus/carbs until COB is zero and IOB is < currentBasal/2
+        // For now, if another meal IOB/COB stacks on top of it, consider them together
+        // Compare beginning and ending BGs, and calculate how much more/less insulin is needed to neutralize
+        // Use entered carbs vs. starting IOB + delivered insulin + needed-at-end insulin to directly calculate CR.
+
+        if (mealCOB > 0 || calculatingCR ) {
+            // set initial values when we first see COB
+            CRCarbs += myCarbs;
+            if (!calculatingCR) {
+                CRInitialIOB = iob.iob;
+                CRInitialBG = glucoseDatum.glucose;
+                CRInitialCarbTime = new Date(glucoseDatum.date);
+                console.error("CRInitialIOB:",CRInitialIOB,"CRInitialBG:",CRInitialBG,"CRInitialCarbTime:",CRInitialCarbTime);
+            }
+            // keep calculatingCR as long as we have COB or enough IOB
+            if ( mealCOB > 0 ) {
+                calculatingCR = true;
+            } else if ( iob.iob > currentBasal/2 ) {
+                calculatingCR = true;
+            // when COB=0 and IOB drops low enough, record end values and be done calculatingCR
+            } else {
+                CREndIOB = iob.iob;
+                CREndBG = glucoseDatum.glucose;
+                CREndTime = new Date(glucoseDatum.date);
+                console.error("CREndIOB:",CREndIOB,"CREndBG:",CREndBG,"CREndTime:",CREndTime);
+                var CRDatum = {
+                    CRInitialIOB: CRInitialIOB
+                ,   CRInitialBG: CRInitialBG
+                ,   CRInitialCarbTime: CRInitialCarbTime
+                ,   CREndIOB: CREndIOB
+                ,   CREndBG: CREndBG
+                ,   CREndTime: CREndTime
+                ,   CRCarbs: CRCarbs
+                };
+                console.error(CRDatum);
+
+                var CRElapsedMinutes = Math.round((CREndTime - CRInitialCarbTime) / 1000 / 60);
+                console.error(CREndTime - CRInitialCarbTime, CRElapsedMinutes);
+                if ( CRElapsedMinutes < 60 ) {
+                    console.error("Ignoring",CRElapsedMinutes,"m CR period.");
+                } else {
+                    CRData.push(CRDatum);
+                }
+
+                CRCarbs = 0;
+                calculatingCR = false;
+            }
+        }
+
 
         // If mealCOB is zero but all deviations since hitting COB=0 are positive, assign those data points to CSFGlucoseData
         // Once deviations go negative for at least one data point after COB=0, we can use the rest of the data to tune ISF or basals
@@ -266,7 +324,26 @@ function categorizeBGDatums(opts) {
         console.error(absorbing.toString(),"mealCOB:",mealCOB.toFixed(1),"mealCarbs:",mealCarbs,"basalBGI:",basalBGI.toFixed(1),"BGI:",BGI.toFixed(1),"IOB:",iob.iob.toFixed(1),"at",BGTime,"dev:",deviation,"avgDelta:",avgDelta,type);
     }
 
+    var IOBInputs = {
+        profile: profileData
+    ,   history: opts.pumpHistory
+    };
+    var treatments = find_insulin(IOBInputs);
+    CRData.forEach(function(CRDatum) {
+        var dosedOpts = {
+            treatments: treatments
+            , profile: opts.profile
+            , start: CRDatum.CRInitialCarbTime
+            , end: CRDatum.CREndTime
+        };
+        var insulinDosed = dosed(dosedOpts);
+        CRDatum.CRInsulin = insulinDosed.insulin;
+        console.error(CRDatum);
+    });
+
+
     return {
+        CRData: CRData,
         CSFGlucoseData: CSFGlucoseData,
         ISFGlucoseData: ISFGlucoseData,
         basalGlucoseData: basalGlucoseData

--- a/lib/autotune-prep/dosed.js
+++ b/lib/autotune-prep/dosed.js
@@ -1,0 +1,28 @@
+function insulinDosed(opts) {
+
+    var start = opts.start.getTime();
+    var end = opts.end.getTime();
+    var treatments = opts.treatments;
+    var profile_data = opts.profile;
+    var insulinDosed = 0;
+    if (!treatments) {
+        console.error("No treatments to process.");
+        return {};
+    }
+
+    treatments.forEach(function(treatment) {
+        //console.error(treatment);
+        if(treatment.insulin && treatment.date > start && treatment.date <= end) {
+            insulinDosed += treatment.insulin;
+        }
+    });
+    //console.error(insulinDosed);
+
+    var rval = {
+        insulin: Math.round( insulinDosed * 1000 ) / 1000
+    };
+
+    return rval;
+}
+
+exports = module.exports = insulinDosed;

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -3,7 +3,7 @@
 
 var tz = require('moment-timezone');
 var find_meals = require('oref0/lib/meal/history');
-var sum = require('./categorize');
+var categorize = require('./categorize');
 
 function generate (inputs) {
 
@@ -19,7 +19,7 @@ function generate (inputs) {
   , basalprofile: inputs.profile.basalprofile
   };
 
-  var autotune_prep_output = sum(opts);
+  var autotune_prep_output = categorize(opts);
   return autotune_prep_output;
 }
 

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -64,10 +64,10 @@ function tuneAllTheThings (inputs) {
     console.error("CRTotalCarbs:",CRTotalCarbs,"CRTotalInsulin:",CRTotalInsulin,"totalCR:",totalCR);
 
     // convert the basal profile to hourly if it isn't already
-    hourlyBasalProfile = [];
-    hourlyPumpProfile = [];
+    var hourlyBasalProfile = [];
+    var hourlyPumpProfile = [];
     for (var i=0; i < 24; i++) {
-        // aututuned basal profile
+        // autotuned basal profile
         for (var j=0; j < basalProfile.length; ++j) {
             if (basalProfile[j].minutes <= i * 60) {
                 if (basalProfile[j].rate == 0) {
@@ -101,6 +101,7 @@ function tuneAllTheThings (inputs) {
     }
     //console.error(hourlyPumpProfile);
     //console.error(hourlyBasalProfile);
+    var newHourlyBasalProfile = JSON.parse(JSON.stringify(hourlyBasalProfile));
 
     // look at net deviations for each hour
     for (var hour=0; hour < 24; hour++) {
@@ -129,8 +130,8 @@ function tuneAllTheThings (inputs) {
                 offsetHour = hour + offset;
                 if (offsetHour < 0) { offsetHour += 24; }
                 //console.error(offsetHour);
-                hourlyBasalProfile[offsetHour].rate += basalNeeded / 3;
-                hourlyBasalProfile[offsetHour].rate=Math.round(hourlyBasalProfile[offsetHour].rate*1000)/1000
+                newHourlyBasalProfile[offsetHour].rate += basalNeeded / 3;
+                newHourlyBasalProfile[offsetHour].rate=Math.round(newHourlyBasalProfile[offsetHour].rate*1000)/1000
             }
         // otherwise, figure out the percentage reduction required to the 1-3 hour prior basals
         // and adjust all of them downward proportionally
@@ -139,41 +140,66 @@ function tuneAllTheThings (inputs) {
             for (var offset=-3; offset < 0; offset++) {
                 offsetHour = hour + offset;
                 if (offsetHour < 0) { offsetHour += 24; }
-                threeHourBasal += hourlyBasalProfile[offsetHour].rate;
+                threeHourBasal += newHourlyBasalProfile[offsetHour].rate;
             }
             var adjustmentRatio = 1.0 + basalNeeded / threeHourBasal;
             //console.error(adjustmentRatio);
             for (var offset=-3; offset < 0; offset++) {
                 offsetHour = hour + offset;
                 if (offsetHour < 0) { offsetHour += 24; }
-                hourlyBasalProfile[offsetHour].rate = hourlyBasalProfile[offsetHour].rate * adjustmentRatio;
-                hourlyBasalProfile[offsetHour].rate=Math.round(hourlyBasalProfile[offsetHour].rate*1000)/1000
+                newHourlyBasalProfile[offsetHour].rate = newHourlyBasalProfile[offsetHour].rate * adjustmentRatio;
+                newHourlyBasalProfile[offsetHour].rate=Math.round(newHourlyBasalProfile[offsetHour].rate*1000)/1000
             }
         }
     }
     if (pumpBasalProfile && pumpBasalProfile[0]) {
         for (var hour=0; hour < 24; hour++) {
-            //console.error(hourlyBasalProfile[hour],hourlyPumpProfile[hour].rate*1.2);
+            //console.error(newHourlyBasalProfile[hour],hourlyPumpProfile[hour].rate*1.2);
             // cap adjustments at autosens_max and autosens_min
             autotuneMax = pumpProfile.autosens_max;
             autotuneMin = pumpProfile.autosens_min;
             var maxRate = hourlyPumpProfile[hour].rate * autotuneMax;
             var minRate = hourlyPumpProfile[hour].rate * autotuneMin;
-            if (hourlyBasalProfile[hour].rate > maxRate ) {
+            if (newHourlyBasalProfile[hour].rate > maxRate ) {
                 console.error("Limiting hour",hour,"basal to",maxRate.toFixed(2),"(which is",autotuneMax,"* pump basal of",hourlyPumpProfile[hour].rate,")");
                 //console.error("Limiting hour",hour,"basal to",maxRate.toFixed(2),"(which is 20% above pump basal of",hourlyPumpProfile[hour].rate,")");
-                hourlyBasalProfile[hour].rate = maxRate;
-            } else if (hourlyBasalProfile[hour].rate < minRate ) {
+                newHourlyBasalProfile[hour].rate = maxRate;
+            } else if (newHourlyBasalProfile[hour].rate < minRate ) {
                 console.error("Limiting hour",hour,"basal to",minRate.toFixed(2),"(which is",autotuneMin,"* pump basal of",hourlyPumpProfile[hour].rate,")");
                 //console.error("Limiting hour",hour,"basal to",minRate.toFixed(2),"(which is 20% below pump basal of",hourlyPumpProfile[hour].rate,")");
-                hourlyBasalProfile[hour].rate = minRate;
+                newHourlyBasalProfile[hour].rate = minRate;
             }
-            hourlyBasalProfile[hour].rate = Math.round(hourlyBasalProfile[hour].rate*1000)/1000;
+            newHourlyBasalProfile[hour].rate = Math.round(newHourlyBasalProfile[hour].rate*1000)/1000;
         }
     }
 
-    console.error(hourlyBasalProfile);
-    basalProfile = hourlyBasalProfile;
+    // some hours of the day rarely have data to tune basals due to meals.
+    // when no adjustments are needed to a particular hour, we should adjust it toward the average of the
+    // periods before and after it that do have data to be tuned
+
+    var lastAdjustedHour = 0;
+    // scan through newHourlyBasalProfile and find hours where the rate is unchanged
+    for (var hour=0; hour < 24; hour++) {
+        if (hourlyBasalProfile[hour].rate === newHourlyBasalProfile[hour].rate) {
+            var nextAdjustedHour = 23;
+            for (var nextHour = hour; nextHour < 24; nextHour++) {
+                if (! (hourlyBasalProfile[nextHour].rate === newHourlyBasalProfile[nextHour].rate)) {
+                    nextAdjustedHour = nextHour;
+                    break;
+                //} else {
+                    //console.error(nextHour, hourlyBasalProfile[nextHour].rate, newHourlyBasalProfile[nextHour].rate);
+                }
+            }
+            //console.error(hour, newHourlyBasalProfile);
+            newHourlyBasalProfile[hour].rate = Math.round( (0.9*hourlyBasalProfile[hour].rate + 0.05*newHourlyBasalProfile[lastAdjustedHour].rate + 0.05*newHourlyBasalProfile[nextAdjustedHour].rate)*1000 )/1000;
+            console.error("Adjusting hour",hour,"basal from",hourlyBasalProfile[hour].rate,"to",newHourlyBasalProfile[hour].rate,"based on hour",lastAdjustedHour,"=",newHourlyBasalProfile[lastAdjustedHour].rate,"and hour",nextAdjustedHour,"=",newHourlyBasalProfile[nextAdjustedHour].rate);
+        } else {
+            lastAdjustedHour = hour;
+        }
+    }
+
+    console.error(newHourlyBasalProfile);
+    basalProfile = newHourlyBasalProfile;
 
     // Calculate carb ratio (CR) independently of CSF and ISF
     // Use the time period from meal bolus/carbs until COB is zero and IOB is < currentBasal/2

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -316,7 +316,7 @@ function tuneAllTheThings (inputs) {
     if (pumpProfile.autotune_isf_adjustmentFraction) {
         adjustmentFraction = pumpProfile.autotune_isf_adjustmentFraction;
     } else {
-        adjustmentFraction = 1.0;
+        adjustmentFraction = 0.5;
     }
     if (typeof(pumpISF) !== 'undefined') {
         var adjustedISF = adjustmentFraction*fullNewISF + (1-adjustmentFraction)*pumpISF;

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -35,7 +35,7 @@ function tuneAllTheThings (inputs) {
     var basalGlucose = preppedGlucose.basalGlucoseData;
     //console.error(basalGlucose[0]);
     var CRData = preppedGlucose.CRData;
-    console.error(CRData);
+    //console.error(CRData);
 
         // Calculate carb ratio (CR) independently of CSF and ISF
         // Use the time period from meal bolus/carbs until COB is zero and IOB is < currentBasal/2
@@ -53,14 +53,15 @@ function tuneAllTheThings (inputs) {
         //console.error(CRDatum.CRInitialIOB, CRDatum.CRInsulin, CRInsulinReq, CRInsulinTotal);
         CR = Math.round( CRDatum.CRCarbs / CRDatum.CRInsulinTotal * 1000 )/1000;
         //console.error(CRBGChange, CRInsulinReq, CRIOBChange, CRInsulinTotal);
-        console.error(CRDatum.CRCarbs, CRDatum.CRInsulinTotal, CR);
+        //console.error("CRCarbs:",CRDatum.CRCarbs,"CRInsulin:",CRDatum.CRInsulinTotal,"CR:",CR);
         if (CRDatum.CRInsulin > 0) {
             CRTotalCarbs += CRDatum.CRCarbs;
             CRTotalInsulin += CRDatum.CRInsulinTotal;
         }
     });
+    CRTotalInsulin = Math.round(CRTotalInsulin*1000)/1000;
     totalCR = Math.round( CRTotalCarbs / CRTotalInsulin * 1000 )/1000;
-    console.error(CRTotalCarbs, CRTotalInsulin, totalCR);
+    console.error("CRTotalCarbs:",CRTotalCarbs,"CRTotalInsulin:",CRTotalInsulin,"totalCR:",totalCR);
 
     // convert the basal profile to hourly if it isn't already
     hourlyBasalProfile = [];
@@ -239,6 +240,7 @@ function tuneAllTheThings (inputs) {
         } //else { console.error("newCSF",newCSF,"is close enough to",pumpCSF); }
     }
     newCSF = Math.round( newCSF * 1000 ) / 1000;
+    totalDeviations = Math.round ( totalDeviations * 1000 )/1000;
     console.error("totalMealCarbs:",totalMealCarbs,"totalDeviations:",totalDeviations,"fullNewCSF:",fullNewCSF,"newCSF:",newCSF);
     // this is where CSF is set based on the outputs
     if (newCSF) {
@@ -348,6 +350,9 @@ function tuneAllTheThings (inputs) {
     newISF = Math.round( newISF * 1000 ) / 1000;
     //console.error(avgRatio);
     //console.error(newISF);
+    p50deviation = Math.round( p50deviation * 1000 ) / 1000;
+    p50BGI = Math.round( p50BGI * 1000 ) / 1000;
+    adjustedISF = Math.round( adjustedISF * 1000 ) / 1000;
     console.error("p50deviation:",p50deviation,"p50BGI",p50BGI,"p50ratios:",p50ratios,"Old ISF:",ISF,"fullNewISF:",fullNewISF,"adjustedISF:",adjustedISF,"newISF:",newISF);
 
     if (newISF) {

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -23,6 +23,9 @@ function tuneAllTheThings (inputs) {
         pumpCarbRatio = pumpProfile.carb_ratio;
         pumpCSF = pumpISF / pumpCarbRatio;
     }
+    if (! carbRatio) { carbRatio = pumpCarbRatio; }
+    if (! CSF) { CSF = pumpCSF; }
+    if (! ISF) { ISF = pumpISF; }
     //console.error(CSF);
     var preppedGlucose = inputs.preppedGlucose;
     var CSFGlucose = preppedGlucose.CSFGlucoseData;
@@ -31,6 +34,33 @@ function tuneAllTheThings (inputs) {
     //console.error(ISFGlucose[0]);
     var basalGlucose = preppedGlucose.basalGlucoseData;
     //console.error(basalGlucose[0]);
+    var CRData = preppedGlucose.CRData;
+    console.error(CRData);
+
+        // Calculate carb ratio (CR) independently of CSF and ISF
+        // Use the time period from meal bolus/carbs until COB is zero and IOB is < currentBasal/2
+        // For now, if another meal IOB/COB stacks on top of it, consider them together
+        // Compare beginning and ending BGs, and calculate how much more/less insulin is needed to neutralize
+        // Use entered carbs vs. starting IOB + delivered insulin + needed-at-end insulin to directly calculate CR.
+
+    var CRTotalCarbs = 0;
+    var CRTotalInsulin = 0;
+    CRData.forEach(function(CRDatum) {
+        CRBGChange = CRDatum.CREndBG - CRDatum.CRInitialBG;
+        CRInsulinReq = CRBGChange / ISF;
+        CRIOBChange = CRDatum.CREndIOB - CRDatum.CRInitialIOB;
+        CRDatum.CRInsulinTotal = CRDatum.CRInitialIOB + CRDatum.CRInsulin + CRInsulinReq;
+        //console.error(CRDatum.CRInitialIOB, CRDatum.CRInsulin, CRInsulinReq, CRInsulinTotal);
+        CR = Math.round( CRDatum.CRCarbs / CRDatum.CRInsulinTotal * 1000 )/1000;
+        //console.error(CRBGChange, CRInsulinReq, CRIOBChange, CRInsulinTotal);
+        console.error(CRDatum.CRCarbs, CRDatum.CRInsulinTotal, CR);
+        if (CRDatum.CRInsulin > 0) {
+            CRTotalCarbs += CRDatum.CRCarbs;
+            CRTotalInsulin += CRDatum.CRInsulinTotal;
+        }
+    });
+    totalCR = Math.round( CRTotalCarbs / CRTotalInsulin * 1000 )/1000;
+    console.error(CRTotalCarbs, CRTotalInsulin, totalCR);
 
     // convert the basal profile to hourly if it isn't already
     hourlyBasalProfile = [];
@@ -144,78 +174,13 @@ function tuneAllTheThings (inputs) {
     console.error(hourlyBasalProfile);
     basalProfile = hourlyBasalProfile;
 
-    // calculate median deviation and bgi in data attributable to ISF
-    var deviations = [];
-    var BGIs = [];
-    var avgDeltas = [];
-    var ratios = [];
-    var count = 0;
-    for (var i=0; i < ISFGlucose.length; ++i) {
-        deviation = parseFloat(ISFGlucose[i].deviation);
-        deviations.push(deviation);
-        BGI = parseFloat(ISFGlucose[i].BGI);
-        BGIs.push(BGI);
-        avgDelta = parseFloat(ISFGlucose[i].avgDelta);
-        avgDeltas.push(avgDelta);
-        ratio = 1 + deviation / BGI;
-        //console.error("Deviation:",deviation,"BGI:",BGI,"avgDelta:",avgDelta,"ratio:",ratio);
-        ratios.push(ratio);
-        count++;
-    }
-    avgDeltas.sort(function(a, b){return a-b});
-    BGIs.sort(function(a, b){return a-b});
-    deviations.sort(function(a, b){return a-b});
-    ratios.sort(function(a, b){return a-b});
-    p50deviation = percentile(deviations, 0.50);
-    p50BGI = percentile(BGIs, 0.50);
-    p50ratios = Math.round( percentile(ratios, 0.50) * 1000)/1000;
-    if (count < 5) {
-        // leave ISF unchanged if fewer than 5 ISF data points
-        fullNewISF = ISF;
-    } else {
-        // calculate what adjustments to ISF would have been necessary to bring median deviation to zero
-        fullNewISF = ISF * p50ratios;
-    }
-    fullNewISF = Math.round( fullNewISF * 1000 ) / 1000;
-    // adjust the target ISF to be a weighted average of fullNewISF and pumpISF
-    var adjustmentFraction;
-    if (pumpProfile.autotune_isf_adjustmentFraction) {
-        adjustmentFraction = pumpProfile.autotune_isf_adjustmentFraction;
-    } else {
-        adjustmentFraction = 0.5;
-    }
-    if (typeof(pumpISF) !== 'undefined') {
-        var adjustedISF = adjustmentFraction*fullNewISF + (1-adjustmentFraction)*pumpISF;
-        // cap adjustedISF before applying 10%
-        if (adjustedISF > maxISF) {
-            console.error("Limiting adjusted ISF of",adjustedISF.toFixed(2),"to",maxISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMin,")");
-            adjustedISF = maxISF;
-        } else if (adjustedISF < minISF) {
-            console.error("Limiting adjusted ISF of",adjustedISF.toFixed(2),"to",minISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMax,")");
-            adjustedISF = minISF;
-        }
+    // Calculate carb ratio (CR) independently of CSF and ISF
+    // Use the time period from meal bolus/carbs until COB is zero and IOB is < currentBasal/2
+    // For now, if another meal IOB/COB stacks on top of it, consider them together
+    // Compare beginning and ending BGs, and calculate how much more/less insulin is needed to neutralize
+    // Use entered carbs vs. starting IOB + delivered insulin + needed-at-end insulin to directly calculate CR.
 
-        // and apply 10% of that adjustment
-        var newISF = ( 0.9 * ISF ) + ( 0.1 * adjustedISF );
 
-        // low autosens ratio = high ISF
-        var maxISF = pumpISF / autotuneMin;
-        // high autosens ratio = low ISF
-        var minISF = pumpISF / autotuneMax;
-        if (newISF > maxISF) {
-            console.error("Limiting ISF of",newISF.toFixed(2),"to",maxISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMin,")");
-            newISF = maxISF;
-        } else if (newISF < minISF) {
-            console.error("Limiting ISF of",newISF.toFixed(2),"to",minISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMax,")");
-            newISF = minISF;
-        }
-    }
-    newISF = Math.round( newISF * 1000 ) / 1000;
-    //console.error(avgRatio);
-    //console.error(newISF);
-    console.error("p50deviation:",p50deviation,"p50BGI",p50BGI,"p50ratios:",p50ratios,"Old ISF:",ISF,"fullNewISF:",fullNewISF,"adjustedISF:",adjustedISF,"newISF:",newISF);
-
-    ISF = newISF;
 
     // calculate net deviations while carbs are absorbing
     // measured from carb entry until COB and deviations both drop to zero
@@ -276,7 +241,119 @@ function tuneAllTheThings (inputs) {
     newCSF = Math.round( newCSF * 1000 ) / 1000;
     console.error("totalMealCarbs:",totalMealCarbs,"totalDeviations:",totalDeviations,"fullNewCSF:",fullNewCSF,"newCSF:",newCSF);
     // this is where CSF is set based on the outputs
-    CSF = newCSF;
+    if (newCSF) {
+        CSF = newCSF;
+    }
+
+    if (totalCR == 0) {
+        // if no meals today, CR is unchanged
+        fullNewCR = carbRatio;
+    } else {
+        // how much change would be required to account for all of the deviations
+        fullNewCR = totalCR;
+    }
+    // only adjust by 10%
+    newCR = ( 0.9 * carbRatio ) + ( 0.1 * fullNewCR );
+    // safety cap CR
+    if (typeof(pumpCarbRatio) !== 'undefined') {
+        var maxCR = pumpCarbRatio * autotuneMax;
+        var minCR = pumpCarbRatio * autotuneMin;
+        if (newCR > maxCR) {
+            console.error("Limiting CR to",maxCR.toFixed(2),"(which is",autotuneMax,"* pump CR of",pumpCarbRatio,")");
+            newCR = maxCR;
+        } else if (newCR < minCR) {
+            console.error("Limiting CR to",minCR.toFixed(2),"(which is",autotuneMin,"* pump CR of",pumpCarbRatio,")");
+            newCR = minCR;
+        } //else { console.error("newCR",newCR,"is close enough to",pumpCarbRatio); }
+    }
+    newCR = Math.round( newCR * 1000 ) / 1000;
+    console.error("oldCR:",carbRatio,"fullNewCR:",fullNewCR,"newCR:",newCR);
+    // this is where CR is set based on the outputs
+    if (newCR) {
+        carbRatio = newCR;
+    }
+
+
+    var ISFFromCRAndCSF = Math.round( carbRatio * CSF * 1000)/1000;
+
+    // calculate median deviation and bgi in data attributable to ISF
+    var deviations = [];
+    var BGIs = [];
+    var avgDeltas = [];
+    var ratios = [];
+    var count = 0;
+    for (var i=0; i < ISFGlucose.length; ++i) {
+        deviation = parseFloat(ISFGlucose[i].deviation);
+        deviations.push(deviation);
+        BGI = parseFloat(ISFGlucose[i].BGI);
+        BGIs.push(BGI);
+        avgDelta = parseFloat(ISFGlucose[i].avgDelta);
+        avgDeltas.push(avgDelta);
+        ratio = 1 + deviation / BGI;
+        //console.error("Deviation:",deviation,"BGI:",BGI,"avgDelta:",avgDelta,"ratio:",ratio);
+        ratios.push(ratio);
+        count++;
+    }
+    avgDeltas.sort(function(a, b){return a-b});
+    BGIs.sort(function(a, b){return a-b});
+    deviations.sort(function(a, b){return a-b});
+    ratios.sort(function(a, b){return a-b});
+    p50deviation = percentile(deviations, 0.50);
+    p50BGI = percentile(BGIs, 0.50);
+    p50ratios = Math.round( percentile(ratios, 0.50) * 1000)/1000;
+    if (count < 5) {
+        // leave ISF unchanged if fewer than 5 ISF data points
+        fullNewISF = ISF;
+    } else {
+        // calculate what adjustments to ISF would have been necessary to bring median deviation to zero
+        fullNewISF = ISF * p50ratios;
+    }
+    fullNewISF = Math.round( fullNewISF * 1000 ) / 1000;
+    // adjust the target ISF to be a weighted average of fullNewISF and pumpISF
+    var adjustmentFraction;
+    if (pumpProfile.autotune_isf_adjustmentFraction) {
+        adjustmentFraction = pumpProfile.autotune_isf_adjustmentFraction;
+    } else {
+        adjustmentFraction = 1.0;
+    }
+    if (typeof(pumpISF) !== 'undefined') {
+        var adjustedISF = adjustmentFraction*fullNewISF + (1-adjustmentFraction)*pumpISF;
+        // cap adjustedISF before applying 10%
+        if (adjustedISF > maxISF) {
+            console.error("Limiting adjusted ISF of",adjustedISF.toFixed(2),"to",maxISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMin,")");
+            adjustedISF = maxISF;
+        } else if (adjustedISF < minISF) {
+            console.error("Limiting adjusted ISF of",adjustedISF.toFixed(2),"to",minISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMax,")");
+            adjustedISF = minISF;
+        }
+
+        // and apply 10% of that adjustment
+        var newISF = ( 0.9 * ISF ) + ( 0.1 * adjustedISF );
+
+        // average both the directly-calculated ISF and the ISFFromCRAndCSF
+        newISF = (newISF + ISFFromCRAndCSF) / 2;
+
+        // low autosens ratio = high ISF
+        var maxISF = pumpISF / autotuneMin;
+        // high autosens ratio = low ISF
+        var minISF = pumpISF / autotuneMax;
+        if (newISF > maxISF) {
+            console.error("Limiting ISF of",newISF.toFixed(2),"to",maxISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMin,")");
+            newISF = maxISF;
+        } else if (newISF < minISF) {
+            console.error("Limiting ISF of",newISF.toFixed(2),"to",minISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMax,")");
+            newISF = minISF;
+        }
+    }
+    newISF = Math.round( newISF * 1000 ) / 1000;
+    //console.error(avgRatio);
+    //console.error(newISF);
+    console.error("p50deviation:",p50deviation,"p50BGI",p50BGI,"p50ratios:",p50ratios,"Old ISF:",ISF,"fullNewISF:",fullNewISF,"adjustedISF:",adjustedISF,"newISF:",newISF);
+
+    if (newISF) {
+        ISF = newISF;
+    }
+
 
     // reconstruct updated version of previousAutotune as autotuneOutput
     autotuneOutput = previousAutotune;
@@ -285,7 +362,7 @@ function tuneAllTheThings (inputs) {
     autotuneOutput.isfProfile = isfProfile;
     autotuneOutput.sens = ISF;
     autotuneOutput.csf = CSF;
-    carbRatio = ISF / CSF;
+    //carbRatio = ISF / CSF;
     carbRatio = Math.round( carbRatio * 1000 ) / 1000;
     autotuneOutput.carb_ratio = carbRatio;
 

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -191,7 +191,7 @@ function tuneAllTheThings (inputs) {
                 }
             }
             //console.error(hour, newHourlyBasalProfile);
-            newHourlyBasalProfile[hour].rate = Math.round( (0.9*hourlyBasalProfile[hour].rate + 0.05*newHourlyBasalProfile[lastAdjustedHour].rate + 0.05*newHourlyBasalProfile[nextAdjustedHour].rate)*1000 )/1000;
+            newHourlyBasalProfile[hour].rate = Math.round( (0.8*hourlyBasalProfile[hour].rate + 0.1*newHourlyBasalProfile[lastAdjustedHour].rate + 0.1*newHourlyBasalProfile[nextAdjustedHour].rate)*1000 )/1000;
             console.error("Adjusting hour",hour,"basal from",hourlyBasalProfile[hour].rate,"to",newHourlyBasalProfile[hour].rate,"based on hour",lastAdjustedHour,"=",newHourlyBasalProfile[lastAdjustedHour].rate,"and hour",nextAdjustedHour,"=",newHourlyBasalProfile[nextAdjustedHour].rate);
         } else {
             lastAdjustedHour = hour;

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -251,8 +251,8 @@ function tuneAllTheThings (inputs) {
         // how much change would be required to account for all of the deviations
         fullNewCSF = Math.round( (totalDeviations / totalMealCarbs)*100 )/100;
     }
-    // only adjust by 10%
-    newCSF = ( 0.9 * CSF ) + ( 0.1 * fullNewCSF );
+    // only adjust by 20%
+    newCSF = ( 0.8 * CSF ) + ( 0.2 * fullNewCSF );
     // safety cap CSF
     if (typeof(pumpCSF) !== 'undefined') {
         var maxCSF = pumpCSF * autotuneMax;
@@ -265,9 +265,10 @@ function tuneAllTheThings (inputs) {
             newCSF = minCSF;
         } //else { console.error("newCSF",newCSF,"is close enough to",pumpCSF); }
     }
+    oldCSF = Math.round( CSF * 1000 ) / 1000;
     newCSF = Math.round( newCSF * 1000 ) / 1000;
     totalDeviations = Math.round ( totalDeviations * 1000 )/1000;
-    console.error("totalMealCarbs:",totalMealCarbs,"totalDeviations:",totalDeviations,"fullNewCSF:",fullNewCSF,"newCSF:",newCSF);
+    console.error("totalMealCarbs:",totalMealCarbs,"totalDeviations:",totalDeviations,"oldCSF",oldCSF,"fullNewCSF:",fullNewCSF,"newCSF:",newCSF);
     // this is where CSF is set based on the outputs
     if (newCSF) {
         CSF = newCSF;
@@ -281,7 +282,7 @@ function tuneAllTheThings (inputs) {
         fullNewCR = totalCR;
     }
     // only adjust by 10%
-    newCR = ( 0.9 * carbRatio ) + ( 0.1 * fullNewCR );
+    newCR = ( 0.8 * carbRatio ) + ( 0.2 * fullNewCR );
     // safety cap CR
     if (typeof(pumpCarbRatio) !== 'undefined') {
         var maxCR = pumpCarbRatio * autotuneMax;
@@ -297,12 +298,13 @@ function tuneAllTheThings (inputs) {
     newCR = Math.round( newCR * 1000 ) / 1000;
     console.error("oldCR:",carbRatio,"fullNewCR:",fullNewCR,"newCR:",newCR);
     // this is where CR is set based on the outputs
+    var ISFFromCRAndCSF = ISF;
     if (newCR) {
         carbRatio = newCR;
+        ISFFromCRAndCSF = Math.round( carbRatio * CSF * 1000)/1000;
     }
 
 
-    var ISFFromCRAndCSF = Math.round( carbRatio * CSF * 1000)/1000;
 
     // calculate median deviation and bgi in data attributable to ISF
     var deviations = [];
@@ -355,11 +357,14 @@ function tuneAllTheThings (inputs) {
             adjustedISF = minISF;
         }
 
+        // average both the directly-calculated ISF and the ISFFromCRAndCSF if we're reasonably well tuned
+        if (p50ratios > 0.4 && p50ratios < 0.6) {
+            // TODO: figure out if there's a way to do this without messing up CSF tuning
+            // adjustedISF = (adjustedISF + ISFFromCRAndCSF) / 2;
+        }
+
         // and apply 10% of that adjustment
         var newISF = ( 0.9 * ISF ) + ( 0.1 * adjustedISF );
-
-        // average both the directly-calculated ISF and the ISFFromCRAndCSF
-        newISF = (newISF + ISFFromCRAndCSF) / 2;
 
         // low autosens ratio = high ISF
         var maxISF = pumpISF / autotuneMin;


### PR DESCRIPTION
Currently autotune categorizes glucose deviations data into buckets based on what is impacting things the most: basals, carbs, or insulin.  It uses the mealtime data to calculate CSF, the IOB-without-COB data to calculate ISF, and then the remainder to adjust basals.  This works fairly well, but due to the fuzzy line between carb-dominated and insulin-dominated deviations after a meal, it tends to overestimate ISF.  CR is calculated as ISF/CSF, so that tends to be overestimated as well.

As an alternative, this change calculates CR directly.  To do so, we use the BG and IOB at the time of carb entry, the BG and IOB after COB==0 and IOB is back down to low level, the total amount of carbs given, and the total amount of insulin given over the meal period.  After adjusting for the BG and IOB changes, that allows a direct calculation of carb ratio as total carbs / total insulin at mealtime.

Additionally, this change adds some more error checking around bad carb ratios (falling back to the pump profile carb ratio if needed), and avoids setting new ISF, CSF, or CRs unless the new ones are valid.  These should help with the occasional situation where someone's autotune gets messed up and their rig stops looping just after midnight.