### PR TITLE
look ahead an additional 15m to get insulin started faster

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -438,15 +438,15 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if ( profile.curve == "ultra-rapid" && !profile.useCustomPeakTime ) {
                 insulinPeakTime = 55;
             }
-            // add 15m to allow for insluin delivery (SMBs or temps)
-            insulinPeakTime += 15;
+            // add 30m to allow for insluin delivery (SMBs or temps)
+            insulinPeakTime += 30;
             var insulinPeak5m = (insulinPeakTime/60)*12;
             //console.error(insulinPeakTime, insulinPeak5m, profile.insulinPeakTime, profile.curve);
 
-            // wait 70-90m before setting minIOBPredBG
+            // wait 80-100 before setting minIOBPredBG
             if ( IOBpredBGs.length > insulinPeak5m && (IOBpredBG < minIOBPredBG) ) { minIOBPredBG = round(IOBpredBG); }
             if ( IOBpredBG > maxIOBPredBG ) { maxIOBPredBG = IOBpredBG; }
-            // wait 70-90m before setting COB and 60m for UAM minPredBGs
+            // wait 85-105m before setting COB and 60m for UAM minPredBGs
             if ( (cid || remainingCIpeak > 0) && COBpredBGs.length > insulinPeak5m && (COBpredBG < minCOBPredBG) ) { minCOBPredBG = round(COBpredBG); }
             if ( (cid || remainingCIpeak > 0) && COBpredBG > maxIOBPredBG ) { maxCOBPredBG = COBpredBG; }
             if ( enableUAM && UAMpredBGs.length > 12 && (UAMpredBG < minUAMPredBG) ) { minUAMPredBG = round(UAMpredBG); }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -315,7 +315,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //console.error(meal_data.lastCarbTime, lastCarbAge);
 
         fractionCOBAbsorbed = ( meal_data.carbs - meal_data.mealCOB ) / meal_data.carbs;
-        remainingCATime = remainingCATimeMin + lastCarbAge/60;
+        remainingCATime = remainingCATimeMin + 1.5 * lastCarbAge/60;
         remainingCATime = round(remainingCATime,1);
         //console.error(fractionCOBAbsorbed, remainingCATimeAdjustment, remainingCATime)
         console.error("Last carbs",lastCarbAge,"minutes ago; remainingCATime:",remainingCATime,"hours;",round(fractionCOBAbsorbed*100)+"% carbs absorbed");


### PR DESCRIPTION
originally we were waiting 90m before setting minPredBGs in order to be sufficiently aggressive at bringing down BGs predicted to ramp up quickly from meals.  When experimenting with shorter remainingCA carb absorption times we shortened the minPredBG lookahead to 55m+15m=70m for Fiasp, leaving rapid-acting insulins at 75m+15m=90m.  This extends that another 15m, to 85m for Fiasp and 105m for RAIs, which will allow eSMB to be more aggressive at mealtimes, as seems to be necessary to accomplish no-bolus (carb guesstimate only) looping with Fiasp with 80% time in range.