### PR TITLE
Fix update of Decocare 

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -543,7 +543,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     # TODO: remove this and switch back to easy_install or pip once decocare 0.1.0 is released
     if [ -d "$HOME/src/decocare/" ]; then
         echo "$HOME/src/decocare/ already exists; pulling latest 0.1.0-dev"
-        (cd $HOME/src/decocare && git fetch && git checkout 0.1.0-dev && git pull) || die "Couldn't pull latest decocare 0.1.0-dev"
+        (cd $HOME/src/ && rm -r decocare && git clone -b 0.1.0-dev git://github.com/openaps/decocare.git) || die "Couldn't pull latest decocare 0.1.0-dev"
     else
         echo -n "Cloning decocare 0.1.0-dev: "
         (cd $HOME/src && git clone -b 0.1.0-dev git://github.com/openaps/decocare.git) || die "Couldn't clone decocare 0.1.0-dev"


### PR DESCRIPTION
Fix errors on updating to 0.1.0-dev on decocare

Very common error I get when updating an rig is 
```
Continue? y/[N] y
Checking openaps 0.2.1 installation with --nogit support
openaps 0.2.1-dev
Checking /root/johnopenaps: /root/johnopenaps already exists
Searching for decocare
Reading https://pypi.python.org/simple/decocare/
Best match: decocare 0.0.32.dev0
decocare 0.0.32.dev0 is already the active version in easy-install.pth

Using /root/src/decocare
Processing dependencies for decocare
Finished processing dependencies for decocare
/root/src/decocare/ already exists; pulling latest 0.1.0-dev
error: pathspec '0.1.0-dev' did not match any file(s) known to git.
Couldn't pull latest decocare 0.1.0-dev
```

and that kicks you out of finishing the setup.

So instead of trying to fetch the correct version of decocare it's just easier to remove it, then clone it back in, and away we go. 

Yes there are many ways to use git, but these are the simple ones that always works for me

<insert @scottleibrand  favorite git comic>

anyone see any problem with that? 