### PR TITLE
proceed to enact and set clock if pumphistory-zoned is in the future

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -470,7 +470,7 @@ function refresh_pumphistory_and_enact {
     setglucosetimestamp
     if ((find monitor/ -newer monitor/pumphistory-zoned.json | grep -q glucose.json && echo -n "glucose.json newer than pumphistory. ") \
         || (find enact/ -newer monitor/pumphistory-zoned.json | grep -q enacted.json && echo -n "enacted.json newer than pumphistory. ") \
-        || (! find monitor/ -mmin -5 | grep -q pumphistory-zoned && echo -n "pumphistory more than 5m old. ") ); then
+        || ((! find monitor/ -mmin -5 | grep -q pumphistory-zoned || ! find monitor/ -mmin +0 | grep -q pumphistory-zoned) && echo -n "pumphistory more than 5m old. ") ); then
             (echo -n ": " && gather && enact )
     else
         echo Pumphistory less than 5m old


### PR DESCRIPTION
If the time of a rig running without SMB doesn't sync on boot-up and is therefore reading way in the past, the monitor/pumphistory-zoned.json file will be way in the future (2017 vs. 1969/1970), which causes refresh_pumphistory_and_enact to think nothing needs to be done, and thereby never gets to the `grep incorrectly enact/suggested.json && oref0-set-system-clock 2>/dev/null` line in the `enact` function.  This should force it to consider as "old" a future-dated pumphistory-zoned.json and proceed with the loop.

To test, boot up a non-SMB rig without Internet while watching pump-loop.log on console, and verify that you see it proceed to try to re-sync NTP and then set the system clock from the pump clock when that fails.