### PR TITLE
add an enableSMB_always option

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -267,6 +267,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // disable SMB when a high temptarget is set
     if (profile.temptargetSet && target_bg > 100) {
         enableSMB=false;
+    // enable SMB/UAM if always-on (unless previously disabled for high temptarget)
+    } else if (profile.enableSMB_always) {
+        enableSMB=true;
     // enable SMB/UAM (if enabled in preferences) for DIA hours after bolus
     } else if (profile.enableSMB_with_bolus && bolusiob > 0.1) {
         enableSMB=true;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -607,6 +607,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         console.error("minGuardBG",minGuardBG,"projected below",threshold,"- disabling SMB");
         enableSMB = false;
     }
+    if ( glucose_status.delta > 0.1 * bg ) {
+        console.error("Delta",glucose_status.delta,"> 10% of BG",bg,"- disabling SMB");
+        enableSMB = false;
+    }
 
     console.error("BG projected to remain above",min_bg,"for",minutesAboveMinBG,"minutes");
     // include at least minutesAboveMinBG worth of zero temps in calculating carbsReq

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -605,10 +605,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     if (enableSMB && minGuardBG < threshold) {
         console.error("minGuardBG",minGuardBG,"projected below",threshold,"- disabling SMB");
+        //rT.reason += "minGuardBG "+minGuardBG+"<"+threshold+": SMB disabled; ";
         enableSMB = false;
     }
     if ( glucose_status.delta > 0.1 * bg ) {
         console.error("Delta",glucose_status.delta,"> 10% of BG",bg,"- disabling SMB");
+        rT.reason += "Delta "+glucose_status.delta+" > 10% of BG "+bg+": SMB disabled; ";
         enableSMB = false;
     }
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -30,6 +30,7 @@ function defaults ( ) {
     , remainingCarbsCap: 90 // max carbs we'll assume will absorb over 4h if we don't yet see carb absorption
     // WARNING: the following are advanced oref1 features, and are not yet tested for general use
     , enableUAM: false // enable detection of unannounced meal carb absorption
+    , enableSMB_always: false // always enable supermicrobolus (unless disabled by high temptarget)
     , enableSMB_with_bolus: false // enable supermicrobolus for DIA hours after a manual bolus
     , enableSMB_with_COB: false // enable supermicrobolus while COB is positive
     , enableSMB_with_temptarget: false // enable supermicrobolus for eating soon temp targets


### PR DESCRIPTION
We often see non-meal-related rises that benefit from SMB/UAM correction.  For people who have been running SMB long enough to be comfortable running it overnight, this provides an option to enable such corrections 24x7 (except when overridden by a high temp target).  This is *not* recommended for new users, so it will not be exposed in displayedDefaults.