### PR TITLE
calculate autosens ratio with both 8h and 24h of data

### DIFF
--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -88,9 +88,17 @@ if (!module.parent) {
         , basalprofile: basalprofile
         //, clock: clock_data
     };
+    // calculate sensitivity using 8h of non-exluded data
+    detection_inputs.deviations = 96;
     detect(detection_inputs);
+    ratio8h = ratio;
+    // calculate sensitivity using all non-exluded data (up to 24h)
+    detection_inputs.deviations = 288;
+    detect(detection_inputs);
+    ratio24h = ratio;
+    var lowestRatio = Math.min(ratio8h, ratio24h);
     var sensAdj = {
-        "ratio": ratio
+        "ratio": lowestRatio
     }
     return console.log(JSON.stringify(sensAdj));
 

--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -92,10 +92,17 @@ if (!module.parent) {
     detection_inputs.deviations = 96;
     detect(detection_inputs);
     ratio8h = ratio;
+    newisf8h = newisf;
     // calculate sensitivity using all non-exluded data (up to 24h)
     detection_inputs.deviations = 288;
     detect(detection_inputs);
     ratio24h = ratio;
+    newisf24h = newisf;
+    if ( ratio8h < ratio24h ) {
+        console.error("Using 8h autosens ratio of",ratio8h,"(ISF",newisf8h+")");
+    } else {
+        console.error("Using 24h autosens ratio of",ratio24h,"(ISF",newisf24h+")");
+    }
     var lowestRatio = Math.min(ratio8h, ratio24h);
     var sensAdj = {
         "ratio": lowestRatio

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -123,6 +123,7 @@ function detectSensitivity(inputs) {
     var uam = 0; // unannounced meal
     var mealCOB = 0;
     var mealCarbs = 0;
+    var mealStartCounter = 999;
     var type="";
     //console.error(bucketed_data);
     for (var i=3; i < bucketed_data.length; ++i) {
@@ -188,13 +189,11 @@ function detectSensitivity(inputs) {
             absorbed = ci * profile.carb_ratio / sens;
             mealCOB = Math.max(0, mealCOB-absorbed);
         }
-        // Store the COB, and use it as the starting point for the next data point.
 
-        // If mealCOB is zero but all deviations since hitting COB=0 are positive, assign those data points to CSFGlucoseData
-        // Once deviations go negative for at least one data point after COB=0, we can use the rest of the data to tune ISF or basals
+        // If mealCOB is zero but all deviations since hitting COB=0 are positive, exclude from autosens
         //console.error(mealCOB, absorbing, mealCarbs);
         if (mealCOB > 0 || absorbing || mealCarbs > 0) {
-            if (deviation > 0) {
+            if (deviation > 0 ) {
                 absorbing = 1;
             } else {
                 absorbing = 0;
@@ -206,9 +205,11 @@ function detectSensitivity(inputs) {
             //console.error(type);
             if ( type != "csf" ) {
                 process.stderr.write("g(");
+                mealStartCounter = 0;
                 //glucoseDatum.mealAbsorption = "start";
                 //console.error(glucoseDatum.mealAbsorption,"carb absorption");
             }
+            mealStartCounter++;
             type="csf";
             glucoseDatum.mealCarbs = mealCarbs;
             //if (i == 0) { glucoseDatum.mealAbsorption = "end"; }
@@ -222,7 +223,10 @@ function detectSensitivity(inputs) {
           }
 
           currentBasal = iob_inputs.profile.current_basal;
-          if (iob.iob > currentBasal || uam) {
+          // always exclude the first 45m after each carb entry
+          //if (iob.iob > currentBasal || uam ) {
+          if (iob.iob > currentBasal || uam || mealStartCounter < 9 ) {
+            mealStartCounter++;
             if (deviation > 0) {
                 uam = 1;
             } else {
@@ -233,6 +237,7 @@ function detectSensitivity(inputs) {
                 //glucoseDatum.uamAbsorption = "start";
                 //console.error(glucoseDatum.uamAbsorption,"uannnounced meal absorption");
             }
+            //console.error(mealStartCounter);
             type="uam";
           } else {
             if ( type === "uam" ) {
@@ -262,8 +267,10 @@ function detectSensitivity(inputs) {
             process.stderr.write("x");
             //console.error(bgTime);
         }
+        var lookback = inputs.deviations;
+        if (!lookback) { lookback = 96; }
         // only keep the last 96 non-excluded data points (8h+ for any exclusions)
-        if (deviations.length > 96) {
+        if (deviations.length > lookback) {
             deviations.shift();
         }
     }

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -334,7 +334,8 @@ function detectSensitivity(inputs) {
     //console.error("Basal adjustment "+basalOff.toFixed(2)+"U/hr");
     //console.error("Ratio: "+ratio*100+"%: new ISF: "+newisf.toFixed(1)+"mg/dL/U");
     var output = {
-        "ratio": ratio
+        "ratio": ratio,
+        "newisf": newisf
     }
     return output;
 }

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -225,7 +225,7 @@ function detectSensitivity(inputs) {
           currentBasal = iob_inputs.profile.current_basal;
           // always exclude the first 45m after each carb entry
           //if (iob.iob > currentBasal || uam ) {
-          if (iob.iob > currentBasal || uam || mealStartCounter < 9 ) {
+          if (iob.iob > 2 * currentBasal || uam || mealStartCounter < 9 ) {
             mealStartCounter++;
             if (deviation > 0) {
                 uam = 1;


### PR DESCRIPTION
This calculates the autosens ratio twice, once using the most recent 8h worth of non-excluded data (which during the day ends up being 12h+ due to meal exclusions), and once using up to 24h of non-excluded data (usually closer to 16h due to meal exclusions).  It then uses the lower (more sensitive) of the two ratios.  This improves safety by allowing for faster response to increased sensitivity, while responding more slowly to increased resistance.