### PR TITLE
Fix problem installing 0.6.0 dev on a Raspberry Pi with stretch

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,13 +82,13 @@
   "homepage": "https://github.com/openaps/oref0",
   "dependencies": {
     "crypto": "0.0.3",
+    "json": "~9.0.4",
     "lodash": "^4.15.0",
     "moment": "^2.14.1",
     "request": "^2.79.0",
     "share2nightscout-bridge": "^0.1.5",
     "moment-timezone": "0.5.11",
-    "yargs": "~4.3.2",
-    "json": "~9.0.4"
+    "yargs": "~4.3.2"
   },
   "devDependencies": {
     "coveralls": "^2.11.12",


### PR DESCRIPTION
Work in progress. Trying to make rpi3 install with stretch easier. Please add problems with installing on RPI3.

Problem 1: json is not installed and causes oref0-setup.sh to fail

```
added process://ns/nightscout/ns NIGHTSCOUT_HOST API_SECRET
/usr/local/bin/nightscout: line 338: json: command not found
close failed in file object destructor:
sys.excepthook is missing
lost sys.stderr
Traceback (most recent call last):
  File "/usr/local/bin/openaps-import", line 89, in <module>
    app( )
  File "/usr/local/lib/python2.7/dist-packages/openaps/cli/__init__.py", line 51, in __call__
    self.run(self.args)
  File "/usr/local/bin/openaps-import", line 77, in run
    candidates = json.load(args.input)
  File "/usr/lib/python2.7/json/__init__.py", line 291, in load
    **kw)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
Could not run nightscout autoconfigure-device-crud
```

Solution 1: 
This is caused by a missing `json` command from npm.
Fix this by adding it to as a oref0 dependency in package.json

Problem 2: `sudo` is installed on raspbian and installing should be able to able as `pi` user.  Currently `quick-packages.sh` seems to require to be run as root (because missing `sudo` on edison)

Solution: will do some refactoring to `openaps-install.sh` so that it installs `sudo` for edison and it will call `sudo` for `quick-packages.sh`

Problem 3: No npm or nodejs is installed on raspberry by default
Suggested solution 3: Add nodejs and npm checking in `openaps-install.sh`

Problem 4: `find: ‘/tmp/systemd-private-xxx-systemd-timesyncd.service-yyy’: Permission denied` 
Probably adding in a sudo will fix this. Need to look into this.