### PR TITLE
Eliminate basal vs. bolus distinctions

### DIFF
--- a/bin/oref0-html.js
+++ b/bin/oref0-html.js
@@ -135,7 +135,7 @@ if (!module.parent) {
 
 //console.log("<!-- ");
 console.log( bgnow + requestedtemp.tick + " " + bgTime + ", "
-    + iob + "U -> " + requestedtemp.eventualBG + "-" + requestedtemp.snoozeBG + ", "
+    + iob + "U -> " + requestedtemp.eventualBG + ", "
     + tempstring + "U/hr @ " + temp_time
     + " " + reqtempstring
     + ", " + requestedtemp.reason + ", "
@@ -157,7 +157,7 @@ console.log("<body>");
         console.log("<h1>");
         console.log( bgnow + " " + tick + " at " + bgTime );
         console.log("<br>");
-        console.log( "IOB: " + iob + "U, eventually " + requestedtemp.eventualBG + "-" + requestedtemp.snoozeBG + " mg/dL" );
+        console.log( "IOB: " + iob + "U, eventually " + requestedtemp.eventualBG + " mg/dL" );
         console.log("<br>");
         //+ "Act: " + enactedstring
         //+ " at " + enactedat + "\n"

--- a/bin/oref0-pebble.js
+++ b/bin/oref0-pebble.js
@@ -143,7 +143,8 @@ if (!module.parent) {
 
     var pebble = {        
         "content" : "" + bgnow + requestedtemp.tick + " " + bgTime + "\n"
-        + iob + "U->" + requestedtemp.eventualBG + "-" + requestedtemp.snoozeBG + "\n"
+        //+ iob + "U->" + requestedtemp.eventualBG + "-" + requestedtemp.snoozeBG + "\n"
+        + iob + "U->" + requestedtemp.eventualBG + "\n"
         //+ "Act: " + enactedstring
         //+ " at " + enactedat + "\n"
         + tempstring

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -78,10 +78,10 @@ case $i in
     current_basal_safety_multiplier="${i#*=}"
     shift # past argument=value
     ;;
-    -bdd=*|--bolussnooze_dia_divisor=*)
-    bolussnooze_dia_divisor="${i#*=}"
-    shift # past argument=value
-    ;;
+    #-bdd=*|--bolussnooze_dia_divisor=*)
+    #bolussnooze_dia_divisor="${i#*=}"
+    #shift # past argument=value
+    #;;
     -m5c=*|--min_5m_carbimpact=*)
     min_5m_carbimpact="${i#*=}"
     shift # past argument=value
@@ -425,9 +425,9 @@ fi
 if [[ ! -z "$current_basal_safety_multiplier" ]]; then
     echo -n ", current_basal_safety_multiplier $current_basal_safety_multiplier";
 fi
-if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
-    echo -n ", bolussnooze_dia_divisor $bolussnooze_dia_divisor";
-fi
+#if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
+    #echo -n ", bolussnooze_dia_divisor $bolussnooze_dia_divisor";
+#fi
 if [[ ! -z "$min_5m_carbimpact" ]]; then
     echo -n ", min_5m_carbimpact $min_5m_carbimpact";
 fi
@@ -462,9 +462,9 @@ fi
 if [[ ! -z "$current_basal_safety_multiplier" ]]; then
     echo -n " --current_basal_safety_multiplier=$current_basal_safety_multiplier" | tee -a $OREF0_RUNAGAIN
 fi
-if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
-    echo -n " --bolussnooze_dia_divisor=$bolussnooze_dia_divisor" | tee -a $OREF0_RUNAGAIN
-fi
+#if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
+    #echo -n " --bolussnooze_dia_divisor=$bolussnooze_dia_divisor" | tee -a $OREF0_RUNAGAIN
+#fi
 if [[ ! -z "$min_5m_carbimpact" ]]; then
     echo -n " --min_5m_carbimpact=$min_5m_carbimpact" | tee -a $OREF0_RUNAGAIN
 fi
@@ -576,7 +576,8 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 #fi
 
     cd $directory || die "Can't cd $directory"
-    if [[ "$max_iob" == "0" && -z "$max_daily_safety_multiplier" && -z "$current_basal_safety_multiplier" && -z "$bolussnooze_dia_divisor" && -z "$min_5m_carbimpact" ]]; then
+    #if [[ "$max_iob" == "0" && -z "$max_daily_safety_multiplier" && -z "$current_basal_safety_multiplier" && -z "$bolussnooze_dia_divisor" && -z "$min_5m_carbimpact" ]]; then
+    if [[ "$max_iob" == "0" && -z "$max_daily_safety_multiplier" && -z "$current_basal_safety_multiplier" && -z "$min_5m_carbimpact" ]]; then
         oref0-get-profile --exportDefaults > preferences.json || die "Could not run oref0-get-profile"
     else
         preferences_from_args=()
@@ -589,9 +590,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [[ ! -z "$current_basal_safety_multiplier" ]]; then
             preferences_from_args+="\"current_basal_safety_multiplier\":$current_basal_safety_multiplier "
         fi
-        if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
-            preferences_from_args+="\"bolussnooze_dia_divisor\":$bolussnooze_dia_divisor "
-        fi
+        #if [[ ! -z "$bolussnooze_dia_divisor" ]]; then
+            #preferences_from_args+="\"bolussnooze_dia_divisor\":$bolussnooze_dia_divisor "
+        #fi
         if [[ ! -z "$min_5m_carbimpact" ]]; then
             preferences_from_args+="\"min_5m_carbimpact\":$min_5m_carbimpact "
         fi

--- a/bin/peb-urchin-status.sh
+++ b/bin/peb-urchin-status.sh
@@ -10,10 +10,10 @@ if [[ $(jq .urchin_loop_status pancreoptions.json) = "true" ]]; then
 	echo {"\"message\": "\"loop status at "'$(date +%-I:%M%P)'": Running\"} > upload/urchin-status.json
 fi 
 if [[ $(jq .urchin_iob pancreoptions.json) = "true" ]]; then
-   echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json) - BasalIOB: $(jq .openaps.iob.basaliob upload/ns-status.json)\"} > upload/urchin-status.json
+   echo {"\"message\": "\""$(date +%R)": IOB: $(jq .openaps.iob.iob upload/ns-status.json)\"} > upload/urchin-status.json
 fi
 if [[ $(jq .urchin_temp_rate pancreoptions.json) = "true" ]]; then
-   echo {"\"message\": "\""$(date +%-I:%M%P)": Basel: $(jq .rate monitor/temp_basal.json) U/hr for $(jq .duration monitor/temp_basal.json) mins\"} > upload/urchin-status.json
+   echo {"\"message\": "\""$(date +%-I:%M%P)": Basal: $(jq .rate monitor/temp_basal.json) U/hr for $(jq .duration monitor/temp_basal.json) mins\"} > upload/urchin-status.json
 fi
 
 #Notification Status

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -777,20 +777,20 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
         }
     }
-    // eventualBG, snoozeBG, or minPredBG is below max_bg
-    //if (Math.min(eventualBG,snoozeBG,minPredBG) < max_bg) {
+    // eventualBG or minPredBG is below max_bg
+    if (Math.min(eventualBG,minPredBG) < max_bg) {
         // if in SMB mode, don't cancel SMB zero temp
-        //if (! (microBolusAllowed && enableSMB )) {
-            //rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(Math.min(minPredBG,snoozeBG), profile)+" in range: bolus snooze, no temp required";
-            //if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                //rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
-                //return rT;
-            //} else {
-                //rT.reason += "; setting current basal of " + basal + " as temp. ";
-                //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-            //}
-        //}
-    //}
+        if (! (microBolusAllowed && enableSMB )) {
+            rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(minPredBG, profile)+" in range: bolus snooze, no temp required";
+            if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
+                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
+                return rT;
+            } else {
+                rT.reason += "; setting current basal of " + basal + " as temp. ";
+                return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+            }
+        }
+    }
 
     // eventual BG is at/above target (or bolus snooze disabled for SMB)
     // if iob is over max, just cancel any temps

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -792,7 +792,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (Math.min(eventualBG,minPredBG) < max_bg) {
         // if in SMB mode, don't cancel SMB zero temp
         if (! (microBolusAllowed && enableSMB )) {
-            rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(minPredBG, profile)+" in range: bolus snooze, no temp required";
+            rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(minPredBG, profile)+" in range: no temp required";
             if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
                 rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
                 return rT;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -244,11 +244,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         , 'deliverAt' : deliverAt // The time at which the microbolus should be delivered
     };
 
-    var basaliob = iob_data.basaliob;
-    //if (iob_data.basaliob) { basaliob = iob_data.basaliob; }
-    //else { basaliob = iob_data.iob - iob_data.bolussnooze; }
-    var bolusiob = iob_data.iob - basaliob;
-
     // generate predicted future BGs based on IOB, COB, and current absorption rate
 
     var COBpredBGs = [];
@@ -267,7 +262,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (profile.temptargetSet && target_bg > 100) {
         enableSMB=false;
     // enable SMB/UAM (if enabled in preferences) for DIA hours after bolus
-    } else if (profile.enableSMB_with_bolus && bolusiob > 0.1) {
+    } else if (profile.enableSMB_always) {
         enableSMB=true;
     // enable SMB/UAM (if enabled in preferences) while we have COB
     } else if (profile.enableSMB_with_COB && meal_data.mealCOB) {
@@ -280,8 +275,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else if (profile.enableSMB_after_carbs && meal_data.carbs) {
         enableSMB=true;
     }
-    // enable UAM (if enabled in preferences) for DIA hours after bolus, or if SMB is enabled
-    var enableUAM=(profile.enableUAM && (bolusiob > 0.1 || enableSMB));
+    // enable UAM (if enabled in preferences) if SMB is enabled
+    var enableUAM=(profile.enableUAM && enableSMB);
 
 
     //console.error(meal_data);
@@ -798,8 +793,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     // eventual BG is at/above target (or bolus snooze disabled for SMB)
     // if iob is over max, just cancel any temps
-    if (iob_data.basaliob) { basaliob = iob_data.basaliob; }
-    else { basaliob = iob_data.iob - iob_data.bolussnooze; }
     // if we're not here because of SMB, eventual BG is at/above target
     if (! (microBolusAllowed && rT.COB)) {
         rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " >= " +  convert_bg(max_bg, profile) + ", ";

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -185,11 +185,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // and adjust it for the deviation above
     var eventualBG = naive_eventualBG + deviation;
     // calculate what portion of that is due to bolussnooze
-    var bolusContrib = iob_data.bolussnooze * sens;
+    //var bolusContrib = iob_data.bolussnooze * sens;
     // and add it back in to get snoozeBG, plus another 50% to avoid low-temping at mealtime
-    var naive_snoozeBG = round( naive_eventualBG + 1.5 * bolusContrib );
+    //var naive_snoozeBG = round( naive_eventualBG + 1.5 * bolusContrib );
     // adjust that for deviation like we did eventualBG
-    var snoozeBG = naive_snoozeBG + deviation;
+    //var snoozeBG = naive_snoozeBG + deviation;
 
     // adjust target BG range if needed to safely bring down high BG faster without causing lows
     if ( bg > max_bg && profile.adv_target_adjustments && ! profile.temptargetSet ) {
@@ -238,7 +238,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         , 'bg': bg
         , 'tick': tick
         , 'eventualBG': eventualBG
-        , 'snoozeBG': snoozeBG
+        //, 'snoozeBG': snoozeBG
         , 'insulinReq': 0
         , 'reservoir' : reservoir_data // The expected reservoir volume at which to deliver the microbolus (the reservoir volume from right before the last pumphistory run)
         , 'deliverAt' : deliverAt // The time at which the microbolus should be delivered
@@ -574,10 +574,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         minPredBG = Math.min(minPredBG, maxCOBPredBG);
     }
     // set snoozeBG to minPredBG if it's higher
-    if (minPredBG < 999) {
-        snoozeBG = round(Math.max(snoozeBG,minPredBG));
-    }
-    rT.snoozeBG = snoozeBG;
+    //if (minPredBG < 999) {
+        //snoozeBG = round(Math.max(snoozeBG,minPredBG));
+    //}
+    //rT.snoozeBG = snoozeBG;
     //console.error(minPredBG, minIOBPredBG, minUAMPredBG, minCOBPredBG, maxCOBPredBG, snoozeBG);
 
     rT.COB=meal_data.mealCOB;
@@ -687,31 +687,32 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
 
         // if we've bolused recently, we can snooze until the bolus IOB decays (at double speed)
-        if (snoozeBG > min_bg) { // if adding back in the bolus contribution BG would be above min
+        //if (snoozeBG > min_bg) { // if adding back in the bolus contribution BG would be above min
             // If we're not in SMB mode with COB, or lastCOBpredBG > target_bg, bolus snooze
-            if (! (microBolusAllowed && rT.COB) || lastCOBpredBG > target_bg) {
-                rT.reason += ", bolus snooze: eventual BG range " + convert_bg(eventualBG, profile) + "-" + convert_bg(snoozeBG, profile);
+            //if (! (microBolusAllowed && rT.COB) || lastCOBpredBG > target_bg) {
+                //rT.reason += ", bolus snooze: eventual BG range " + convert_bg(eventualBG, profile) + "-" + convert_bg(snoozeBG, profile);
                 //console.error(currenttemp, basal );
-                if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                    rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
-                    return rT;
-                } else {
-                    rT.reason += "; setting current basal of " + basal + " as temp. ";
-                    return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-                }
-            }
-        } else {
+                //if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
+                    //rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
+                    //return rT;
+                //} else {
+                    //rT.reason += "; setting current basal of " + basal + " as temp. ";
+                    //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+                //}
+            //}
+        //} else {
             // calculate 30m low-temp required to get projected BG up to target
             // use snoozeBG to more gradually ramp in any counteraction of the user's boluses
             // multiply by 2 to low-temp faster for increased hypo safety
-            var insulinReq = 2 * Math.min(0, (snoozeBG - target_bg) / sens);
+            //var insulinReq = 2 * Math.min(0, (snoozeBG - target_bg) / sens);
+            var insulinReq = 2 * Math.min(0, (eventualBG - target_bg) / sens);
             insulinReq = round( insulinReq , 2);
             // calculate naiveInsulinReq based on naive_eventualBG
             var naiveInsulinReq = Math.min(0, (naive_eventualBG - target_bg) / sens);
             naiveInsulinReq = round( naiveInsulinReq , 2);
             if (minDelta < 0 && minDelta > expectedDelta) {
                 // if we're barely falling, newinsulinReq should be barely negative
-                rT.reason += ", Snooze BG " + convert_bg(snoozeBG, profile);
+                //rT.reason += ", Snooze BG " + convert_bg(snoozeBG, profile);
                 var newinsulinReq = round(( insulinReq * (minDelta / expectedDelta) ), 2);
                 //console.error("Increasing insulinReq from " + insulinReq + " to " + newinsulinReq);
                 insulinReq = newinsulinReq;
@@ -755,7 +756,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 }
                 return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
             }
-        }
+        //}
     }
   
     // if eventual BG is above min but BG is falling faster than expected Delta
@@ -777,19 +778,19 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
     // eventualBG, snoozeBG, or minPredBG is below max_bg
-    if (Math.min(eventualBG,snoozeBG,minPredBG) < max_bg) {
+    //if (Math.min(eventualBG,snoozeBG,minPredBG) < max_bg) {
         // if in SMB mode, don't cancel SMB zero temp
-        if (! (microBolusAllowed && enableSMB )) {
-            rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(Math.min(minPredBG,snoozeBG), profile)+" in range: bolus snooze, no temp required";
-            if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
-                return rT;
-            } else {
-                rT.reason += "; setting current basal of " + basal + " as temp. ";
-                return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-            }
-        }
-    }
+        //if (! (microBolusAllowed && enableSMB )) {
+            //rT.reason += convert_bg(eventualBG, profile)+"-"+convert_bg(Math.min(minPredBG,snoozeBG), profile)+" in range: bolus snooze, no temp required";
+            //if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
+                //rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
+                //return rT;
+            //} else {
+                //rT.reason += "; setting current basal of " + basal + " as temp. ";
+                //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+            //}
+        //}
+    //}
 
     // eventual BG is at/above target (or bolus snooze disabled for SMB)
     // if iob is over max, just cancel any temps
@@ -810,7 +811,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
         // insulinReq is the additional insulin required to get minPredBG down to target_bg
         //console.error(minPredBG,snoozeBG,eventualBG);
-        var insulinReq = round( (Math.min(minPredBG,snoozeBG,eventualBG) - target_bg) / sens, 2);
+        //var insulinReq = round( (Math.min(minPredBG,snoozeBG,eventualBG) - target_bg) / sens, 2);
+        var insulinReq = round( (Math.min(minPredBG,eventualBG) - target_bg) / sens, 2);
         // when dropping, but not as fast as expected, reduce insulinReq proportionally
         // to the what fraction of expectedDelta we're dropping at
         if (minDelta < 0 && minDelta > expectedDelta) {
@@ -858,9 +860,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
 
             // if no microBolus required, snoozeBG > target_bg, and lastCOBpredBG > target_bg, don't set a zero temp
-            if (microBolus < 0.1 && snoozeBG > target_bg && lastCOBpredBG > target_bg) {
-                durationReq = 0;
-            }
+            //if (microBolus < 0.1 && snoozeBG > target_bg && lastCOBpredBG > target_bg) {
+                //durationReq = 0;
+            //}
 
             var smbLowTempReq = 0;
             if (durationReq <= 0) {
@@ -905,10 +907,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
 
             // if insulinReq is negative, snoozeBG > target_bg, and lastCOBpredBG > target_bg, set a neutral temp
-            if (insulinReq < 0 && snoozeBG > target_bg && lastCOBpredBG > target_bg) {
-                rT.reason += "; SMB bolus snooze: setting current basal of " + basal + " as temp. ";
-                return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-            }
+            //if (insulinReq < 0 && snoozeBG > target_bg && lastCOBpredBG > target_bg) {
+                //rT.reason += "; SMB bolus snooze: setting current basal of " + basal + " as temp. ";
+                //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+            //}
         }
 
         var maxSafeBasal = tempBasalFunctions.getMaxSafeBasal(profile);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -734,7 +734,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 return rT;
             } else {
                 // calculate a long enough zero temp to eventually correct back up to target
-                if ( rate < 0 ) {
+                if ( rate <=0 ) {
                     var bgUndershoot = target_bg - naive_eventualBG;
                     var worstCaseInsulinReq = bgUndershoot / sens;
                     var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);

--- a/lib/iob/calculate.js
+++ b/lib/iob/calculate.js
@@ -137,8 +137,8 @@ function iobCalc(treatment, time, dia, profile) {
         activityContrib = treatment.insulin * (S / Math.pow(tau, 2)) * t * (1 - t / td) * Math.exp(-t / tau);
         iobContrib = treatment.insulin * (1 - S * (1 - a) * ((Math.pow(t, 2) / (tau * td * (1 - a)) - t / tau - 1) * Math.exp(-t / tau) + 1));
         // calculate bolus snooze insulin in the same pass
-        t = t * profile.bolussnooze_dia_divisor;
-        biobContrib = treatment.insulin * (1 - S * (1 - a) * ((Math.pow(t, 2) / (tau * td * (1 - a)) - t / tau - 1) * Math.exp(-t / tau) + 1));
+        //t = t * profile.bolussnooze_dia_divisor;
+        //biobContrib = treatment.insulin * (1 - S * (1 - a) * ((Math.pow(t, 2) / (tau * td * (1 - a)) - t / tau - 1) * Math.exp(-t / tau) + 1));
 
         //console.error('DIA: ' + dia + ' t: ' + t + ' td: ' + td + ' tp: ' + tp + ' tau: ' + tau + ' a: ' + a + ' S: ' + S + ' activityContrib: ' + activityContrib + ' iobContrib: ' + iobContrib);
 
@@ -147,7 +147,7 @@ function iobCalc(treatment, time, dia, profile) {
     results = {
         iobContrib: iobContrib,
         activityContrib: activityContrib,
-        biobContrib: biobContrib
+        //biobContrib: biobContrib
     };
 
     return results;

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -5,6 +5,10 @@ function iobTotal(opts, time) {
     var treatments = opts.treatments;
     var profile_data = opts.profile;
     var iob = 0;
+    var basaliob = 0;
+    var bolusiob = 0;
+    var netbasalinsulin = 0;
+    var bolusinsulin = 0;
     //var bolussnooze = 0;
     var activity = 0;
     if (!treatments) return {};
@@ -13,7 +17,7 @@ function iobTotal(opts, time) {
     //}
 
     treatments.forEach(function(treatment) {
-        if(treatment.date <= time.getTime( )) {
+        if( treatment.date <= now ) {
             var dia = profile_data.dia;
             // force minimum DIA of 3h
             if (dia < 3) {
@@ -21,33 +25,26 @@ function iobTotal(opts, time) {
                 dia = 3;
             }
             var dia_ago = now - profile_data.dia*60*60*1000;
-            // tIOB = total IOB
-            var tIOB = iobCalc(treatment, time, dia, profile_data);
-            if (tIOB && tIOB.iobContrib) iob += tIOB.iobContrib;
-            if (tIOB && tIOB.activityContrib) activity += tIOB.activityContrib;
-            // for purposes of categorizing boluses as SMBs to add to basalIOB, use max_daily_basal
-            if (typeof profile_data.maxSMBBasalMinutes == 'undefined' ) {
-                var maxSMB = profile_data.max_daily_basal * 30 / 60;
-                //console.error("profile.maxSMBBasalMinutes undefined: defaulting to 30m");
-            } else {
-                var maxSMB = profile_data.max_daily_basal * 60 / profile_data.maxSMBBasalMinutes;
-            }
-            // keep track of bolus IOB separately for snoozes, but decay it twice as fast
-            // only snooze for boluses that deliver more than maxSMBBasalMinutes m worth of basal (excludes SMBs)
-            if (treatment.insulin > maxSMB && treatment.started_at) {
-                //default bolussnooze_dia_divisor is 2, for 2x speed bolus snooze
-                // bIOB = bolus IOB
-                if (tIOB.biobContrib !== undefined) {
-                    //bolussnooze += tIOB.biobContrib;
-                } else {
-                    //var bIOB = iobCalc(treatment, time, dia / profile_data.bolussnooze_dia_divisor, profile_data);
-                    //console.log(treatment);
-                    //console.log(bIOB);
-                    //if (bIOB && bIOB.iobContrib) bolussnooze += bIOB.iobContrib;
+            if( treatment.date > dia_ago ) {
+                // tIOB = total IOB
+                var tIOB = iobCalc(treatment, time, dia, profile_data);
+                if (tIOB && tIOB.iobContrib) { iob += tIOB.iobContrib; }
+                if (tIOB && tIOB.activityContrib) { activity += tIOB.activityContrib; }
+                // basals look like either of these:
+                // {"insulin":-0.05,"date":1507265512363.6365,"created_at":"2017-10-06T04:51:52.363Z"}
+                // {"insulin":0.05,"date":1507266530000,"created_at":"2017-10-06T05:08:50.000Z"}
+                // boluses look like:
+                // {"timestamp":"2017-10-05T22:06:31-07:00","started_at":"2017-10-06T05:06:31.000Z","date":1507266391000,"insulin":0.5}
+                if (treatment.insulin && tIOB && tIOB.iobContrib) {
+                    if (treatment.insulin < 0.1) {
+                        basaliob += tIOB.iobContrib;
+                        netbasalinsulin += treatment.insulin;
+                    } else {
+                        bolusiob += tIOB.iobContrib;
+                        bolusinsulin += treatment.insulin;
+                    }
                 }
-            } else {
-                // aIOB = basal IOB
-                var aIOB = tIOB; // iobCalc(treatment, time, dia, profile_data);
+                //console.error(JSON.stringify(treatment));
             }
         }
     });
@@ -55,7 +52,10 @@ function iobTotal(opts, time) {
     var rval = {
         iob: Math.round(iob * 1000) / 1000,
         activity: Math.round(activity * 10000) / 10000,
-        //bolussnooze: Math.round(bolussnooze * 1000) / 1000,
+        basaliob: Math.round(basaliob * 1000) / 1000,
+        bolusiob: Math.round(bolusiob * 1000) / 1000,
+        netbasalinsulin: Math.round(netbasalinsulin * 1000) / 1000,
+        bolusinsulin: Math.round(bolusinsulin * 1000) / 1000,
         time: time
     };
 

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -8,7 +8,6 @@ function iobTotal(opts, time) {
     //var bolussnooze = 0;
     var activity = 0;
     var netbasalinsulin = 0;
-    var hightempinsulin = 0;
     var microBolusInsulin = 0;
     var microBolusIOB = 0;
     if (!treatments) return {};
@@ -50,7 +49,7 @@ function iobTotal(opts, time) {
                     //if (bIOB && bIOB.iobContrib) bolussnooze += bIOB.iobContrib;
                 }
             } else {
-                // track microBolus IOB, but also count it toward hightempinsulin
+                // track microBolus IOB
                 if (treatment.insulin <= maxSMB && treatment.started_at) {
                     if(treatment.date > dia_ago && treatment.date <= now) {
                         microBolusInsulin += treatment.insulin;
@@ -64,9 +63,6 @@ function iobTotal(opts, time) {
                 if (treatment.insulin) {
                     if(treatment.date > dia_ago && treatment.date <= now) {
                         netbasalinsulin += treatment.insulin;
-                        if (treatment.insulin > 0) {
-                            hightempinsulin += treatment.insulin;
-                        }
                     }
                 }
             }
@@ -78,7 +74,6 @@ function iobTotal(opts, time) {
         activity: Math.round(activity * 10000) / 10000,
         //bolussnooze: Math.round(bolussnooze * 1000) / 1000,
         netbasalinsulin: Math.round(netbasalinsulin * 1000) / 1000,
-        hightempinsulin: Math.round(hightempinsulin * 1000) / 1000,
         microBolusInsulin: Math.round(microBolusInsulin * 1000) / 1000,
         microBolusIOB: Math.round(microBolusIOB * 1000) / 1000,
         time: time

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -7,7 +7,6 @@ function iobTotal(opts, time) {
     var iob = 0;
     //var bolussnooze = 0;
     var activity = 0;
-    var netbasalinsulin = 0;
     var microBolusInsulin = 0;
     var microBolusIOB = 0;
     if (!treatments) return {};
@@ -60,11 +59,6 @@ function iobTotal(opts, time) {
                 }
                 // aIOB = basal IOB
                 var aIOB = tIOB; // iobCalc(treatment, time, dia, profile_data);
-                if (treatment.insulin) {
-                    if(treatment.date > dia_ago && treatment.date <= now) {
-                        netbasalinsulin += treatment.insulin;
-                    }
-                }
             }
         }
     });
@@ -73,7 +67,6 @@ function iobTotal(opts, time) {
         iob: Math.round(iob * 1000) / 1000,
         activity: Math.round(activity * 10000) / 10000,
         //bolussnooze: Math.round(bolussnooze * 1000) / 1000,
-        netbasalinsulin: Math.round(netbasalinsulin * 1000) / 1000,
         microBolusInsulin: Math.round(microBolusInsulin * 1000) / 1000,
         microBolusIOB: Math.round(microBolusIOB * 1000) / 1000,
         time: time

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -5,7 +5,7 @@ function iobTotal(opts, time) {
     var treatments = opts.treatments;
     var profile_data = opts.profile;
     var iob = 0;
-    var bolussnooze = 0;
+    //var bolussnooze = 0;
     var activity = 0;
     var netbasalinsulin = 0;
     var hightempinsulin = 0;
@@ -42,12 +42,12 @@ function iobTotal(opts, time) {
                 //default bolussnooze_dia_divisor is 2, for 2x speed bolus snooze
                 // bIOB = bolus IOB
                 if (tIOB.biobContrib !== undefined) {
-                    bolussnooze += tIOB.biobContrib;
+                    //bolussnooze += tIOB.biobContrib;
                 } else {
-                    var bIOB = iobCalc(treatment, time, dia / profile_data.bolussnooze_dia_divisor, profile_data);
+                    //var bIOB = iobCalc(treatment, time, dia / profile_data.bolussnooze_dia_divisor, profile_data);
                     //console.log(treatment);
                     //console.log(bIOB);
-                    if (bIOB && bIOB.iobContrib) bolussnooze += bIOB.iobContrib;
+                    //if (bIOB && bIOB.iobContrib) bolussnooze += bIOB.iobContrib;
                 }
             } else {
                 // track microBolus IOB, but also count it toward hightempinsulin
@@ -76,7 +76,7 @@ function iobTotal(opts, time) {
     var rval = {
         iob: Math.round(iob * 1000) / 1000,
         activity: Math.round(activity * 10000) / 10000,
-        bolussnooze: Math.round(bolussnooze * 1000) / 1000,
+        //bolussnooze: Math.round(bolussnooze * 1000) / 1000,
         netbasalinsulin: Math.round(netbasalinsulin * 1000) / 1000,
         hightempinsulin: Math.round(hightempinsulin * 1000) / 1000,
         microBolusInsulin: Math.round(microBolusInsulin * 1000) / 1000,

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -7,8 +7,6 @@ function iobTotal(opts, time) {
     var iob = 0;
     //var bolussnooze = 0;
     var activity = 0;
-    var microBolusInsulin = 0;
-    var microBolusIOB = 0;
     if (!treatments) return {};
     //if (typeof time === 'undefined') {
         //var time = new Date();
@@ -48,15 +46,6 @@ function iobTotal(opts, time) {
                     //if (bIOB && bIOB.iobContrib) bolussnooze += bIOB.iobContrib;
                 }
             } else {
-                // track microBolus IOB
-                if (treatment.insulin <= maxSMB && treatment.started_at) {
-                    if(treatment.date > dia_ago && treatment.date <= now) {
-                        microBolusInsulin += treatment.insulin;
-                    }
-                    if (tIOB && tIOB.iobContrib) {
-                        microBolusIOB += tIOB.iobContrib;
-                    }
-                }
                 // aIOB = basal IOB
                 var aIOB = tIOB; // iobCalc(treatment, time, dia, profile_data);
             }
@@ -67,8 +56,6 @@ function iobTotal(opts, time) {
         iob: Math.round(iob * 1000) / 1000,
         activity: Math.round(activity * 10000) / 10000,
         //bolussnooze: Math.round(bolussnooze * 1000) / 1000,
-        microBolusInsulin: Math.round(microBolusInsulin * 1000) / 1000,
-        microBolusIOB: Math.round(microBolusIOB * 1000) / 1000,
         time: time
     };
 

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -6,7 +6,6 @@ function iobTotal(opts, time) {
     var profile_data = opts.profile;
     var iob = 0;
     var bolussnooze = 0;
-    var basaliob = 0;
     var activity = 0;
     var netbasalinsulin = 0;
     var hightempinsulin = 0;
@@ -51,7 +50,7 @@ function iobTotal(opts, time) {
                     if (bIOB && bIOB.iobContrib) bolussnooze += bIOB.iobContrib;
                 }
             } else {
-                // track microBolus IOB, but also count it toward basaliob and hightempinsulin
+                // track microBolus IOB, but also count it toward hightempinsulin
                 if (treatment.insulin <= maxSMB && treatment.started_at) {
                     if(treatment.date > dia_ago && treatment.date <= now) {
                         microBolusInsulin += treatment.insulin;
@@ -62,7 +61,6 @@ function iobTotal(opts, time) {
                 }
                 // aIOB = basal IOB
                 var aIOB = tIOB; // iobCalc(treatment, time, dia, profile_data);
-                if (aIOB && aIOB.iobContrib) basaliob += aIOB.iobContrib;
                 if (treatment.insulin) {
                     if(treatment.date > dia_ago && treatment.date <= now) {
                         netbasalinsulin += treatment.insulin;
@@ -79,7 +77,6 @@ function iobTotal(opts, time) {
         iob: Math.round(iob * 1000) / 1000,
         activity: Math.round(activity * 10000) / 10000,
         bolussnooze: Math.round(bolussnooze * 1000) / 1000,
-        basaliob: Math.round(basaliob * 1000) / 1000,
         netbasalinsulin: Math.round(netbasalinsulin * 1000) / 1000,
         hightempinsulin: Math.round(hightempinsulin * 1000) / 1000,
         microBolusInsulin: Math.round(microBolusInsulin * 1000) / 1000,

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -30,7 +30,7 @@ function defaults ( ) {
     , remainingCarbsCap: 90 // max carbs we'll assume will absorb over 4h if we don't yet see carb absorption
     // WARNING: the following are advanced oref1 features, and are not yet tested for general use
     , enableUAM: false // enable detection of unannounced meal carb absorption
-    , enableSMB_with_bolus: false // enable supermicrobolus for DIA hours after a manual bolus
+    , enableSMB_always: false // always enable supermicrobolus (unless disabled by high temptarget)
     , enableSMB_with_COB: false // enable supermicrobolus while COB is positive
     , enableSMB_with_temptarget: false // enable supermicrobolus for eating soon temp targets
     , enableSMB_after_carbs: false // enable supermicrobolus for 6h after carbs, even with 0 COB
@@ -55,7 +55,6 @@ function displayedDefaults () {
     profile.rewind_resets_autosens = allDefaults.rewind_resets_autosens;
     profile.adv_target_adjustments = allDefaults.adv_target_adjustments;
     profile.unsuspend_if_no_temp = allDefaults.unsuspend_if_no_temp;
-    profile.enableSMB_with_bolus = allDefaults.enableSMB_with_bolus;
     profile.enableSMB_with_COB = allDefaults.enableSMB_with_COB;
     profile.enableSMB_with_temptarget = allDefaults.enableSMB_with_temptarget;
     profile.enableUAM = allDefaults.enableUAM;

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -501,14 +501,15 @@ describe('determine-basal', function ( ) {
 
     // meal assist / bolus snooze
     // right after 20g 1U meal bolus
-    it('should set current basal as temp when low and rising after meal bolus', function () {
-        var glucose_status = {"delta":1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
-        var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
-        var meal_data = {"carbs":20,"boluses":1, "mealCOB":20};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
-        output.rate.should.equal(0.9);
-        output.duration.should.equal(30);
-    });
+    //it('should set current basal as temp when low and rising after meal bolus', function () {
+        //var glucose_status = {"delta":1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
+        //var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
+        //var meal_data = {"carbs":20,"boluses":1, "mealCOB":20};
+        //var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
+        //console.log(output);
+        //output.rate.should.equal(0.9);
+        //output.duration.should.equal(30);
+    //});
 
     it('should do nothing when requested temp already running with >15m left', function () {
         var glucose_status = {"delta":-2,"glucose":121,"long_avgdelta":-1.333,"short_avgdelta":-1.333};
@@ -522,29 +523,29 @@ describe('determine-basal', function ( ) {
         (typeof output.duration).should.equal('undefined');
     });
 
-    it('should cancel high temp when low and dropping after meal bolus', function () {
-        var glucose_status = {"delta":-1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
-        var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
-        var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
-        //console.log(output);
-        //output.rate.should.equal(0);
-        //output.duration.should.equal(0);
-        output.rate.should.be.below(1.0);
-        output.duration.should.equal(30);
-    });
+    //it('should cancel high temp when low and dropping after meal bolus', function () {
+        //var glucose_status = {"delta":-1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
+        //var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
+        //var currenttemp = {"duration":20,"rate":2,"temp":"absolute"};
+        //var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
+        ////console.log(output);
+        ////output.rate.should.equal(0);
+        ////output.duration.should.equal(0);
+        //output.rate.should.be.below(1.0);
+        //output.duration.should.equal(30);
+    //});
 
-    it('should cancel low temp when low and rising after meal bolus', function () {
-        var glucose_status = {"delta":1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
-        var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
-        var currenttemp = {"duration":20,"rate":0,"temp":"absolute"};
-        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
-        //console.log(output);
-        output.rate.should.equal(0.9);
-        output.duration.should.equal(30);
-        //output.rate.should.equal(0);
-        //output.duration.should.equal(0);
-    });
+    //it('should cancel low temp when low and rising after meal bolus', function () {
+        //var glucose_status = {"delta":1,"glucose":80,"long_avgdelta":1,"short_avgdelta":1};
+        //var iob_data = {"iob":0.5,"activity":-0.01,"bolussnooze":1,"basaliob":-0.5};
+        //var currenttemp = {"duration":20,"rate":0,"temp":"absolute"};
+        //var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
+        ////console.log(output);
+        //output.rate.should.equal(0.9);
+        //output.duration.should.equal(30);
+        ////output.rate.should.equal(0);
+        ////output.duration.should.equal(0);
+    //});
 
     /* TODO: figure out how to do tests for advanced-meal-assist
     // 40m after 20g 1U meal bolus

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -485,10 +485,10 @@ describe('determine-basal', function ( ) {
       result.error.should.equal('Error: iob_data undefined. ');
     });
 
-    it('iob_data should contain activity, iob, bolussnooze', function () {
-      var result = determine_basal({glucose:100}, undefined,{"activity":0}, {"current_basal":0.0, "max_bg":100,"min_bg":110}, undefined, meal_data, tempBasalFunctions);
-      result.error.should.equal('Error: iob_data missing some property. ');
-    });
+    //it('iob_data should contain activity, iob, bolussnooze', function () {
+      //var result = determine_basal({glucose:100}, undefined,{"activity":0}, {"current_basal":0.0, "max_bg":100,"min_bg":110}, undefined, meal_data, tempBasalFunctions);
+      //result.error.should.equal('Error: iob_data missing some property. ');
+    //});
 
 /*
     it('should return error eventualBG if something went wrong', function () {

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -92,7 +92,7 @@ describe('determine-basal', function ( ) {
         //console.error(output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
-        output.reason.should.match(/in range.*/);
+        //output.reason.should.match(/in range.*/);
     });
 
     //it('should let low temp run in range w/o IOB', function () {
@@ -330,7 +330,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":3,"glucose":85,"long_avgdelta":3,"short_avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
-        output.rate.should.equal(0.9);
+        output.rate.should.be.above(0.8);
         output.duration.should.equal(30);
         //output.rate.should.equal(0);
         //output.duration.should.equal(0);
@@ -342,7 +342,8 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":3,"glucose":85,"long_avgdelta":3,"short_avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
-        output.rate.should.equal(0.9);
+        console.log(output);
+        output.rate.should.be.above(0.8);
         output.duration.should.equal(30);
     });
 
@@ -353,6 +354,7 @@ describe('determine-basal', function ( ) {
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //(typeof output.rate).should.equal('undefined');
         //(typeof output.duration).should.equal('undefined');
+        console.log(profile, output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         output.reason.should.match(/in range.*setting current basal/);

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -26,7 +26,7 @@ describe('IOB', function() {
                 }],
                 profile: {
                     dia: 3,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile,
                     current_basal: 1,
                     max_daily_basal: 1
@@ -36,13 +36,13 @@ describe('IOB', function() {
 
         var rightAfterBolus = require('../lib/iob')(inputs)[0];
         rightAfterBolus.iob.should.equal(2);
-        rightAfterBolus.bolussnooze.should.equal(2);
+        //rightAfterBolus.bolussnooze.should.equal(2);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(1.45);
-        hourLater.bolussnooze.should.be.lessThan(.5);
+        //hourLater.bolussnooze.should.be.lessThan(.5);
         hourLater.iob.should.be.greaterThan(0);
         hourLater.activity.should.be.greaterThan(0.01);
         hourLater.activity.should.be.lessThan(0.02);
@@ -52,7 +52,7 @@ describe('IOB', function() {
         var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
-        afterDIA.bolussnooze.should.equal(0);
+        //afterDIA.bolussnooze.should.equal(0);
     });
 
     it('should calculate IOB with Ultra-fast curve', function() {
@@ -75,7 +75,7 @@ describe('IOB', function() {
                 }],
                 profile: {
                     dia: 5,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile,
                     current_basal: 1,
                     max_daily_basal: 1,
@@ -86,7 +86,7 @@ describe('IOB', function() {
         var rightAfterBolus = require('../lib/iob')(inputs)[0];
         
         rightAfterBolus.iob.should.equal(2);
-        rightAfterBolus.bolussnooze.should.equal(2);
+        //rightAfterBolus.bolussnooze.should.equal(2);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
@@ -94,7 +94,7 @@ describe('IOB', function() {
         hourLater.iob.should.be.lessThan(1.6);
         hourLater.iob.should.be.greaterThan(1.3);
         
-        hourLater.bolussnooze.should.be.lessThan(1.7);
+        //hourLater.bolussnooze.should.be.lessThan(1.7);
         hourLater.iob.should.be.greaterThan(0);
         hourLater.activity.should.be.greaterThan(0.006);
         hourLater.activity.should.be.lessThan(0.015);
@@ -103,7 +103,7 @@ describe('IOB', function() {
         afterDIAInputs.clock = new Date(now + (5 * 60 * 60 * 1000)).toISOString();
         var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
         afterDIA.iob.should.equal(0);
-        afterDIA.bolussnooze.should.equal(0);
+        //afterDIA.bolussnooze.should.equal(0);
     });
 
 
@@ -128,7 +128,7 @@ describe('IOB', function() {
                 profile: {
                     dia: 5,
                     insulinPeakTime: 55,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile,
                     current_basal: 1,
                     max_daily_basal: 1,
@@ -138,13 +138,13 @@ describe('IOB', function() {
 
         var rightAfterBolus = require('../lib/iob')(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
-        rightAfterBolus.bolussnooze.should.equal(1);
+        //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.75);
-        hourLater.bolussnooze.should.be.lessThan(0.75);
+        //hourLater.bolussnooze.should.be.lessThan(0.75);
         hourLater.iob.should.be.greaterThan(0);
         hourLater.activity.should.be.greaterThan(0.0065);
         hourLater.activity.should.be.lessThan(0.008);
@@ -154,7 +154,7 @@ describe('IOB', function() {
         var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
-        afterDIA.bolussnooze.should.equal(0);
+        //afterDIA.bolussnooze.should.equal(0);
     });
 
     it('should calculate IOB with Ultra-fast curve peak setting of 65', function() {
@@ -179,7 +179,7 @@ describe('IOB', function() {
                     dia: 5,
                     insulinPeakTime: 65,
                     useCustomPeakTime: true,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile,
                     current_basal: 1,
                     max_daily_basal: 1,
@@ -189,15 +189,15 @@ describe('IOB', function() {
 
         var rightAfterBolus = require('../lib/iob')(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
-        rightAfterBolus.bolussnooze.should.equal(1);
+        //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.77);
-        hourLater.bolussnooze.should.be.lessThan(0.36);
+        //hourLater.bolussnooze.should.be.lessThan(0.36);
         hourLater.iob.should.be.greaterThan(0.72);
-        hourLater.bolussnooze.should.be.greaterThan(0.354);
+        //hourLater.bolussnooze.should.be.greaterThan(0.354);
 
         hourLater.activity.should.be.greaterThan(0.0055);
         hourLater.activity.should.be.lessThan(0.007);
@@ -207,7 +207,7 @@ describe('IOB', function() {
         var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
-        afterDIA.bolussnooze.should.equal(0);
+        //afterDIA.bolussnooze.should.equal(0);
     });
 
     it('should calculate IOB with Ultra-rapid curve peak setting of 75', function() {
@@ -232,7 +232,7 @@ describe('IOB', function() {
                     dia: 5,
                     insulinPeakTime: 75,
                     useCustomPeakTime: true,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile,
                     current_basal: 1,
                     max_daily_basal: 1,
@@ -242,15 +242,15 @@ describe('IOB', function() {
 
         var rightAfterBolus = require('../lib/iob')(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
-        rightAfterBolus.bolussnooze.should.equal(1);
+        //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.81);
-        hourLater.bolussnooze.should.be.lessThan(0.5);
+        //hourLater.bolussnooze.should.be.lessThan(0.5);
         hourLater.iob.should.be.greaterThan(0.76);
-        hourLater.bolussnooze.should.be.greaterThan(0.40);
+        //hourLater.bolussnooze.should.be.greaterThan(0.40);
         
         hourLater.iob.should.be.greaterThan(0);
         hourLater.activity.should.be.greaterThan(0.0047);
@@ -261,7 +261,7 @@ describe('IOB', function() {
         var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
-        afterDIA.bolussnooze.should.equal(0);
+        //afterDIA.bolussnooze.should.equal(0);
     });
 
     it('should calculate IOB with Ultra-rapid curve peak setting of 44 and DIA = 6', function() {
@@ -286,7 +286,7 @@ describe('IOB', function() {
                     dia: 6,
                     insulinPeakTime: 44,
                     useCustomPeakTime: true,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile,
                     current_basal: 1,
                     max_daily_basal: 1,
@@ -296,16 +296,16 @@ describe('IOB', function() {
 
         var rightAfterBolus = require('../lib/iob')(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
-        rightAfterBolus.bolussnooze.should.equal(1);
+        //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.59);
-        hourLater.bolussnooze.should.be.lessThan(0.23);
+        //hourLater.bolussnooze.should.be.lessThan(0.23);
         
         hourLater.iob.should.be.greaterThan(0.57);
-        hourLater.bolussnooze.should.be.greaterThan(0.21);
+        //hourLater.bolussnooze.should.be.greaterThan(0.21);
         
         hourLater.activity.should.be.greaterThan(0.007);
         hourLater.activity.should.be.lessThan(0.0085);
@@ -315,7 +315,7 @@ describe('IOB', function() {
         var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
-        afterDIA.bolussnooze.should.equal(0);
+        //afterDIA.bolussnooze.should.equal(0);
     });
 
 
@@ -340,7 +340,7 @@ describe('IOB', function() {
                 }],
                 profile: {
                     dia: 5,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile,
                     current_basal: 1,
                     max_daily_basal: 1,
@@ -350,13 +350,13 @@ describe('IOB', function() {
 
         var rightAfterBolus = require('../lib/iob')(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
-        rightAfterBolus.bolussnooze.should.equal(1);
+        //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.8);
-        hourLater.bolussnooze.should.be.lessThan(.8);
+        //hourLater.bolussnooze.should.be.lessThan(.8);
         hourLater.iob.should.be.greaterThan(0);
 
         var afterDIAInputs = inputs;
@@ -364,32 +364,32 @@ describe('IOB', function() {
         var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
-        afterDIA.bolussnooze.should.equal(0);
+        //afterDIA.bolussnooze.should.equal(0);
     });
 
 
-    it('should snooze fast if bolussnooze_dia_divisor is high', function() {
+    //it('should snooze fast if bolussnooze_dia_divisor is high', function() {
 
-        var now = Date.now(),
-            timestamp = new Date(now).toISOString(),
-            inputs = {
-                clock: timestamp,
-                history: [{
-                    _type: 'Bolus',
-                    amount: 1,
-                    timestamp: timestamp
-                }],
-                profile: {
-                    dia: 3,
-                    bolussnooze_dia_divisor: 10
-                }
-            };
+        //var now = Date.now(),
+            //timestamp = new Date(now).toISOString(),
+            //inputs = {
+                //clock: timestamp,
+                //history: [{
+                    //_type: 'Bolus',
+                    //amount: 1,
+                    //timestamp: timestamp
+                //}],
+                //profile: {
+                    //dia: 3,
+                    //bolussnooze_dia_divisor: 10
+                //}
+            //};
 
-        var snoozeInputs = inputs;
-        snoozeInputs.clock = new Date(now + (20 * 60 * 1000)).toISOString();
-        var snooze = require('../lib/iob')(snoozeInputs)[0];
-        snooze.bolussnooze.should.equal(0);
-    });
+        //var snoozeInputs = inputs;
+        //snoozeInputs.clock = new Date(now + (20 * 60 * 1000)).toISOString();
+        //var snooze = require('../lib/iob')(snoozeInputs)[0];
+        //snooze.bolussnooze.should.equal(0);
+    //});
 
     it('should calculate IOB with Temp Basals', function() {
 
@@ -428,7 +428,7 @@ describe('IOB', function() {
                     dia: 3,
                     current_basal: 1,
                     max_daily_basal: 1,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     'basalprofile': basalprofile
                 }
             };
@@ -485,7 +485,7 @@ describe('IOB', function() {
             }],
             profile: {
                 dia: 3,
-                bolussnooze_dia_divisor: 2,
+                //bolussnooze_dia_divisor: 2,
                 basalprofile: basalprofile
             }
         };
@@ -547,7 +547,7 @@ describe('IOB', function() {
                     dia: 3,
                     current_basal: 0.1,
                     max_daily_basal: 1,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile
                 }
             };
@@ -621,7 +621,7 @@ describe('IOB', function() {
                 dia: 3,
                 current_basal: 0.1,
                 max_daily_basal: 1,
-                bolussnooze_dia_divisor: 2,
+                //bolussnooze_dia_divisor: 2,
                 basalprofile: basalprofile
             }
         };
@@ -683,7 +683,7 @@ describe('IOB', function() {
                     dia: 3,
                     current_basal: 0.1,
                     max_daily_basal: 1,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile
                 }
             };
@@ -742,7 +742,7 @@ describe('IOB', function() {
                 dia: 3,
                 current_basal: 2,
                 max_daily_basal: 2,
-                bolussnooze_dia_divisor: 2,
+                //bolussnooze_dia_divisor: 2,
                 'basalprofile': basalprofile
             }
         };
@@ -839,7 +839,7 @@ describe('IOB', function() {
                     dia: 3,
                     current_basal: 2,
                     max_daily_basal: 2,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     'basalprofile': basalprofile
                 }
             };
@@ -870,7 +870,7 @@ describe('IOB', function() {
                     dia: 3,
                     current_basal: 1,
                     max_daily_basal: 1,
-                    bolussnooze_dia_divisor: 2
+                    //bolussnooze_dia_divisor: 2
                 }
             };
 
@@ -905,7 +905,7 @@ describe('IOB', function() {
                     dia: 3,
                     current_basal: 1,
                     max_daily_basal: 1,
-                    bolussnooze_dia_divisor: 2
+                    //bolussnooze_dia_divisor: 2
                 }
             };
 
@@ -938,7 +938,7 @@ describe('IOB', function() {
                 }],
                 profile: {
                     dia: 4,
-                    bolussnooze_dia_divisor: 2,
+                    //bolussnooze_dia_divisor: 2,
                     basalprofile: basalprofile,
                     current_basal: 1,
                     max_daily_basal: 1
@@ -948,13 +948,13 @@ describe('IOB', function() {
 
         var rightAfterBolus = require('../lib/iob')(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
-        rightAfterBolus.bolussnooze.should.equal(1);
+        //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
         var hourLater = require('../lib/iob')(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(1);
-        hourLater.bolussnooze.should.be.lessThan(.5);
+        //hourLater.bolussnooze.should.be.lessThan(.5);
         hourLater.iob.should.be.greaterThan(0);
 
         var after3hInputs = inputs;


### PR DESCRIPTION
With eSMB now allowing no-bolus operation of OpenAPS, the distinctions between manual boluses and microboluses are breaking down, which prevents things like bolus snooze, which assume that automatically administered insulin should be classified as basal insulin / IOB and kept distinct from bolus insulin / IOB.

Now that carb ratios can be properly autotuned, carb absorption is assumed to occur over less than DIA, the original need for bolus snooze is largely eliminated.  The only remaining need for it might be if anyone is not entering carbs (either via NS or the pump), is manually bolusing for food, and then is expecting bolus snooze to cover until UAM kicks in.  If that turns out to be a significant fraction of the OpenAPS user base (which I doubt) we can revisit how best to support that use case.

This PR removes all references to bolus snooze, bolus vs. basal insulin, and other similar now-obsolete distinctions.  It has been tested and working with when using eSMB with no-bolus meals, but also needs testing by those doing meal boluses, either with or without SMB and/or UAM.

TODO:
- [x] Re-add bolus vs. basal IOB calculations for human-only use, without SMB heuristics