### PR TITLE
autotune de-biasing

### DIFF
--- a/bin/oref0-autotune-recommends-report.sh
+++ b/bin/oref0-autotune-recommends-report.sh
@@ -69,11 +69,11 @@ printf "%s\n" "-------------------------------------" >> $report_file
 
 # Print ISF, CSF and Carb Ratio Recommendations
 printf "%-${parameter_width}s| %-${data_width}.3f| %-${data_width}.3f\n" "ISF [mg/dL/U]" $isf_current $isf_new >> $report_file
-if [ $csf_current != null ]; then
-  printf "%-${parameter_width}s| %-${data_width}.3f| %-${data_width}.3f\n" "CSF [mg/dL/g]" $csf_current $csf_new >> $report_file
-else
-  printf "%-${parameter_width}s| %-${data_width}s| %-${data_width}.3f\n" "CSF [mg/dL/g]" "n/a" $csf_new >> $report_file
-fi
+# if [ $csf_current != null ]; then
+  # printf "%-${parameter_width}s| %-${data_width}.3f| %-${data_width}.3f\n" "CSF [mg/dL/g]" $csf_current $csf_new >> $report_file
+# else
+  # printf "%-${parameter_width}s| %-${data_width}s| %-${data_width}.3f\n" "CSF [mg/dL/g]" "n/a" $csf_new >> $report_file
+# fi
 printf "%-${parameter_width}s| %-${data_width}.3f| %-${data_width}.3f\n" "Carb Ratio[g/U]" $carb_ratio_current $carb_ratio_new >> $report_file
 
 # Print Basal Profile Recommendations

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -189,7 +189,9 @@ do
     # Get Nightscout carb and insulin Treatments
     # echo $i $START_DATE;
     #query="find%5Bdate%5D%5B%24gte%5D=`(date -d $i +%s | tr -d'\n'; echo 000)`&find%5Bdate%5D%5B%24lte%5D=`(date --date="$i +1 days" +%s | tr -d '\n'; echo 000)`&count=1000"
-    query="find%5Bcreated_at%5D%5B%24gte%5D=`date --date="$i -5 hours" -Iminutes`&find%5Bcreated_at%5D%5B%24lte%5D=`date --date="$i +1 days" -Iminutes`"
+    # to capture UTC-dated treatments, we need to capture an extra 12h on either side, plus the DIA lookback
+    # 18h = 12h for timezones + 6h for DIA; 36h = 24h for end-of-day + 12h for timezones
+    query="find%5Bcreated_at%5D%5B%24gte%5D=`date --date="$i -18 hours" -Iminutes`&find%5Bcreated_at%5D%5B%24lte%5D=`date --date="$i +36 hours" -Iminutes`"
     echo Query: $NIGHTSCOUT_HOST/$query
     ns-get host $NIGHTSCOUT_HOST treatments.json $query > ns-treatments.$i.json || die "Couldn't download ns-treatments.$i.json"
     ls -la ns-treatments.$i.json || die "No ns-treatments.$i.json downloaded"

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -49,8 +49,8 @@ if [ -n "${API_SECRET_READ}" ]; then
 fi
 
 if [[ -z "$API_SECRET" ]]; then
