### PR TITLE
display curve in preferences by default

### DIFF
--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -59,6 +59,7 @@ function displayedDefaults () {
     profile.enableSMB_with_COB = allDefaults.enableSMB_with_COB;
     profile.enableSMB_with_temptarget = allDefaults.enableSMB_with_temptarget;
     profile.enableUAM = allDefaults.enableUAM;
+    profile.curve = allDefaults.curve;
 
     console.error(profile);
     return profile


### PR DESCRIPTION
Since there are no strings displayed in preferences.json by default, it's non-intuitive to know how to add "curve".  Since we'll eventually want everyone to change over to an exponential curve (and most likely will eventually want to make "rapid-acting" the default and deprecate "bilinear"), we should include "curve" in displayedDefaults.