### PR TITLE
don't adjust temptargets for high BG

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -192,7 +192,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var snoozeBG = naive_snoozeBG + deviation;
 
     // adjust target BG range if needed to safely bring down high BG faster without causing lows
-    if ( bg > max_bg && profile.adv_target_adjustments ) {
+    if ( bg > max_bg && profile.adv_target_adjustments && ! profile.temptargetSet ) {
         // with target=100, as BG rises from 100 to 160, adjustedTarget drops from 100 to 80
         var adjustedMinBG = round(Math.max(80, min_bg - (bg - min_bg)/3 ),0);
         var adjustedTargetBG =round( Math.max(80, target_bg - (bg - target_bg)/3 ),0);


### PR DESCRIPTION
Prior to this change, a not-very-high temptarget (like 110) could be adjusted below 100 by a sufficiently high BG, causing SMB to kick in unexpectedly.  This prevents temptargets from being adjusted by adv_target_adjustments.