### PR TITLE
Refresh pumphistory before setting temps and after SMB/enact

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -223,7 +223,7 @@ function smb_bolus {
 }
 
 function refresh_after_bolus_or_enact {
-    if (grep -q '"units":' enact/smb-suggested.json || (cat monitor/temp_basal.json | json -c "this.duration > 28" | grep -q duration)); then
+    if (find enact/ -mmin -2 -size +5c | grep -q bolused.json || (cat monitor/temp_basal.json | json -c "this.duration > 28" | grep -q duration)); then
         gather || ( wait_for_silence 10 && gather )
         true
     fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -224,7 +224,7 @@ function smb_bolus {
 
 function refresh_after_bolus_or_enact {
     if (grep -q '"units":' enact/smb-suggested.json || (cat monitor/temp_basal.json | json -c "this.duration > 28" | grep -q duration)); then
-        ( smb_verify_status || ( wait_for_silence 10 && smb_verify_status ) ) && gather
+        gather || ( wait_for_silence 10 && gather )
         true
     fi
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -455,7 +455,7 @@ function refresh_smb_temp_and_enact {
     # only smb_enact_temp if we haven't successfully completed a pump_loop recently
     # (no point in enacting a temp that's going to get changed after we see our last SMB)
     if (cat monitor/temp_basal.json | json -c "this.duration > 20" | grep -q duration); then
-        echo "Temp duration >20m. "
+        echo -n "Temp duration >20m. "
     elif ( find monitor/ -mmin +10 | grep -q monitor/pump_loop_completed ); then
         echo "pump_loop_completed more than 10m ago: setting temp before refreshing pumphistory. "
         smb_enact_temp

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -204,6 +204,7 @@ function smb_verify_status {
         echo -n "Pump suspended; "
         unsuspend_if_no_temp
         gather
+        false
     fi
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -63,6 +63,7 @@ smb_main() {
             fi
             ) \
             && ( refresh_profile; refresh_pumphistory_24h; true ) \
+            && ( ( smb_verify_status || ( sleep 30 && smb_verify_status ) ) && gather; true ) \
             && echo Completed supermicrobolus pump-loop at $(date): \
             && touch monitor/pump_loop_completed -r monitor/pump_loop_enacted \
             && echo \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -210,7 +210,7 @@ function smb_verify_status {
 function smb_bolus {
     # Verify that the suggested.json is less than 5 minutes old
     # and administer the supermicrobolus
-    find enact/ -mmin -5 | grep smb-suggested.json \
+    find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
     && if (grep -q '"units":' enact/smb-suggested.json); then
         openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -224,7 +224,7 @@ function smb_bolus {
 
 function refresh_after_bolus_or_enact {
     if (find enact/ -mmin -2 -size +5c | grep -q bolused.json || (cat monitor/temp_basal.json | json -c "this.duration > 28" | grep -q duration)); then
-        gather || ( wait_for_silence 10 && gather )
+        gather || ( wait_for_silence 10 && gather ) || ( wait_for_silence 20 && gather )
         true
     fi
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -454,7 +454,9 @@ function refresh_smb_temp_and_enact {
     setglucosetimestamp
     # only smb_enact_temp if we haven't successfully completed a pump_loop recently
     # (no point in enacting a temp that's going to get changed after we see our last SMB)
-    if ( find monitor/ -mmin +10 | grep -q monitor/pump_loop_completed ); then
+    if (cat monitor/temp_basal.json | json -c "this.duration > 20" | grep -q duration); then
+        echo "Temp duration >20m. "
+    elif ( find monitor/ -mmin +10 | grep -q monitor/pump_loop_completed ); then
         echo "pump_loop_completed more than 10m ago: setting temp before refreshing pumphistory. "
         smb_enact_temp
     else

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -329,7 +329,7 @@ function preflight {
     echo -n "Preflight "
     # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
     ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&1 >/dev/null | tail -1 \
-    && egrep -q "[57](15|22|23|54)" settings/model.json \
+    && ( egrep -q "[57](15|22|23|54)" settings/model.json || (echo "error: pump model untested with SMB: "; false) ) \
     && echo -n "OK. " \
     || ( echo -n "fail. "; false )
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -223,7 +223,7 @@ function smb_bolus {
 }
 
 function refresh_after_bolus_or_enact {
-    if (grep -q '"units":' enact/smb-suggested.json || (cat monitor/temp_basal.json | json -c "this.duration > 28" | grep -q duration); then
+    if (grep -q '"units":' enact/smb-suggested.json || (cat monitor/temp_basal.json | json -c "this.duration > 28" | grep -q duration)); then
         ( smb_verify_status || ( wait_for_silence 10 && smb_verify_status ) ) && gather
         true
     fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -329,7 +329,7 @@ function preflight {
     echo -n "Preflight "
     # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
     ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&1 >/dev/null | tail -1 \
-    && ( egrep -q "[57](15|22|23|54)" settings/model.json || (echo "error: pump model untested with SMB: "; false) ) \
+    && ( egrep -q "[57](15|22|23|54)" settings/model.json || (echo -n "error: pump model untested with SMB: "; false) ) \
     && echo -n "OK. " \
     || ( echo -n "fail. "; false )
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -429,9 +429,9 @@ function refresh_old_pumphistory_enact {
     || ( echo -n "Old pumphistory: " && gather && enact )
 }
 
-# refresh pumphistory if it's more than 15m old, but don't enact
+# refresh pumphistory if it's more than 30m old, but don't enact
 function refresh_old_pumphistory {
-    find monitor/ -mmin -15 -size +100c | grep -q pumphistory-zoned \
+    find monitor/ -mmin -30 -size +100c | grep -q pumphistory-zoned \
     || ( echo -n "Old pumphistory, waiting for $upto30s seconds of silence: " && wait_for_silence $upto30s && gather )
 }
 


### PR DESCRIPTION
We currently allow oref0-pump-loop to try to set a temp basal before it tries to refresh pumphistory if it hasn't completed a pump loop recently, as a way to make sure that we can enact temp basals based on updated BG data even when pump comms are flaky.  However, this results in high temps being set and then immediately canceled when an SMB has been delivered that the rig doesn't know about yet.

This change skips the "setting temp before refreshing pumphistory" code path if the currently running temp basal has a duration of more than 20 minutes.

This also makes oref0-pump-loop refresh pumphistory after bolusing or enacting a temp, so we don't have to wait 5 minutes for it to be displayed in NS.