### PR TITLE
randomize wait_for_silence before smb_verify_reservoir

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -110,7 +110,7 @@ function smb_check_everything {
     && smb_enact_temp \
     && if (grep -q '"units":' enact/smb-suggested.json); then
         ( smb_verify_suggested || smb_suggest ) \
-        && echo -n "Listening for $upto10s silence" && wait_for_silence $upto10s \
+        && echo -n "Listening for $upto10s s silence: " && wait_for_silence $upto10s \
         && smb_verify_reservoir \
         && smb_verify_status \
         || ( echo Retrying SMB checks

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -110,7 +110,7 @@ function smb_check_everything {
     && smb_enact_temp \
     && if (grep -q '"units":' enact/smb-suggested.json); then
         ( smb_verify_suggested || smb_suggest ) \
-        && wait_for_silence 1 \
+        && echo -n "Listening for $upto10s silence" && wait_for_silence $upto10s \
         && smb_verify_reservoir \
         && smb_verify_status \
         || ( echo Retrying SMB checks


### PR DESCRIPTION
I'm still seeing occasional instances where two rigs get all the way through to issuing small SMBs at the exact same time.  (SMBs larger than about 0.2U take too long to be an issue.)  This randomizes the wait_for_silence before smb_verify_reservoir to be $upto10s to try to make sure that other rigs are done talking before we do our reservoir check to see if any other rig has just SMB'd > 0.1U.