### PR TITLE
remove extra minPredBG in rT object

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -242,7 +242,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         , 'insulinReq': 0
         , 'reservoir' : reservoir_data // The expected reservoir volume at which to deliver the microbolus (the reservoir volume from right before the last pumphistory run)
         , 'deliverAt' : deliverAt // The time at which the microbolus should be delivered
-        , 'minPredBG' : 999
     };
 
     var basaliob = iob_data.basaliob;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -839,7 +839,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rate = round_basal(rate, profile);
         insulinReq = round(insulinReq,3);
         rT.insulinReq = insulinReq;
-        rT.minPredBG = minPredBG;
         //console.error(iob_data.lastBolusTime);
         // minutes since last bolus
         var lastBolusAge = round(( new Date().getTime() - iob_data.lastBolusTime ) / 60000,1);


### PR DESCRIPTION
minPredBG was displayed twice in the suggested.json, once at the top level and once as part of the reason field.  The top-level object was not always updated correctly.  This removes the duplicate.