### PR TITLE
allow UAM duration to extend to 4h

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -405,8 +405,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // calculate predicted CI from UAM based on slopeFromDeviations
             predUCIslope = Math.max(0, uci + ( UAMpredBGs.length*slopeFromDeviations ) );
             // if slopeFromDeviations is too flat, predicted deviation impact drops linearly from
-            // current deviation down to zero over 3h (data points every 5m)
-            predUCImax = Math.max(0, uci * ( 1 - UAMpredBGs.length/Math.max(3*60/5,1) ) );
+            // current deviation down to zero over 4h (data points every 5m)
+            predUCImax = Math.max(0, uci * ( 1 - UAMpredBGs.length/Math.max(4*60/5,1) ) );
             //console.error(predUCIslope, predUCImax);
             // predicted CI from UAM is the lesser of CI based on deviationSlope or DIA
             predUCI = Math.min(predUCIslope, predUCImax);


### PR DESCRIPTION
In order to limit UAM, we originally had a maximum of 3 hours over which UAM carb impact could be extrapolated.  Now that we're better able to limit UAM duration based on minimum deviation as well as maximum, extending that to 4 hours allows us to do a better job of projecting deviations from high and steady deviations from large meals.  Any increasing or decreasing deviations will still result in UAM durations shorter than 3h in most cases: this will just allow UAM to keep up with COB-based predictions when deviations aren't increasing or decreasing much over 45m.