-  echo "ERROR: API_SECRET is not set when calling oref0-autotune.sh"
-  exit 1
+  echo "Warning: API_SECRET is not set when calling oref0-autotune.sh"
+  # exit 1
 fi
 
 # If we are running OS X, we need to use a different version

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -352,15 +352,6 @@ function categorizeBGDatums(opts) {
     var UAMLength = UAMGlucoseData.length;
     var basalLength = basalGlucoseData.length;
 
-    if (4*basalLength < CSFLength) {
-        console.error("Warning: too many deviations categorized as meals");
-        //console.error("Adding",CSFLength,"CSF deviations to",basalLength,"basal ones");
-        //var basalGlucoseData = basalGlucoseData.concat(CSFGlucoseData);
-        console.error("Adding",CSFLength,"CSF deviations to",ISFLength,"ISF ones");
-        var ISFGlucoseData = ISFGlucoseData.concat(CSFGlucoseData);
-        CSFGlucoseData = [];
-    }
-
     if (2*basalLength < UAMLength) {
         //console.error(basalGlucoseData, UAMGlucoseData);
         console.error("Warning: too many deviations categorized as UnAnnounced Meals");
@@ -370,6 +361,17 @@ function categorizeBGDatums(opts) {
         var ISFGlucoseData = ISFGlucoseData.concat(UAMGlucoseData);
         //console.error(ISFGlucoseData.length, UAMLength);
     }
+    var basalLength = basalGlucoseData.length;
+    var ISFLength = ISFGlucoseData.length;
+    if (4*basalLength + ISFLength < CSFLength) {
+        console.error("Warning: too many deviations categorized as meals");
+        //console.error("Adding",CSFLength,"CSF deviations to",basalLength,"basal ones");
+        //var basalGlucoseData = basalGlucoseData.concat(CSFGlucoseData);
+        console.error("Adding",CSFLength,"CSF deviations to",ISFLength,"ISF ones");
+        var ISFGlucoseData = ISFGlucoseData.concat(CSFGlucoseData);
+        CSFGlucoseData = [];
+    }
+
 
     return {
         CRData: CRData,

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -363,7 +363,7 @@ function categorizeBGDatums(opts) {
     }
     var basalLength = basalGlucoseData.length;
     var ISFLength = ISFGlucoseData.length;
-    if (4*basalLength + ISFLength < CSFLength) {
+    if ( 4*basalLength + ISFLength < CSFLength && ISFLength < 10 ) {
         console.error("Warning: too many deviations categorized as meals");
         //console.error("Adding",CSFLength,"CSF deviations to",basalLength,"basal ones");
         //var basalGlucoseData = basalGlucoseData.concat(CSFGlucoseData);

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -277,7 +277,6 @@ function categorizeBGDatums(opts) {
             console.error(CSFGlucoseData[CSFGlucoseData.length-1].mealAbsorption,"carb absorption");
           }
 
-          // check that we have a decent amount of basal tuning data before excluding data as UAM
           if ((iob.iob > currentBasal || uam) ) {
             if (deviation > 0) {
                 uam = 1;
@@ -303,7 +302,7 @@ function categorizeBGDatums(opts) {
             // unless avgDelta is positive: then that's some sort of unexplained rise we don't want to use for ISF, so that means basals
             if (basalBGI > -4 * BGI) {
                 // attempting to prevent basal from being calculated as negative; should help prevent basals from going below 0
-                var minPossibleDeviation = -( basalBGI + Math.max(0,BGI) );
+                //var minPossibleDeviation = -( basalBGI + Math.max(0,BGI) );
                 //var minPossibleDeviation = -basalBGI;
                 //if ( deviation < minPossibleDeviation ) {
                     //console.error("Adjusting deviation",deviation,"to",minPossibleDeviation.toFixed(2));
@@ -314,7 +313,7 @@ function categorizeBGDatums(opts) {
                 type="basal";
                 basalGlucoseData.push(glucoseDatum);
             } else {
-                if (avgDelta > 0 ) {
+                if (avgDelta > -BGI ) {
                     //type="unknown"
                     type="basal"
                     basalGlucoseData.push(glucoseDatum);

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -313,7 +313,7 @@ function categorizeBGDatums(opts) {
                 type="basal";
                 basalGlucoseData.push(glucoseDatum);
             } else {
-                if ( avgDelta > 0 && avgDelta > -BGI ) {
+                if ( avgDelta > 0 && avgDelta > -2*BGI ) {
                     //type="unknown"
                     type="basal"
                     basalGlucoseData.push(glucoseDatum);

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -233,7 +233,7 @@ function categorizeBGDatums(opts) {
 
                 var CRElapsedMinutes = Math.round((CREndTime - CRInitialCarbTime) / 1000 / 60);
                 //console.error(CREndTime - CRInitialCarbTime, CRElapsedMinutes);
-                if ( CRElapsedMinutes < 60 ) {
+                if ( CRElapsedMinutes < 60 || ( i==1 && mealCOB > 0 ) ) {
                     console.error("Ignoring",CRElapsedMinutes,"m CR period.");
                 } else {
                     CRData.push(CRDatum);

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -313,7 +313,7 @@ function categorizeBGDatums(opts) {
                 type="basal";
                 basalGlucoseData.push(glucoseDatum);
             } else {
-                if (avgDelta > -BGI ) {
+                if ( avgDelta > 0 && avgDelta > -BGI ) {
                     //type="unknown"
                     type="basal"
                     basalGlucoseData.push(glucoseDatum);

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -363,7 +363,11 @@ function tuneAllTheThings (inputs) {
     // high autosens ratio = low ISF
     var minISF = pumpISF / autotuneMax;
     if (typeof(pumpISF) !== 'undefined') {
-        var adjustedISF = adjustmentFraction*fullNewISF + (1-adjustmentFraction)*pumpISF;
+        if ( fullNewISF < 0 ) {
+            var adjustedISF = ISF;
+        } else {
+            var adjustedISF = adjustmentFraction*fullNewISF + (1-adjustmentFraction)*pumpISF;
+        }
         // cap adjustedISF before applying 10%
         //console.error(adjustedISF, maxISF, minISF);
         if (adjustedISF > maxISF) {

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -356,7 +356,7 @@ function tuneAllTheThings (inputs) {
     if (pumpProfile.autotune_isf_adjustmentFraction) {
         adjustmentFraction = pumpProfile.autotune_isf_adjustmentFraction;
     } else {
-        adjustmentFraction = 0.5;
+        adjustmentFraction = 1.0;
     }
     // low autosens ratio = high ISF
     var maxISF = pumpISF / autotuneMin;

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -374,8 +374,8 @@ function tuneAllTheThings (inputs) {
             adjustedISF = minISF;
         }
 
-        // and apply 10% of that adjustment
-        var newISF = ( 0.9 * ISF ) + ( 0.1 * adjustedISF );
+        // and apply 20% of that adjustment
+        var newISF = ( 0.8 * ISF ) + ( 0.2 * adjustedISF );
 
         if (newISF > maxISF) {
             console.error("Limiting ISF of",newISF.toFixed(2),"to",maxISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMin,")");

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -310,10 +310,10 @@ function tuneAllTheThings (inputs) {
     newCR = Math.round( newCR * 1000 ) / 1000;
     console.error("oldCR:",carbRatio,"fullNewCR:",fullNewCR,"newCR:",newCR);
     // this is where CR is set based on the outputs
-    var ISFFromCRAndCSF = ISF;
+    //var ISFFromCRAndCSF = ISF;
     if (newCR) {
         carbRatio = newCR;
-        ISFFromCRAndCSF = Math.round( carbRatio * CSF * 1000)/1000;
+        //ISFFromCRAndCSF = Math.round( carbRatio * CSF * 1000)/1000;
     }
 
 
@@ -343,7 +343,7 @@ function tuneAllTheThings (inputs) {
     p50deviation = percentile(deviations, 0.50);
     p50BGI = percentile(BGIs, 0.50);
     p50ratios = Math.round( percentile(ratios, 0.50) * 1000)/1000;
-    if (count < 5) {
+    if (count < 10) {
         // leave ISF unchanged if fewer than 5 ISF data points
         fullNewISF = ISF;
     } else {

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -365,7 +365,7 @@ function tuneAllTheThings (inputs) {
     if (typeof(pumpISF) !== 'undefined') {
         var adjustedISF = adjustmentFraction*fullNewISF + (1-adjustmentFraction)*pumpISF;
         // cap adjustedISF before applying 10%
-        console.error(adjustedISF, maxISF, minISF);
+        //console.error(adjustedISF, maxISF, minISF);
         if (adjustedISF > maxISF) {
             console.error("Limiting adjusted ISF of",adjustedISF.toFixed(2),"to",maxISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMin,")");
             adjustedISF = maxISF;

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -281,9 +281,21 @@ function tuneAllTheThings (inputs) {
         // how much change would be required to account for all of the deviations
         fullNewCR = totalCR;
     }
-    // only adjust by 10%
+    // safety cap fullNewCR
+    if (typeof(pumpCarbRatio) !== 'undefined') {
+        var maxCR = pumpCarbRatio * autotuneMax;
+        var minCR = pumpCarbRatio * autotuneMin;
+        if (fullNewCR > maxCR) {
+            console.error("Limiting fullNewCR from",fullNewCR,"to",maxCR.toFixed(2),"(which is",autotuneMax,"* pump CR of",pumpCarbRatio,")");
+            fullNewCR = maxCR;
+        } else if (fullNewCR < minCR) {
+            console.error("Limiting fullNewCR from",fullNewCR,"to",minCR.toFixed(2),"(which is",autotuneMin,"* pump CR of",pumpCarbRatio,")");
+            fullNewCR = minCR;
+        } //else { console.error("newCR",newCR,"is close enough to",pumpCarbRatio); }
+    }
+    // only adjust by 20%
     newCR = ( 0.8 * carbRatio ) + ( 0.2 * fullNewCR );
-    // safety cap CR
+    // safety cap newCR
     if (typeof(pumpCarbRatio) !== 'undefined') {
         var maxCR = pumpCarbRatio * autotuneMax;
         var minCR = pumpCarbRatio * autotuneMin;
@@ -346,9 +358,14 @@ function tuneAllTheThings (inputs) {
     } else {
         adjustmentFraction = 0.5;
     }
+    // low autosens ratio = high ISF
+    var maxISF = pumpISF / autotuneMin;
+    // high autosens ratio = low ISF
+    var minISF = pumpISF / autotuneMax;
     if (typeof(pumpISF) !== 'undefined') {
         var adjustedISF = adjustmentFraction*fullNewISF + (1-adjustmentFraction)*pumpISF;
         // cap adjustedISF before applying 10%
+        console.error(adjustedISF, maxISF, minISF);
         if (adjustedISF > maxISF) {
             console.error("Limiting adjusted ISF of",adjustedISF.toFixed(2),"to",maxISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMin,")");
             adjustedISF = maxISF;
@@ -357,19 +374,9 @@ function tuneAllTheThings (inputs) {
             adjustedISF = minISF;
         }
 
-        // average both the directly-calculated ISF and the ISFFromCRAndCSF if we're reasonably well tuned
-        if (p50ratios > 0.4 && p50ratios < 0.6) {
-            // TODO: figure out if there's a way to do this without messing up CSF tuning
-            // adjustedISF = (adjustedISF + ISFFromCRAndCSF) / 2;
-        }
-
         // and apply 10% of that adjustment
         var newISF = ( 0.9 * ISF ) + ( 0.1 * adjustedISF );
 
-        // low autosens ratio = high ISF
-        var maxISF = pumpISF / autotuneMin;
-        // high autosens ratio = low ISF
-        var minISF = pumpISF / autotuneMax;
         if (newISF > maxISF) {
             console.error("Limiting ISF of",newISF.toFixed(2),"to",maxISF.toFixed(2),"(which is pump ISF of",pumpISF,"/",autotuneMin,")");
             newISF = maxISF;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -25,7 +25,7 @@ function defaults ( ) {
     , bolussnooze_dia_divisor: 2 // bolus snooze decays after 1/2 of DIA
     , min_5m_carbimpact: 8 // mg/dL per 5m (8 mg/dL/5m corresponds to 24g/hr at a CSF of 4 mg/dL/g (x/5*60/4))
     , carbratio_adjustmentratio: 1 // if carb ratios on pump are set higher to lower initial bolus using wizard, .8 = assume only 80 percent of carbs covered with full bolus
-    , autotune_isf_adjustmentFraction: 0.5 // keep autotune ISF closer to pump ISF via a weighted average of fullNewISF and pumpISF.  1.0 allows full adjustment, 0 is no adjustment from pump ISF.
+    , autotune_isf_adjustmentFraction: 1.0 // keep autotune ISF closer to pump ISF via a weighted average of fullNewISF and pumpISF.  1.0 allows full adjustment, 0 is no adjustment from pump ISF.
     , remainingCarbsFraction: 1.0 // fraction of carbs we'll assume will absorb over 4h if we don't yet see carb absorption
     , remainingCarbsCap: 90 // max carbs we'll assume will absorb over 4h if we don't yet see carb absorption
     // WARNING: the following are advanced oref1 features, and are not yet tested for general use


### PR DESCRIPTION
This fixes an upward bias in the new CR autotuning from dinners that don't finish absorbing by midnight, and removes the upward bias on ISF from ignoring (slightly) positive deltas.

It also fixes a bug that was preventing ISF data from being capped by the min/max limits before being applied, and only capping it afterward.  Fixing that allows us to stop relying on the autotune ISF adjustment ratio hack, so it changes the default value to 1.0 (in preparation for removing it entirely at some future date).

CSF is also removed from the recommendations report to reduce confusion now that ISF and CR are both calculated directly (and somewhat independently).