### PR TITLE
don't run loop if rig is too hot

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -82,7 +82,7 @@ smb_main() {
 }
 
 function overtemp {
-    # check for CPU temperature above 80F
+    # check for CPU temperature above 80°C
     sensors -u 2>/dev/null | awk '$NF > 80' | grep input \
     && echo Rig is too hot: not running pump-loop at $(date)\
     && echo Please ensure rig is properly ventilated

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -82,8 +82,8 @@ smb_main() {
 }
 
 function overtemp {
-    # check for CPU temperature above 80°C
-    sensors -u 2>/dev/null | awk '$NF > 80' | grep input \
+    # check for CPU temperature above 85°C
+    sensors -u 2>/dev/null | awk '$NF > 85' | grep input \
     && echo Rig is too hot: not running pump-loop at $(date)\
     && echo Please ensure rig is properly ventilated
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -83,8 +83,8 @@ smb_main() {
 
 function overtemp {
     # check for CPU temperature above 80F
-    sensors -u 2>/dev/null | awk '$NF > 78' | grep input \
-    && echo Rig is too hot: not running pump-loop \
+    sensors -u 2>/dev/null | awk '$NF > 80' | grep input \
+    && echo Rig is too hot: not running pump-loop at $(date)\
     && echo Please ensure rig is properly ventilated
 }
 function smb_reservoir_before {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -83,7 +83,9 @@ smb_main() {
 
 function overtemp {
     # check for CPU temperature above 80F
-    sensors -u 2>/dev/null | awk '$NF > 78' | grep input
+    sensors -u 2>/dev/null | awk '$NF > 78' | grep input \
+    && echo Rig is too hot: not running pump-loop \
+    && echo Please ensure rig is properly ventilated
 }
 function smb_reservoir_before {
     # Refresh reservoir.json and pumphistory.json

--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -171,7 +171,7 @@
     "type": "alias",
     "name": "ns-loop",
     "ns-loop": {
-      "command": "! bash -c \"echo Starting ns-loop at $(date): && openaps get-ns-bg; openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload\""
+      "command": "! bash -c \"echo Starting ns-loop at $(date): && openaps get-ns-bg; sensors -u 2>/dev/null | awk '$NF > 80' | grep input || ( openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload )\""
     }
   },
   {

--- a/lib/oref0-setup/alias.json
+++ b/lib/oref0-setup/alias.json
@@ -171,7 +171,7 @@
     "type": "alias",
     "name": "ns-loop",
     "ns-loop": {
-      "command": "! bash -c \"echo Starting ns-loop at $(date): && openaps get-ns-bg; sensors -u 2>/dev/null | awk '$NF > 80' | grep input || ( openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload )\""
+      "command": "! bash -c \"echo Starting ns-loop at $(date): && openaps get-ns-bg; sensors -u 2>/dev/null | awk '$NF > 85' | grep input || ( openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload )\""
     }
   },
   {


### PR DESCRIPTION
If a rig is getting too hot, we should pause pump-loop and ns-loop (the two that drive most CPU activity) until the rig cools off, while printing error messages in pump-loop.log to inform the user they need to better ventilate their rig.  This will allow the rig to set temps at least occasionally, rather than getting to the Edison's critical temperature alarm threshold and rebooting (or presumably shutting down hard at some point).

This has been tested on a well-insulated overheating Edison rig by pulling the updated oref0-online and manually updating openaps.ini. We'll also need to make sure that the alias.json change doesn't break anything, and that checking `sensors` doesn't break anything on Pi rigs that don't have it.