### PR TITLE
Make remainingCI time responsive to temp targets

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -305,7 +305,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // assume that all carbs will absorb over 4 more hours w/ normal targets
     var remainingCATime = 4;
     // if an eating soon low temp target is set, assume a 3h absorption time (for 80 mg/dL)
-    // conversely, assume 5h for 120, 6h for 140, etc.
+    if (profile.temptargetSet && ( target_bg < 90 || target_bg > 110 )) {
+        // conversely, assume 5h for 120, 6h for 140, etc.
+        // number of hours to adjust remainingCATime.  80 -> -1, 120 -> +1, 140 -> +2
+        remainingCATimeAdjustment = (target_bg - 100) / 20;
+        remainingCATime += remainingCATimeAdjustment;
+        console.error("Adjusting remainingCATime to",remainingCATime,"h based on temp target of",target_bg);
+    }
 
     // calculate the number of carbs absorbed over remainingCATime hours at current CI
     // CI (mg/dL/5m) * (5m)/5 (m) * 60 (min/hr) * 4 (h) / 2 (linear decay factor) = total carb impact (mg/dL)

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -845,7 +845,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // (or enough insulin to cover COB, or maxBolus, whichever is smallest)
             if ( iob_data.iob < mealInsulinReq ) {
                 initialMealInsulinReq = round(mealInsulinReq-iob_data.iob,1);
-                console.error("IOB",iob_data.iob,"<< COB",meal_data.mealCOB+"; insulinReq/2 =",insulinReq/2+"; initialMealInsulinReq =",initialMealInsulinReq);
+                console.error("IOB",iob_data.iob,"< COB",meal_data.mealCOB+"; insulinReq/2 =",insulinReq/2+"; initialMealInsulinReq =",initialMealInsulinReq);
                 if (initialMealInsulinReq > microBolus) {
                     microBolus = round(Math.min(insulinReq/2,maxBolus,initialMealInsulinReq),1);
                 }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -302,9 +302,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     //console.error(csf * meal_data.carbs);
     // meal_carbimpact (mg/dL/5m) = CSF (mg/dL/g) * carbs (g) / 6 (h) * (1h/60m) * 5 (m/5m) * 2 (for linear decay)
     //var meal_carbimpact = round((csf * meal_data.carbs / 6 / 60 * 5 * 2),1)
-    // calculate the number of carbs absorbed over 4h at current CI
+    // assume that all carbs will absorb over 4 more hours w/ normal targets
+    var remainingCATime = 4;
+    // if an eating soon low temp target is set, assume a 3h absorption time (for 80 mg/dL)
+    // conversely, assume 5h for 120, 6h for 140, etc.
+
+    // calculate the number of carbs absorbed over remainingCATime hours at current CI
     // CI (mg/dL/5m) * (5m)/5 (m) * 60 (min/hr) * 4 (h) / 2 (linear decay factor) = total carb impact (mg/dL)
-    var totalCI = Math.max(0, ci / 5 * 60 * 4 / 2);
+    var totalCI = Math.max(0, ci / 5 * 60 * remainingCATime / 2);
     // totalCI (mg/dL) / CSF (mg/dL/g) = total carbs absorbed (g)
     var totalCA = totalCI / csf;
     var remainingCarbsCap = 90; // default to 90
@@ -314,13 +319,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var remainingCarbsIgnore = 1 - remainingCarbsFraction;
     var remainingCarbs = Math.max(0, meal_data.mealCOB - totalCA - meal_data.carbs*remainingCarbsIgnore);
     remainingCarbs = Math.min(remainingCarbsCap,remainingCarbs);
-    // assume remainingCarbs will absorb in a /\ shaped bilinear curve peaking at 2h and ending at 4h
-    // area of the /\ triangle is the same as a remainingCIpeak-height rectangle out to 2h
-    // remainingCIpeak (mg/dL/5m) = remainingCarbs (g) * CSF (mg/dL/g) * 5 (m/5m) * 1h/60m / 2 (h)
-    var remainingCIpeak = remainingCarbs * csf * 5 / 60 / 2;
-    // remainingCI (mg/dL/5m) = remainingCarbs (g) * CSF (mg/dL/g) * 5 (m/5m) * 1h/60m / 4 (h)
-    //var remainingCI = remainingCarbs * csf * 5 / 60 / 4;
-    //console.error(profile.min_5m_carbimpact,ci,totalCI,totalCA,remainingCarbs,remainingCI);
+    // assume remainingCarbs will absorb in a /\ shaped bilinear curve
+    // peaking at remainingCATime / 2 and ending at remainingCATime hours
+    // area of the /\ triangle is the same as a remainingCIpeak-height rectangle out to remainingCATime/2
+    // remainingCIpeak (mg/dL/5m) = remainingCarbs (g) * CSF (mg/dL/g) * 5 (m/5m) * 1h/60m / (remainingCATime/2) (h)
+    var remainingCIpeak = remainingCarbs * csf * 5 / 60 / (remainingCATime/2);
+    //console.error(profile.min_5m_carbimpact,ci,totalCI,totalCA,remainingCarbs,remainingCI,remainingCATime);
     //if (meal_data.mealCOB * 3 > meal_data.carbs) { }
 
     // calculate peak deviation in last hour, and slope from that to current deviation
@@ -330,8 +334,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     aci = 10;
     //5m data points = g * (1U/10g) * (40mg/dL/1U) / (mg/dL/5m)
     // duration (in 5m data points) = COB (g) * CSF (mg/dL/g) / ci (mg/dL/5m)
-    // limit cid to 4 hours: the reset goes to remainingCI
-    cid = Math.min(4*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
+    // limit cid to remainingCATime hours: the reset goes to remainingCI
+    cid = Math.min(remainingCATime*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
     acid = Math.max(0, meal_data.mealCOB * csf / aci );
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
     console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (2h peak):",round(remainingCIpeak,1),"mg/dL per 5m");
@@ -367,10 +371,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // eventually accounting for all carbs (if they can be absorbed over DIA)
             predCI = Math.max(0, Math.max(0,ci) * ( 1 - COBpredBGs.length/Math.max(cid*2,1) ) );
             predACI = Math.max(0, Math.max(0,aci) * ( 1 - COBpredBGs.length/Math.max(acid*2,1) ) );
-            // if any carbs aren't absorbed after 4 hours, assume they'll absorb in a /\ shaped
-            // bilinear curve peaking at remainingCIpeak at 2h (24*5m) and ending at 4h (48*5m intervals)
-            var intervals = Math.min( COBpredBGs.length, 48-COBpredBGs.length );
-            var remainingCI = Math.max(0, intervals / 24 * remainingCIpeak );
+            // if any carbs aren't absorbed after remainingCATime hours, assume they'll absorb in a /\ shaped
+            // bilinear curve peaking at remainingCIpeak at remainingCATime/2 hours (remainingCATime/2*12 * 5m)
+            // and ending at remainingCATime h (remainingCATime*12 * 5m intervals)
+            var intervals = Math.min( COBpredBGs.length, (remainingCATime*12)-COBpredBGs.length );
+            var remainingCI = Math.max(0, intervals / (remainingCATime/2*12) * remainingCIpeak );
             remainingCItotal += predCI+remainingCI;
             remainingCIs.push(round(remainingCI,1));
             predCIs.push(round(predCI,1));


### PR DESCRIPTION
Even with the new bilinear /\ shaped carb absorption curve, some meals spike more quickly than the assumed 4h, so it would be better to provide the user a way to tell the system that an upcoming meal is likely to be fast-absorbing, and allow oref1 to more aggressively SMB for the predicted rise.

To do so, this change adjusts the duration of the /\ remainingCI absorption curve to be shorter (3h) when a temp target of 80 is set, and longer for a high temp target (5h for 120, 6h for 140, etc.).  This gives the user more control over how aggressive they want SMB to be for carbs that have been entered but aren't yet absorbing.