### PR TITLE
Exercise mode

### DIFF
--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -148,6 +148,8 @@ function detectSensitivity(inputs) {
         avgDelta = avgDelta.toFixed(2);
         iob_inputs.clock=bgTime;
         iob_inputs.profile.current_basal = basal.basalLookup(basalprofile, bgTime);
+        // make sure autosens doesn't use temptarget-adjusted insulin calculations
+        iob_inputs.profile.temptargetSet = false;
         //console.log(JSON.stringify(iob_inputs.profile));
         //console.error("Before: ", new Date().getTime());
         var iob = get_iob(iob_inputs, true, treatments)[0];

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -94,10 +94,18 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     var sensitivityRatio;
-    if ( profile.high_temptarget_sensitivity && profile.temptargetSet && target_bg > 110 ) {
+    var normalTarget = 100; // evaluate high/low temptarget against 100, not scheduled basal (which might change)
+    if ( profile.half_basal_target ) {
+        var halfBasalTarget = profile.half_basal_target;
+    } else {
+        var halfBasalTarget = 160; // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
+    }
+    if ( profile.high_temptarget_sensitivity && profile.temptargetSet && target_bg > normalTarget + 10 ) {
         // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
         // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
-        sensitivityRatio = 2/(2+(target_bg-100)/40);
+        //sensitivityRatio = 2/(2+(target_bg-normalTarget)/40);
+        var c = halfBasalTarget - normalTarget;
+        sensitivityRatio = c/(c+target_bg-normalTarget);
         sensitivityRatio = round(sensitivityRatio,2);
         process.stderr.write("Sensitivity ratio set to "+sensitivityRatio+" based on temp target of "+target_bg+"; ");
     } else if (typeof autosens_data !== 'undefined' ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -94,7 +94,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     var sensitivityRatio;
-    if (profile.temptargetSet && target_bg > 110) {
+    if ( profile.high_temptarget_sensitivity && profile.temptargetSet && target_bg > 110 ) {
         // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
         // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
         sensitivityRatio = 2/(2+(target_bg-100)/40);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -53,22 +53,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     var deliverAt = new Date();
 
-    if (typeof profile === 'undefined' || typeof profile.current_basal === 'undefined') {
-        rT.error ='Error: could not get current basal rate';
-        return rT;
-    }
-    var profile_current_basal = round_basal(profile.current_basal, profile);
-    var basal = profile_current_basal;
-    if (typeof autosens_data !== 'undefined' ) {
-        basal = profile.current_basal * autosens_data.ratio;
-        basal = round_basal(basal, profile);
-        if (basal != profile_current_basal) {
-            process.stderr.write("Autosens adjusting basal from "+profile_current_basal+" to "+basal+"; ");
-        } else {
-            process.stderr.write("Basal unchanged: "+basal+"; ");
-        }
-    }
-
     var bg = glucose_status.glucose;
     if (bg < 39) {  //Dexcom is in ??? mode or calibrating
         rT.reason = "CGM is calibrating or in ??? state";
@@ -102,10 +86,35 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         return rT;
     }
 
+    if (typeof profile === 'undefined' || typeof profile.current_basal === 'undefined') {
+        rT.error ='Error: could not get current basal rate';
+        return rT;
+    }
+    var profile_current_basal = round_basal(profile.current_basal, profile);
+    var basal = profile_current_basal;
+    if (profile.temptargetSet) {
+        // w/ target 100, temp target 120 = 2/3, 140 = 2/4, 160 = 2/5, and 200 = 2/7
+        sensitivityRatio = 2/(2+(target_bg-100)/20)
+        sensitivityRatio = round(sensitivityRatio,2);
+        process.stderr.write("Sensitivity ratio set to "+sensitivityRatio+" based on temp target of "+target_bg+"; ");
+    } else if (typeof autosens_data !== 'undefined' ) {
+        sensitivityRatio = autosens_data.ratio;
+        process.stderr.write("Autosens ratio: "+sensitivityRatio+"; ");
+    }
+    if (sensitivityRatio) {
+        basal = profile.current_basal * sensitivityRatio;
+        basal = round_basal(basal, profile);
+        if (basal != profile_current_basal) {
+            process.stderr.write("Adjusting basal from "+profile_current_basal+" to "+basal+"; ");
+        } else {
+            process.stderr.write("Basal unchanged: "+basal+"; ");
+        }
+    }
+
     // adjust min, max, and target BG for sensitivity, such that 50% increase in ISF raises target from 100 to 120
     if (typeof autosens_data !== 'undefined' && profile.autosens_adjust_targets) {
       if (profile.temptargetSet) {
-        process.stderr.write("Temp Target set, not adjusting with autosens; ");
+        //process.stderr.write("Temp Target set, not adjusting with autosens; ");
       } else {
         // with a target of 100, default 0.7-1.2 autosens min/max range would allow a 93-117 target range
         min_bg = round((min_bg - 60) / autosens_data.ratio) + 60;
@@ -152,14 +161,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var profile_sens = round(profile.sens,1)
     var sens = profile.sens;
     if (typeof autosens_data !== 'undefined' ) {
-        sens = profile.sens / autosens_data.ratio;
+        sens = profile.sens / sensitivityRatio;
         sens = round(sens, 1);
         if (sens != profile_sens) {
-            process.stderr.write("sens from "+profile_sens+" to "+sens);
+            process.stderr.write("ISF from "+profile_sens+" to "+sens);
         } else {
-            process.stderr.write("sens unchanged: "+sens);
+            process.stderr.write("ISF unchanged: "+sens);
         }
-        process.stderr.write(" (autosens ratio "+autosens_data.ratio+")");
+        //process.stderr.write(" (autosens ratio "+sensitivityRatio+")");
     }
     console.error("");
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -92,9 +92,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
     var profile_current_basal = round_basal(profile.current_basal, profile);
     var basal = profile_current_basal;
-    if (profile.temptargetSet) {
-        // w/ target 100, temp target 120 = 2/3, 140 = 2/4, 160 = 2/5, and 200 = 2/7
-        sensitivityRatio = 2/(2+(target_bg-100)/20)
+    if (profile.temptargetSet && target_bg > 110) {
+        // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
+        // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
+        sensitivityRatio = 2/(2+(target_bg-100)/40);
         sensitivityRatio = round(sensitivityRatio,2);
         process.stderr.write("Sensitivity ratio set to "+sensitivityRatio+" based on temp target of "+target_bg+"; ");
     } else if (typeof autosens_data !== 'undefined' ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -96,11 +96,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var sensitivityRatio;
     var normalTarget = 100; // evaluate high/low temptarget against 100, not scheduled basal (which might change)
     if ( profile.half_basal_target ) {
-        var halfBasalTarget = profile.half_basal_target;
+        var halfBasalTarget = profile.half_basal_exercise_target;
     } else {
         var halfBasalTarget = 160; // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
     }
-    if ( profile.high_temptarget_sensitivity && profile.temptargetSet && target_bg > normalTarget + 10 ) {
+    if ( profile.exercise_mode && profile.temptargetSet && target_bg > normalTarget + 10 ) {
         // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
         // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
         //sensitivityRatio = 2/(2+(target_bg-normalTarget)/40);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -53,6 +53,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     var deliverAt = new Date();
 
+    if (typeof profile === 'undefined' || typeof profile.current_basal === 'undefined') {
+        rT.error ='Error: could not get current basal rate';
+        return rT;
+    }
+    var profile_current_basal = round_basal(profile.current_basal, profile);
+    var basal = profile_current_basal;
+
     var bg = glucose_status.glucose;
     if (bg < 39) {  //Dexcom is in ??? mode or calibrating
         rT.reason = "CGM is calibrating or in ??? state";
@@ -86,12 +93,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         return rT;
     }
 
-    if (typeof profile === 'undefined' || typeof profile.current_basal === 'undefined') {
-        rT.error ='Error: could not get current basal rate';
-        return rT;
-    }
-    var profile_current_basal = round_basal(profile.current_basal, profile);
-    var basal = profile_current_basal;
     var sensitivityRatio;
     if (profile.temptargetSet && target_bg > 110) {
         // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -92,6 +92,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
     var profile_current_basal = round_basal(profile.current_basal, profile);
     var basal = profile_current_basal;
+    var sensitivityRatio;
     if (profile.temptargetSet && target_bg > 110) {
         // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
         // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -692,7 +692,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (eventualBG < min_bg) { // if eventual BG is below target:
         rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " < " + convert_bg(min_bg, profile);
         // if 5m or 30m avg BG is rising faster than expected delta
-        if (minDelta > expectedDelta && minDelta > 0) {
+        if ( minDelta > expectedDelta && minDelta > 0 && !carbsReq ) {
             // if naive_eventualBG < 40, set a 30m zero temp (oref0-pump-loop will let any longer SMB zero temp run)
             if (naive_eventualBG < 40) {
                 rT.reason += ", naive_eventualBG < 40. ";

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -217,9 +217,16 @@ function calcTempTreatments (inputs) {
         if (currentItem.duration > 0) {
 
             var currentRate = profile_data.current_basal;
-
             if (!_.isEmpty(profile_data.basalprofile)) {
                 currentRate = basalprofile.basalLookup(profile_data.basalprofile,new Date(currentItem.timestamp));
+            }
+
+            if (typeof profile_data.min_bg !== 'undefined' && typeof profile_data.max_bg !== 'undefined') {
+                target_bg = (profile_data.min_bg + profile_data.max_bg) / 2;
+            }
+            if (profile_data.temptargetSet && target_bg > 110) {
+                sensitivityRatio = 2/(2+(target_bg-100)/40);
+                currentRate = profile_data.current_basal * sensitivityRatio;
             }
 
             var netBasalRate = currentItem.rate - currentRate;

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -232,11 +232,11 @@ function calcTempTreatments (inputs) {
             var profile = profile_data;
             var normalTarget = 100; // evaluate high/low temptarget against 100, not scheduled basal (which might change)
             if ( profile.half_basal_target ) {
-                var halfBasalTarget = profile.half_basal_target;
+                var halfBasalTarget = profile.half_basal_exercise_target;
             } else {
                 var halfBasalTarget = 160; // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
             }
-            if ( profile.high_temptarget_sensitivity && profile.temptargetSet && target_bg > normalTarget + 10 ) {
+            if ( profile.exercise_mode && profile.temptargetSet && target_bg > normalTarget + 10 ) {
                 // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
                 // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
                 var c = halfBasalTarget - normalTarget;

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -224,9 +224,27 @@ function calcTempTreatments (inputs) {
             if (typeof profile_data.min_bg !== 'undefined' && typeof profile_data.max_bg !== 'undefined') {
                 target_bg = (profile_data.min_bg + profile_data.max_bg) / 2;
             }
-            if (profile_data.temptargetSet && target_bg > 110) {
-                sensitivityRatio = 2/(2+(target_bg-100)/40);
-                currentRate = profile_data.current_basal * sensitivityRatio;
+            //if (profile_data.temptargetSet && target_bg > 110) {
+                //sensitivityRatio = 2/(2+(target_bg-100)/40);
+                //currentRate = profile_data.current_basal * sensitivityRatio;
+            //}
+            var sensitivityRatio;
+            var profile = profile_data;
+            var normalTarget = 100; // evaluate high/low temptarget against 100, not scheduled basal (which might change)
+            if ( profile.half_basal_target ) {
+                var halfBasalTarget = profile.half_basal_target;
+            } else {
+                var halfBasalTarget = 160; // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
+            }
+            if ( profile.high_temptarget_sensitivity && profile.temptargetSet && target_bg > normalTarget + 10 ) {
+                // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
+                // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
+                var c = halfBasalTarget - normalTarget;
+                sensitivityRatio = c/(c+target_bg-normalTarget);
+                sensitivityRatio = round(sensitivityRatio,2);
+            //} else if (typeof autosens_data !== 'undefined' ) {
+                //sensitivityRatio = autosens_data.ratio;
+                //process.stderr.write("Autosens ratio: "+sensitivityRatio+"; ");
             }
 
             var netBasalRate = currentItem.rate - currentRate;

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -241,10 +241,12 @@ function calcTempTreatments (inputs) {
                 // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
                 var c = halfBasalTarget - normalTarget;
                 sensitivityRatio = c/(c+target_bg-normalTarget);
-                sensitivityRatio = round(sensitivityRatio,2);
             //} else if (typeof autosens_data !== 'undefined' ) {
                 //sensitivityRatio = autosens_data.ratio;
                 //process.stderr.write("Autosens ratio: "+sensitivityRatio+"; ");
+            }
+            if ( sensitivityRatio ) {
+                currentRate = profile_data.current_basal * sensitivityRatio;
             }
 
             var netBasalRate = currentItem.rate - currentRate;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -17,6 +17,7 @@ function defaults ( ) {
     , adv_target_adjustments: true // lower target automatically when BG and eventualBG are high
     // TODO: figure out what we want to call this and whether to change it to false at first
     , high_temptarget_sensitivity: true // > 110 mg/dL target adjusts sensitivityRatio for exercise mode
+    , half_basal_target: 160 // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.
     // Essentially, this just limits AMA as a safety cap against weird COB calculations)

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -15,8 +15,7 @@ function defaults ( ) {
     , rewind_resets_autosens: true // reset autosensitivity to neutral for awhile after each pump rewind
     , autosens_adjust_targets: true // when autosens detects sensitivity/resistance, also adjust BG target accordingly
     , adv_target_adjustments: true // lower target automatically when BG and eventualBG are high
-    // TODO: figure out what we want to call this and whether to change it to false at first
-    , exercise_mode: true // when true, > 110 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before.
+    , exercise_mode: false // when true, > 110 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before.
     , half_basal_exercise_target: 160 // when temptarget is 160 mg/dL *and* exercise_mode=true, run 50% basal at this level (120 = 75%; 140 = 60%)
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.
@@ -58,7 +57,7 @@ function displayedDefaults () {
     profile.autosens_min = allDefaults.autosens_min;
     profile.rewind_resets_autosens = allDefaults.rewind_resets_autosens;
     profile.adv_target_adjustments = allDefaults.adv_target_adjustments;
-    profile.high_temptarget_sensitivity = allDefaults.high_temptarget_sensitivity;
+    profile.exercise_mode = allDefaults.exercise_mode;
     profile.unsuspend_if_no_temp = allDefaults.unsuspend_if_no_temp;
     profile.enableSMB_with_bolus = allDefaults.enableSMB_with_bolus;
     profile.enableSMB_with_COB = allDefaults.enableSMB_with_COB;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -15,6 +15,8 @@ function defaults ( ) {
     , rewind_resets_autosens: true // reset autosensitivity to neutral for awhile after each pump rewind
     , autosens_adjust_targets: true // when autosens detects sensitivity/resistance, also adjust BG target accordingly
     , adv_target_adjustments: true // lower target automatically when BG and eventualBG are high
+    // TODO: figure out what we want to call this and whether to change it to false at first
+    , high_temptarget_sensitivity: true // > 110 mg/dL target adjusts sensitivityRatio for exercise mode
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.
     // Essentially, this just limits AMA as a safety cap against weird COB calculations)
@@ -55,6 +57,7 @@ function displayedDefaults () {
     profile.autosens_min = allDefaults.autosens_min;
     profile.rewind_resets_autosens = allDefaults.rewind_resets_autosens;
     profile.adv_target_adjustments = allDefaults.adv_target_adjustments;
+    profile.high_temptarget_sensitivity = allDefaults.high_temptarget_sensitivity;
     profile.unsuspend_if_no_temp = allDefaults.unsuspend_if_no_temp;
     profile.enableSMB_with_bolus = allDefaults.enableSMB_with_bolus;
     profile.enableSMB_with_COB = allDefaults.enableSMB_with_COB;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -16,8 +16,8 @@ function defaults ( ) {
     , autosens_adjust_targets: true // when autosens detects sensitivity/resistance, also adjust BG target accordingly
     , adv_target_adjustments: true // lower target automatically when BG and eventualBG are high
     // TODO: figure out what we want to call this and whether to change it to false at first
-    , high_temptarget_sensitivity: true // > 110 mg/dL target adjusts sensitivityRatio for exercise mode
-    , half_basal_target: 160 // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
+    , exercise_mode: true // when true, > 110 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before.
+    , half_basal_exercise_target: 160 // when temptarget is 160 mg/dL *and* exercise_mode=true, run 50% basal at this level (120 = 75%; 140 = 60%)
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.
     // Essentially, this just limits AMA as a safety cap against weird COB calculations)


### PR DESCRIPTION
As described in https://github.com/openaps/oref0/issues/588 and https://github.com/LoopKit/Loop/issues/593, OpenAPS activity mode doesn't do enough (at reasonably low temp target levels) to handle extended aerobic exercise, and often overshoots if you set the temp target high enough to do so.  This implements a better approach, which uses the level of the temptarget to set a manual sensitivityRatio.  This is used the same way as the autosens ratio, to set the basal and ISF used for current decisions.  In addition, it also is used to set the basal used by IOB calculations, such that setting an activity mode raises OpenAPS' estimate of IOB, and causes it to zero temp long enough to get IOB down to a level more suitable for aerobic activity.

These extra adjustments kick in for temp targets > 110 mg/dL, and scale up as the target increases.  Some testing will be required to see if the formula used for scaling that up is appropriate or if it needs adjusting to better balance the basal and ISF adjustments against the actual BG target people want to run at during such exercise.