### PR TITLE
avoid divide by zero (NaN) in CI Duration

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -341,7 +341,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     //5m data points = g * (1U/10g) * (40mg/dL/1U) / (mg/dL/5m)
     // duration (in 5m data points) = COB (g) * CSF (mg/dL/g) / ci (mg/dL/5m)
     // limit cid to remainingCATime hours: the reset goes to remainingCI
-    cid = Math.min(remainingCATime*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
+    if (ci == 0) {
+        // avoid divide by zero
+        cid = 0;
+    } else {
+        cid = Math.min(remainingCATime*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
+    }
     acid = Math.max(0, meal_data.mealCOB * csf / aci );
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
     console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (2h peak):",round(remainingCIpeak,1),"mg/dL per 5m");


### PR DESCRIPTION
Fixes a cosmetic bug that resulted in NaN being displayed in pump-loop.log when CI is exactly zero:

```
Carb Impact: 0 mg/dL per 5m; CI Duration: NaN hours; remaining CI (2h peak): 0 mg/dL per 5m
Accel. Carb Impact: 10 mg/dL per 5m; ACI Duration: 0 hours
predCIs: NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
remainingCIs: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
COB: 0 remainingCItotal/csf: NaN remainingCarbs: 0
```