### PR TITLE
recalculate IOB and predBGs after each loop

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -229,7 +229,8 @@ function refresh_after_bolus_or_enact {
         refresh_profile 3
         gather || ( wait_for_silence 10 && gather ) || ( wait_for_silence 20 && gather )
         openaps report invoke enact/smb-suggested.json 2>/dev/null >/dev/null \
-        && cp -up enact/smb-suggested.json enact/suggested.json
+        && cp -up enact/smb-suggested.json enact/suggested.json \
+        && echo -n "IOB: " && cat enact/smb-suggested.json | jq .IOB
         true
     fi
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -228,7 +228,7 @@ function refresh_after_bolus_or_enact {
         # refresh profile if >5m old to give SMB a chance to deliver
         refresh_profile 3
         gather || ( wait_for_silence 10 && gather ) || ( wait_for_silence 20 && gather )
-        smb_suggest
+        smb_suggest 2>&1
         true
     fi
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -515,8 +515,8 @@ function refresh_profile {
     else
         profileage=$1
     fi
-    find settings/ -mmin -$profileage -size +5c | grep -q settings.json && echo Settings less than $profileage minutes old \
-    || (echo -n Settings refresh && openaps get-settings 2>/dev/null >/dev/null && echo ed)
+    find settings/ -mmin -$profileage -size +5c | grep -q settings.json && echo -n "Settings less than $profileage minutes old. " \
+    || (echo -n Settings refresh && openaps get-settings 2>/dev/null >/dev/null && echo -n "ed. ")
 }
 
 function wait_for_bg {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -228,7 +228,8 @@ function refresh_after_bolus_or_enact {
         # refresh profile if >5m old to give SMB a chance to deliver
         refresh_profile 3
         gather || ( wait_for_silence 10 && gather ) || ( wait_for_silence 20 && gather )
-        smb_suggest 2>&1
+        openaps report invoke enact/smb-suggested.json 2>/dev/null >/dev/null \
+        && cp -up enact/smb-suggested.json enact/suggested.json
         true
     fi
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -228,6 +228,7 @@ function refresh_after_bolus_or_enact {
         # refresh profile if >5m old to give SMB a chance to deliver
         refresh_profile 3
         gather || ( wait_for_silence 10 && gather ) || ( wait_for_silence 20 && gather )
+        smb_suggest
         true
     fi
 


### PR DESCRIPTION
Now that we're refreshing pumphistory after each loop, the only things remaining out of date until the next one are the IOB pill and purple prediction lines.  This recalculates those so they can be uploaded as well.