### PR TITLE
disable SMB if predicted BG drops below threshold

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -455,7 +455,7 @@ function refresh_smb_temp_and_enact {
     # only smb_enact_temp if we haven't successfully completed a pump_loop recently
     # (no point in enacting a temp that's going to get changed after we see our last SMB)
     if (cat monitor/temp_basal.json | json -c "this.duration > 20" | grep -q duration); then
-        echo "Temp duration >20m. "
+        echo -n "Temp duration >20m. "
     elif ( find monitor/ -mmin +10 | grep -q monitor/pump_loop_completed ); then
         echo "pump_loop_completed more than 10m ago: setting temp before refreshing pumphistory. "
         smb_enact_temp

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -454,7 +454,9 @@ function refresh_smb_temp_and_enact {
     setglucosetimestamp
     # only smb_enact_temp if we haven't successfully completed a pump_loop recently
     # (no point in enacting a temp that's going to get changed after we see our last SMB)
-    if ( find monitor/ -mmin +10 | grep -q monitor/pump_loop_completed ); then
+    if (cat monitor/temp_basal.json | json -c "this.duration > 20" | grep -q duration); then
+        echo "Temp duration >20m. "
+    elif ( find monitor/ -mmin +10 | grep -q monitor/pump_loop_completed ); then
         echo "pump_loop_completed more than 10m ago: setting temp before refreshing pumphistory. "
         smb_enact_temp
     else

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -429,9 +429,9 @@ function refresh_old_pumphistory_enact {
     || ( echo -n "Old pumphistory: " && gather && enact )
 }
 
-# refresh pumphistory if it's more than 15m old, but don't enact
+# refresh pumphistory if it's more than 30m old, but don't enact
 function refresh_old_pumphistory {
-    find monitor/ -mmin -15 -size +100c | grep -q pumphistory-zoned \
+    find monitor/ -mmin -30 -size +100c | grep -q pumphistory-zoned \
     || ( echo -n "Old pumphistory, waiting for $upto30s seconds of silence: " && wait_for_silence $upto30s && gather )
 }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -562,7 +562,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     rT.COB=meal_data.mealCOB;
     rT.IOB=iob_data.iob;
-    rT.reason="COB: " + meal_data.mealCOB + ", Dev: " + deviation + ", BGI: " + bgi + ", ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(target_bg, profile) + ", minPredBG " + convert_bg(minPredBG, profile) + ", IOBpredBG " + convert_bg(lastIOBpredBG, profile) + ", minGuardBG " + convert_bg(minGuardBG, profile);
+    rT.reason="COB: " + meal_data.mealCOB + ", Dev: " + deviation + ", BGI: " + bgi + ", ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(target_bg, profile) + ", minPredBG " + convert_bg(minPredBG, profile) + ", minGuardBG " + convert_bg(minGuardBG, profile) + ", IOBpredBG " + convert_bg(lastIOBpredBG, profile);
     if (lastCOBpredBG > 0) {
         rT.reason += ", COBpredBG " + convert_bg(lastCOBpredBG, profile);
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -349,6 +349,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var minIOBPredBG = 999;
     var minCOBPredBG = 999;
     var minUAMPredBG = 999;
+    var minGuardBG = 999;
     var minPredBG;
     var avgPredBG;
     var IOBpredBG = eventualBG;
@@ -408,6 +409,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if ( COBpredBGs.length < 48) { COBpredBGs.push(COBpredBG); }
             if ( aCOBpredBGs.length < 48) { aCOBpredBGs.push(aCOBpredBG); }
             if ( UAMpredBGs.length < 48) { UAMpredBGs.push(UAMpredBG); }
+            // calculate minGuardBG without a wait from COB if available, or UAM, or IOB predBGs
+            if (cid || remainingCIpeak > 0) {
+                if ( COBpredBG < minGuardBG ) { minGuardBG = round(COBpredBG); }
+            } else if ( enableUAM ) {
+                if ( UAMpredBG < minGuardBG ) { minGuardBG = round(UAMpredBG); }
+            } else {
+                if ( IOBpredBG < minIOBPredBG ) { minIOBPredBG = round(IOBpredBG); }
+            }
             // wait 90m before setting minIOBPredBG
             if ( IOBpredBGs.length > 18 && (IOBpredBG < minIOBPredBG) ) { minIOBPredBG = round(IOBpredBG); }
             if ( IOBpredBG > maxIOBPredBG ) { maxIOBPredBG = IOBpredBG; }
@@ -553,7 +562,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     rT.COB=meal_data.mealCOB;
     rT.IOB=iob_data.iob;
-    rT.reason="COB: " + meal_data.mealCOB + ", Dev: " + deviation + ", BGI: " + bgi + ", ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(target_bg, profile) + ", minPredBG " + convert_bg(minPredBG, profile) + ", IOBpredBG " + convert_bg(lastIOBpredBG, profile);
+    rT.reason="COB: " + meal_data.mealCOB + ", Dev: " + deviation + ", BGI: " + bgi + ", ISF: " + convert_bg(sens, profile) + ", Target: " + convert_bg(target_bg, profile) + ", minPredBG " + convert_bg(minPredBG, profile) + ", IOBpredBG " + convert_bg(lastIOBpredBG, profile) + ", minGuardBG " + convert_bg(minGuardBG, profile);
     if (lastCOBpredBG > 0) {
         rT.reason += ", COBpredBG " + convert_bg(lastCOBpredBG, profile);
     }
@@ -580,6 +589,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 break;
             }
         }
+    }
+
+    if (enableSMB && minGuardBG < threshold) {
+        console.error("minGuardBG",minGuardBG,"projected below",threshold,"- disabling SMB");
+        enableSMB = false;
     }
 
     console.error("BG projected to remain above",min_bg,"for",minutesAboveMinBG,"minutes");


### PR DESCRIPTION
This change calculates a minGuardBG value, based on the lowest predicted COB value (starting from now, not from 60-90m in the future as other predBGs do) if COB is present, or the lowest predicted UAM value if that's present, or the lowest IOB predBG if neither COB nor UAM is available.  If the minGuardBG is below threshold (the same one used to decide not to high temp), then SMBs are temporarily disabled.