### PR TITLE
add allDeviations to meal.json output for UAM monitoring

### DIFF
--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -102,6 +102,7 @@ function detectCarbAbsorption(inputs) {
     var slopeFromMinDeviation = 999;
     var maxDeviation = 0;
     var minDeviation = 999;
+    var allDeviations = [];
     //console.error(bucketed_data);
     for (var i=0; i < bucketed_data.length-3; ++i) {
         var bgTime = new Date(bucketed_data[i].date);
@@ -142,6 +143,7 @@ function detectCarbAbsorption(inputs) {
             currentDeviation = Math.round((avgDelta-bgi)*1000)/1000;
             if (ciTime > bgTime) {
                 //console.error("currentDeviation:",currentDeviation,avgDelta,bgi);
+                allDeviations.push(currentDeviation);
             }
             if (currentDeviation/2 > profile.min_5m_carbimpact) {
                 //console.error("currentDeviation",currentDeviation,"/2 > min_5m_carbimpact",profile.min_5m_carbimpact);
@@ -159,7 +161,9 @@ function detectCarbAbsorption(inputs) {
                 minDeviation = avgDeviation;
             }
 
-            //console.error("Deviations:",bgTime, avgDeviation, deviationSlope, slopeFromMaxDeviation, slopeFromMinDeviation, avgDelta,bgi);
+            //console.error("Deviations:",avgDeviation, avgDelta,bgi,bgTime);
+            allDeviations.push(avgDeviation);
+            //console.error(allDeviations);
         }
 
         // if bgTime is more recent than mealTime
@@ -184,6 +188,7 @@ function detectCarbAbsorption(inputs) {
     ,   "minDeviation": minDeviation
     ,   "slopeFromMaxDeviation": slopeFromMaxDeviation
     ,   "slopeFromMinDeviation": slopeFromMinDeviation
+    ,   "allDeviations": allDeviations
     }
     return output;
 }

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -83,7 +83,6 @@ function recentCarbs(opts, time) {
         mealCOB = 0;
     }
 
-
     return {
         carbs: Math.round( carbs * 1000 ) / 1000
     ,   mealCOB: Math.round( mealCOB )
@@ -92,6 +91,7 @@ function recentCarbs(opts, time) {
     ,   minDeviation: Math.round( c.minDeviation * 100 ) / 100
     ,   slopeFromMaxDeviation: Math.round( c.slopeFromMaxDeviation * 1000 ) / 1000
     ,   slopeFromMinDeviation: Math.round( c.slopeFromMinDeviation * 1000 ) / 1000
+    ,   allDeviations: c.allDeviations
     };
 }
 


### PR DESCRIPTION
This displays an allDeviations array in pump-loop.log (from meal.json) to help see what UAM is doing and why.

`{"carbs":30,"mealCOB":6,"currentDeviation":6.49,"maxDeviation":10.02,"minDeviation":6.44,"slopeFromMaxDeviation":-1.325,"slopeFromMinDeviation":0.03,"allDeviations":[6.49,6.44,8.02,8.89,10.02,8.46,6.84,7.81]}`