### PR TITLE
remove  variable

### DIFF
--- a/bin/monitor-xdrip.sh
+++ b/bin/monitor-xdrip.sh
@@ -5,7 +5,7 @@ cp -rf xdrip/glucose.json xdrip/last-glucose.json
 curl --compressed -s http://localhost:5000/api/v1/entries?count=288 | json -e "this.glucose = this.sgv" > xdrip/glucose.json
 if ! cmp --silent xdrip/glucose.json xdrip/last-glucose.json; then
     if cat xdrip/glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38" | grep -q glucose; then
-        cp -up $directory/xdrip/glucose.json $directory/monitor/glucose.json
+        cp -up xdrip/glucose.json monitor/glucose.json
     else
         echo No recent glucose data downloaded from xDrip.
         diff xdrip/glucose.json xdrip/last-glucose.json


### PR DESCRIPTION
`monitor-xdrip.sh` fails sometimes because `$directory` is null. It looks to be set in the autotune script [here](https://github.com/openaps/oref0/blob/92919bde860f438556e916e5c6a2c355d5006194/bin/oref0-autotune.sh#L79) so will be undefined if autotune hasn't run.

All of the other `cp` commands in the script work fine without it; as should this one.