### PR TITLE
Less aggressive UAM

### DIFF
--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -141,7 +141,7 @@ function detectCarbAbsorption(inputs) {
         if (i==0) {
             currentDeviation = Math.round((avgDelta-bgi)*1000)/1000;
             if (ciTime > bgTime) {
-                console.error("currentDeviation:",currentDeviation,avgDelta,bgi);
+                //console.error("currentDeviation:",currentDeviation,avgDelta,bgi);
             }
             if (currentDeviation/2 > profile.min_5m_carbimpact) {
                 //console.error("currentDeviation",currentDeviation,"/2 > min_5m_carbimpact",profile.min_5m_carbimpact);
@@ -159,7 +159,7 @@ function detectCarbAbsorption(inputs) {
                 minDeviation = avgDeviation;
             }
 
-            console.error("Deviations:",bgTime, avgDeviation, deviationSlope, slopeFromMaxDeviation, slopeFromMinDeviation, avgDelta,bgi);
+            //console.error("Deviations:",bgTime, avgDeviation, deviationSlope, slopeFromMaxDeviation, slopeFromMinDeviation, avgDelta,bgi);
         }
 
         // if bgTime is more recent than mealTime

--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -62,7 +62,7 @@ function detectCarbAbsorption(inputs) {
         // this allows us to calculate deviations for the last ~45m
         if (typeof ciTime) {
             hoursAgo = (ciTime-bgTime)/(60*60*1000);
-            if (hoursAgo > 1 || hoursAgo < 0) {
+            if (hoursAgo > 2 || hoursAgo < 0) {
                 continue;
             }
         }
@@ -98,7 +98,7 @@ function detectCarbAbsorption(inputs) {
         }
     }
     var currentDeviation;
-    var minDeviationSlope = 0;
+    var slopeFromMaxDeviation = 0;
     var maxDeviation = 0;
     //console.error(bucketed_data);
     for (var i=0; i < bucketed_data.length-3; ++i) {
@@ -106,7 +106,7 @@ function detectCarbAbsorption(inputs) {
 
         var sens = isf.isfLookup(profile.isfProfile,bgTime);
 
-        //console.error(bgTime , bucketed_data[i].glucose);
+        //console.error(bgTime , bucketed_data[i].glucose, bucketed_data[i].date);
         var bg;
         var avgDelta;
         var delta;
@@ -127,7 +127,7 @@ function detectCarbAbsorption(inputs) {
         //console.error("Before: ", new Date().getTime());
         var iob = get_iob(iob_inputs, true, treatments)[0];
         //console.error("After: ", new Date().getTime());
-        //console.log(JSON.stringify(iob));
+        //console.error(JSON.stringify(iob));
 
         var bgi = Math.round(( -iob.activity * sens * 5 )*100)/100;
         bgi = bgi.toFixed(2);
@@ -139,7 +139,7 @@ function detectCarbAbsorption(inputs) {
         if (i==0) {
             currentDeviation = Math.round((avgDelta-bgi)*1000)/1000;
             if (ciTime > bgTime) {
-                //console.error("currentDeviation:",currentDeviation);
+                console.error("currentDeviation:",currentDeviation,avgDelta,bgi);
             }
             if (currentDeviation/2 > profile.min_5m_carbimpact) {
                 //console.error("currentDeviation",currentDeviation,"/2 > min_5m_carbimpact",profile.min_5m_carbimpact);
@@ -148,10 +148,10 @@ function detectCarbAbsorption(inputs) {
             avgDeviation = Math.round((avgDelta-bgi)*1000)/1000;
             deviationSlope = (avgDeviation-currentDeviation)/(bgTime-ciTime)*1000*60*5;
             if (avgDeviation > maxDeviation) {
-                minDeviationSlope = Math.min(0, deviationSlope);
+                slopeFromMaxDeviation = Math.min(0, deviationSlope);
                 maxDeviation = avgDeviation;
             }
-            //console.error("Deviations:",bgTime, avgDeviation, deviationSlope, minDeviationSlope);
+            console.error("Deviations:",bgTime, avgDeviation, deviationSlope, slopeFromMaxDeviation, avgDelta,bgi);
         }
 
         // if bgTime is more recent than mealTime
@@ -166,14 +166,14 @@ function detectCarbAbsorption(inputs) {
         }
     }
     if(maxDeviation>0) {
-        //console.error("currentDeviation:",currentDeviation,"maxDeviation:",maxDeviation,"minDeviationSlope:",minDeviationSlope);
+        //console.error("currentDeviation:",currentDeviation,"maxDeviation:",maxDeviation,"slopeFromMaxDeviation:",slopeFromMaxDeviation);
     }
 
     var output = {
         "carbsAbsorbed": carbsAbsorbed
     ,   "currentDeviation": currentDeviation
     ,   "maxDeviation": maxDeviation
-    ,   "minDeviationSlope": minDeviationSlope
+    ,   "slopeFromMaxDeviation": slopeFromMaxDeviation
     }
     return output;
 }

--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -62,7 +62,7 @@ function detectCarbAbsorption(inputs) {
         // this allows us to calculate deviations for the last ~45m
         if (typeof ciTime) {
             hoursAgo = (ciTime-bgTime)/(60*60*1000);
-            if (hoursAgo > 2 || hoursAgo < 0) {
+            if (hoursAgo > 1 || hoursAgo < 0) {
                 continue;
             }
         }
@@ -99,7 +99,9 @@ function detectCarbAbsorption(inputs) {
     }
     var currentDeviation;
     var slopeFromMaxDeviation = 0;
+    var slopeFromMinDeviation = 999;
     var maxDeviation = 0;
+    var minDeviation = 999;
     //console.error(bucketed_data);
     for (var i=0; i < bucketed_data.length-3; ++i) {
         var bgTime = new Date(bucketed_data[i].date);
@@ -147,11 +149,17 @@ function detectCarbAbsorption(inputs) {
         } else if (ciTime > bgTime) {
             avgDeviation = Math.round((avgDelta-bgi)*1000)/1000;
             deviationSlope = (avgDeviation-currentDeviation)/(bgTime-ciTime)*1000*60*5;
+            //console.error(avgDeviation,currentDeviation,bgTime,ciTime)
             if (avgDeviation > maxDeviation) {
                 slopeFromMaxDeviation = Math.min(0, deviationSlope);
                 maxDeviation = avgDeviation;
             }
-            console.error("Deviations:",bgTime, avgDeviation, deviationSlope, slopeFromMaxDeviation, avgDelta,bgi);
+            if (avgDeviation < minDeviation) {
+                slopeFromMinDeviation = Math.max(0, deviationSlope);
+                minDeviation = avgDeviation;
+            }
+
+            console.error("Deviations:",bgTime, avgDeviation, deviationSlope, slopeFromMaxDeviation, slopeFromMinDeviation, avgDelta,bgi);
         }
 
         // if bgTime is more recent than mealTime
@@ -173,7 +181,9 @@ function detectCarbAbsorption(inputs) {
         "carbsAbsorbed": carbsAbsorbed
     ,   "currentDeviation": currentDeviation
     ,   "maxDeviation": maxDeviation
+    ,   "minDeviation": minDeviation
     ,   "slopeFromMaxDeviation": slopeFromMaxDeviation
+    ,   "slopeFromMinDeviation": slopeFromMinDeviation
     }
     return output;
 }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -292,7 +292,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // calculate current carb absorption rate, and how long to absorb all carbs
     // CI = current carb impact on BG in mg/dL/5m
     ci = round((minDelta - bgi),1);
-    uci = round((minAvgDelta - bgi),1);
+    uci = round((minDelta - bgi),1);
     // ISF (mg/dL/U) / CR (g/U) = CSF (mg/dL/g)
     // use profile.sens instead of autosens-adjusted sens to avoid counteracting
     // autosens meal insulin dosing adjustmenst when sensitive/resistant

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -490,8 +490,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var fractionCarbsLeft = meal_data.mealCOB/meal_data.carbs;
     // if we have COB and UAM is enabled, average all three
     if ( minUAMPredBG < 400 && minCOBPredBG < 400 ) {
-        // weight COBpredBG vs. UAMIOBpredBG based on how many carbs remain as COB
-        avgPredBG = round( (IOBpredBG/3 + (1-fractionCarbsLeft)*UAMIOBpredBG*2/3 + fractionCarbsLeft*COBpredBG*2/3) );
+        // weight COBpredBG vs. UAMpredBG based on how many carbs remain as COB
+        avgPredBG = round( (IOBpredBG/3 + (1-fractionCarbsLeft)*UAMpredBG*2/3 + fractionCarbsLeft*COBpredBG*2/3) );
     // if UAM is disabled, average IOB and COB
     } else if ( minCOBPredBG < 400 ) {
         avgPredBG = round( (IOBpredBG + COBpredBG)/2 );

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -507,8 +507,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     // if any carbs have been entered recently
     if (meal_data.carbs) {
-        // average the minIOBPredBG and minUAMPredBG if available
-        if ( minUAMPredBG < 400 ) {
+        // average the minIOBPredBG and minUAMPredBG if minUAMPredBG is higher`
+        if ( minUAMPredBG < 400 && minUAMPredBG > minIOBPredBG ) {
             avgMinPredBG = round( (minIOBPredBG+minUAMPredBG)/2 );
         } else {
             avgMinPredBG = minIOBPredBG;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -487,14 +487,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     minUAMPredBG = Math.max(39,minUAMPredBG);
     minPredBG = round(minIOBPredBG);
 
-    // if minUAMPredBG < minIOBPredBG, set minUAMPredBG to their average
-    minUAMPredBG = Math.max(minUAMPredBG, ( minUAMPredBG + minIOBPredBG )/2);
-
     var fractionCarbsLeft = meal_data.mealCOB/meal_data.carbs;
     // if we have COB and UAM is enabled, average all three
     if ( minUAMPredBG < 400 && minCOBPredBG < 400 ) {
-        // weight COBpredBG vs. UAMpredBG based on how many carbs remain as COB
-        avgPredBG = round( (IOBpredBG/3 + (1-fractionCarbsLeft)*UAMpredBG*2/3 + fractionCarbsLeft*COBpredBG*2/3) );
+        // if UAMpredBG < IOBpredBG, use their average instead
+        UAMIOBpredBG = Math.max(UAMpredBG, ( UAMpredBG + IOBpredBG )/2);
+        // weight COBpredBG vs. UAMIOBpredBG based on how many carbs remain as COB
+        avgPredBG = round( (IOBpredBG/3 + (1-fractionCarbsLeft)*UAMIOBpredBG*2/3 + fractionCarbsLeft*COBpredBG*2/3) );
     // if UAM is disabled, average IOB and COB
     } else if ( minCOBPredBG < 400 ) {
         avgPredBG = round( (IOBpredBG + COBpredBG)/2 );

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -490,8 +490,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var fractionCarbsLeft = meal_data.mealCOB/meal_data.carbs;
     // if we have COB and UAM is enabled, average all three
     if ( minUAMPredBG < 400 && minCOBPredBG < 400 ) {
-        // if UAMpredBG < IOBpredBG, use their average instead
-        UAMIOBpredBG = Math.max(UAMpredBG, ( UAMpredBG + IOBpredBG )/2);
         // weight COBpredBG vs. UAMIOBpredBG based on how many carbs remain as COB
         avgPredBG = round( (IOBpredBG/3 + (1-fractionCarbsLeft)*UAMIOBpredBG*2/3 + fractionCarbsLeft*COBpredBG*2/3) );
     // if UAM is disabled, average IOB and COB

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -334,8 +334,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     //if (meal_data.mealCOB * 3 > meal_data.carbs) { }
 
     // calculate peak deviation in last hour, and slope from that to current deviation
-    var minDeviationSlope = round(meal_data.minDeviationSlope,2);
-    //console.error(minDeviationSlope);
+    var slopeFromMaxDeviation = round(meal_data.slopeFromMaxDeviation,2);
+    //console.error(slopeFromMaxDeviation);
 
     aci = 10;
     //5m data points = g * (1U/10g) * (40mg/dL/1U) / (mg/dL/5m)
@@ -388,17 +388,17 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             //process.stderr.write(round(predCI,1)+"+"+round(remainingCI,1)+" ");
             COBpredBG = COBpredBGs[COBpredBGs.length-1] + predBGI + Math.min(0,predDev) + predCI + remainingCI;
             aCOBpredBG = aCOBpredBGs[aCOBpredBGs.length-1] + predBGI + Math.min(0,predDev) + predACI;
-            // for UAMpredBGs, predicted carb impact drops at minDeviationSlope
-            // calculate predicted CI from UAM based on minDeviationSlope
-            predUCIslope = Math.max(0, uci + ( UAMpredBGs.length*minDeviationSlope ) );
-            // if minDeviationSlope is too flat, predicted deviation impact drops linearly from
+            // for UAMpredBGs, predicted carb impact drops at slopeFromMaxDeviation
+            // calculate predicted CI from UAM based on slopeFromMaxDeviation
+            predUCIslope = Math.max(0, uci + ( UAMpredBGs.length*slopeFromMaxDeviation ) );
+            // if slopeFromMaxDeviation is too flat, predicted deviation impact drops linearly from
             // current deviation down to zero over 3h (data points every 5m)
             predUCImax = Math.max(0, uci * ( 1 - UAMpredBGs.length/Math.max(3*60/5,1) ) );
             //console.error(predUCIslope, predUCImax);
             // predicted CI from UAM is the lesser of CI based on deviationSlope or DIA
             predUCI = Math.min(predUCIslope, predUCImax);
             if(predUCI>0) {
-                //console.error(UAMpredBGs.length,minDeviationSlope, predUCI);
+                //console.error(UAMpredBGs.length,slopeFromMaxDeviation, predUCI);
                 UAMduration=round((UAMpredBGs.length+1)*5/60,1);
             }
             UAMpredBG = UAMpredBGs[UAMpredBGs.length-1] + predBGI + Math.min(0, predDev) + predUCI;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -487,6 +487,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     minUAMPredBG = Math.max(39,minUAMPredBG);
     minPredBG = round(minIOBPredBG);
 
+    // if minUAMPredBG < minIOBPredBG, set minUAMPredBG to their average
+    minUAMPredBG = Math.max(minUAMPredBG, ( minUAMPredBG + minIOBPredBG )/2);
+
     var fractionCarbsLeft = meal_data.mealCOB/meal_data.carbs;
     // if we have COB and UAM is enabled, average all three
     if ( minUAMPredBG < 400 && minCOBPredBG < 400 ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -335,6 +335,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     // calculate peak deviation in last hour, and slope from that to current deviation
     var slopeFromMaxDeviation = round(meal_data.slopeFromMaxDeviation,2);
+    // calculate lowest deviation in last hour, and slope from that to current deviation
+    var slopeFromMinDeviation = round(meal_data.slopeFromMinDeviation,2);
+    // assume deviations will drop back down at least at 1/3 the rate they ramped up
+    var slopeFromDeviations = Math.min(slopeFromMaxDeviation,-slopeFromMinDeviation/3);
     //console.error(slopeFromMaxDeviation);
 
     aci = 10;
@@ -388,17 +392,17 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             //process.stderr.write(round(predCI,1)+"+"+round(remainingCI,1)+" ");
             COBpredBG = COBpredBGs[COBpredBGs.length-1] + predBGI + Math.min(0,predDev) + predCI + remainingCI;
             aCOBpredBG = aCOBpredBGs[aCOBpredBGs.length-1] + predBGI + Math.min(0,predDev) + predACI;
-            // for UAMpredBGs, predicted carb impact drops at slopeFromMaxDeviation
-            // calculate predicted CI from UAM based on slopeFromMaxDeviation
-            predUCIslope = Math.max(0, uci + ( UAMpredBGs.length*slopeFromMaxDeviation ) );
-            // if slopeFromMaxDeviation is too flat, predicted deviation impact drops linearly from
+            // for UAMpredBGs, predicted carb impact drops at slopeFromDeviations
+            // calculate predicted CI from UAM based on slopeFromDeviations
+            predUCIslope = Math.max(0, uci + ( UAMpredBGs.length*slopeFromDeviations ) );
+            // if slopeFromDeviations is too flat, predicted deviation impact drops linearly from
             // current deviation down to zero over 3h (data points every 5m)
             predUCImax = Math.max(0, uci * ( 1 - UAMpredBGs.length/Math.max(3*60/5,1) ) );
             //console.error(predUCIslope, predUCImax);
             // predicted CI from UAM is the lesser of CI based on deviationSlope or DIA
             predUCI = Math.min(predUCIslope, predUCImax);
             if(predUCI>0) {
-                //console.error(UAMpredBGs.length,slopeFromMaxDeviation, predUCI);
+                //console.error(UAMpredBGs.length,slopeFromDeviations, predUCI);
                 UAMduration=round((UAMpredBGs.length+1)*5/60,1);
             }
             UAMpredBG = UAMpredBGs[UAMpredBGs.length-1] + predBGI + Math.min(0, predDev) + predUCI;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -507,8 +507,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     // if any carbs have been entered recently
     if (meal_data.carbs) {
-        // average the minIOBPredBG and minUAMPredBG if minUAMPredBG is higher`
-        if ( minUAMPredBG < 400 && minUAMPredBG > minIOBPredBG ) {
+        // average the minIOBPredBG and minUAMPredBG if available
+        if ( minUAMPredBG < 400 ) {
             avgMinPredBG = round( (minIOBPredBG+minUAMPredBG)/2 );
         } else {
             avgMinPredBG = minIOBPredBG;

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -89,7 +89,9 @@ function recentCarbs(opts, time) {
     ,   mealCOB: Math.round( mealCOB )
     ,   currentDeviation: Math.round( c.currentDeviation * 100 ) / 100
     ,   maxDeviation: Math.round( c.maxDeviation * 100 ) / 100
+    ,   minDeviation: Math.round( c.minDeviation * 100 ) / 100
     ,   slopeFromMaxDeviation: Math.round( c.slopeFromMaxDeviation * 1000 ) / 1000
+    ,   slopeFromMinDeviation: Math.round( c.slopeFromMinDeviation * 1000 ) / 1000
     };
 }
 

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -68,7 +68,7 @@ function recentCarbs(opts, time) {
     // set mealTime to 6h ago for Deviation calculations
     COB_inputs.mealTime = time.getTime() - 6 * 60 * 60 * 1000;
     var c = calcMealCOB(COB_inputs);
-    //console.error(c.currentDeviation, c.minDeviationSlope);
+    //console.error(c.currentDeviation, c.slopeFromMaxDeviation);
 
     // set a hard upper limit on COB to mitigate impact of erroneous or malicious carb entry
     mealCOB = Math.min( profile.maxCOB, mealCOB );
@@ -89,7 +89,7 @@ function recentCarbs(opts, time) {
     ,   mealCOB: Math.round( mealCOB )
     ,   currentDeviation: Math.round( c.currentDeviation * 100 ) / 100
     ,   maxDeviation: Math.round( c.maxDeviation * 100 ) / 100
-    ,   minDeviationSlope: Math.round( c.minDeviationSlope * 1000 ) / 1000
+    ,   slopeFromMaxDeviation: Math.round( c.slopeFromMaxDeviation * 1000 ) / 1000
     };
 }
 


### PR DESCRIPTION
In 0.5.3, UAM assumes that current deviations will only decrease to zero over 3 hours if the currentDeviation exceeds the maxDeviation over the last ~45m.  This means that the UAMpredBG purple prediction line goes way too far up-and-to-the-right when carb absorption is peaking.  As an alternative to make UAM safer / less aggressive in that situation, this change causes UAM to assume that current deviations will ramp down over time proportional to how quickly they've ramped up from the recent (~45m) minimum deviations.  So if deviations are rising rapidly due to fast carbs, UAM will not project that to continue indefinitely, but typically only for 1-2h.  For meals whose carb absorption ramps up more slowly, the minDeviation will be higher, and a slower ramp down will be projected as well.  Once deviations actually peak, the existing code to project the rate of decrease from peak takes over.  As a result, UAM predictions are now much more reasonable, while still serving as a useful guideline to safely dosing additional insulin when meal carbs are underestimated and BG rises more than expected.