### PR TITLE
512/712/x12 fixes to master

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -316,12 +316,12 @@ function mdt_get_bg {
 }
 # make sure we can talk to the pump and get a valid model number
 function preflight {
-        echo -n "Preflight "
-            # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
-                ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&1 >/dev/null | tail -1 \
-                        && ( egrep -q "[57](15|22|23|54)" settings/model.json || (echo -n "error: pump model untested with SMB: "; false) ) \
-                        && echo -n "OK. " \
-                            || ( echo -n "fail. "; false )
+    echo -n "Preflight "
+    # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
+    ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&1 >/dev/null | tail -1 \
+    && ( egrep -q "[57](15|22|23|54)" settings/model.json || (echo -n "error: pump model untested with SMB: "; false) ) \
+    && echo -n "OK. " \
+    || ( echo -n "fail. "; false )
 }
 
 # reset radio, init world wide pump (if applicable), mmtune, and wait_for_silence 60 if no signal

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -316,10 +316,12 @@ function mdt_get_bg {
 }
 # make sure we can talk to the pump and get a valid model number
 function preflight {
-    # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
-    ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&1 >/dev/null | tail -1 \
-    && egrep -q "[57](15|22|23|54)" settings/model.json \
-    && echo -n "Preflight OK. "
+        echo -n "Preflight "
+            # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
+                ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&1 >/dev/null | tail -1 \
+                    && egrep -q "[57](15|22|23|54)" settings/model.json \
+                        && echo -n "OK. " \
+                            || ( echo -n "fail. "; false )
 }
 
 # reset radio, init world wide pump (if applicable), mmtune, and wait_for_silence 60 if no signal

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -319,7 +319,7 @@ function preflight {
         echo -n "Preflight "
             # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
                 ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&1 >/dev/null | tail -1 \
-                    && egrep -q "[57](15|22|23|54)" settings/model.json \
+                        && ( egrep -q "[57](15|22|23|54)" settings/model.json || (echo -n "error: pump model untested with SMB: "; false) ) \
                         && echo -n "OK. " \
                             || ( echo -n "fail. "; false )
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -383,7 +383,8 @@ function wait_for_silence {
 function gather {
     openaps report invoke monitor/status.json 2>&1 >/dev/null | tail -1 \
     && echo -n Ref \
-    && ( test $(cat monitor/status.json | json suspended) == true || \
+    && ( grep -q "model.*12" monitor/status.json || \
+         test $(cat monitor/status.json | json suspended) == true || \
          test $(cat monitor/status.json | json bolusing) == false ) \
     && echo -n resh \
     && ( openaps monitor-pump || openaps monitor-pump ) 2>&1 >/dev/null | tail -1 \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oref0",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",


### PR DESCRIPTION
Discovered some issues in 0.5.3 that caused issue for 512/712/x12 users.

Includes:

    Confirmation that x12s will not work with SMBs
    Better error messaging around x12 model checks
    Other bugs that were preventing x12s from working successfully
