### PR TITLE
use lastCarbAge to calculate remainingCATime

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -309,11 +309,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // if carbs * carbAbsorptionRate > remainingCATimeMin, raise it
         // so <= 90g is assumed to take 3h, and 120g=4h
         remainingCATimeMin = Math.max(remainingCATimeMin, meal_data.carbs/carbAbsorptionRate);
+        var lastCarbAge = round(( new Date().getTime() - meal_data.lastCarbTime ) / 60000);
+        //console.error(meal_data.lastCarbTime, lastCarbAge);
+
         fractionCOBAbsorbed = ( meal_data.carbs - meal_data.mealCOB ) / meal_data.carbs;
-        remainingCATime = remainingCATimeMin*(1-fractionCOBAbsorbed) + remainingCATimeMax*fractionCOBAbsorbed;
+        remainingCATime = remainingCATimeMin + lastCarbAge/60;
         remainingCATime = round(remainingCATime,1);
         //console.error(fractionCOBAbsorbed, remainingCATimeAdjustment, remainingCATime)
-        console.error("Adjusting remainingCATime to",remainingCATime,"h based on",round(fractionCOBAbsorbed*100)+"% carb absorption");
+        console.error("Last carbs",lastCarbAge,"minutes ago; remainingCATime:",remainingCATime,"hours;",round(fractionCOBAbsorbed*100)+"% carbs absorbed");
     }
 
     // calculate the number of carbs absorbed over remainingCATime hours at current CI

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -302,7 +302,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // meal_carbimpact (mg/dL/5m) = CSF (mg/dL/g) * carbs (g) / 6 (h) * (1h/60m) * 5 (m/5m) * 2 (for linear decay)
     //var meal_carbimpact = round((csf * meal_data.carbs / 6 / 60 * 5 * 2),1)
     var remainingCATimeMin = 3; // h; before carb absorption starts
-    var remainingCATimeMax = 6; // h; just before carb absorption ends
     var carbAbsorptionRate = 30; // g/h; maximum rate to assume carbs will absorb if no CI observed
     var remainingCATime;
     if (meal_data.carbs) {

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -11,6 +11,7 @@ function recentCarbs(opts, time) {
     var carbDelay = 20 * 60 * 1000;
     var maxCarbs = 0;
     var mealCarbTime = time.getTime();
+    var lastCarbTime;
     if (!treatments) return {};
 
     //console.error(glucose_data);
@@ -46,6 +47,7 @@ function recentCarbs(opts, time) {
                 //console.error(treatment.carbs, maxCarbs, treatmentDate);
                 carbs += parseFloat(treatment.carbs);
                 COB_inputs.mealTime = treatmentTime;
+                lastCarbTime = treatmentTime;
                 var myCarbsAbsorbed = calcMealCOB(COB_inputs).carbsAbsorbed;
                 var myMealCOB = Math.max(0, carbs - myCarbsAbsorbed);
                 mealCOB = Math.max(mealCOB, myMealCOB);
@@ -92,6 +94,7 @@ function recentCarbs(opts, time) {
     ,   slopeFromMaxDeviation: Math.round( c.slopeFromMaxDeviation * 1000 ) / 1000
     ,   slopeFromMinDeviation: Math.round( c.slopeFromMinDeviation * 1000 ) / 1000
     ,   allDeviations: c.allDeviations
+    ,   lastCarbTime: lastCarbTime
     };
 }
 

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -11,7 +11,7 @@ function recentCarbs(opts, time) {
     var carbDelay = 20 * 60 * 1000;
     var maxCarbs = 0;
     var mealCarbTime = time.getTime();
-    var lastCarbTime;
+    var lastCarbTime = 0;
     if (!treatments) return {};
 
     //console.error(glucose_data);
@@ -47,7 +47,7 @@ function recentCarbs(opts, time) {
                 //console.error(treatment.carbs, maxCarbs, treatmentDate);
                 carbs += parseFloat(treatment.carbs);
                 COB_inputs.mealTime = treatmentTime;
-                lastCarbTime = treatmentTime;
+                lastCarbTime = Math.max(lastCarbTime,treatmentTime);
                 var myCarbsAbsorbed = calcMealCOB(COB_inputs).carbsAbsorbed;
                 var myMealCOB = Math.max(0, carbs - myCarbsAbsorbed);
                 mealCOB = Math.max(mealCOB, myMealCOB);


### PR DESCRIPTION
Using fractionCOBAbsorbed to calculate remainingCATime works well for meals where all the carbs are entered up front, but tends to be too slow to bolus for additional carbs entered later.  This changes the remainingCATime to be calculated based on the remainingCATimeMin (usually 3h) plus the time since the last carb entry, so that when additional carbs are entered, it resets the clock and assumes that they (and any remaining COB) will absorb over 3h.