### PR TITLE
Go back to using a 90m minPredBG lookahead for all insulin types

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -436,19 +436,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
 
             // set minPredBGs starting when currently-dosed insulin activity will peak
-            var insulinPeakTime = 75;
-            if ( profile.insulinPeakTime ) {
-                insulinPeakTime = profile.insulinPeakTime;
-            }
-            if ( profile.curve == "ultra-rapid" && !profile.useCustomPeakTime ) {
-                insulinPeakTime = 55;
-            }
+            // look ahead 60m (regardless of insulin type) so as to be less aggressive on slower insulins
+            var insulinPeakTime = 60;
             // add 30m to allow for insluin delivery (SMBs or temps)
-            insulinPeakTime += 30;
+            insulinPeakTime = 90;
             var insulinPeak5m = (insulinPeakTime/60)*12;
             //console.error(insulinPeakTime, insulinPeak5m, profile.insulinPeakTime, profile.curve);
 
-            // wait 80-100 before setting minIOBPredBG
+            // wait 90m before setting minIOBPredBG
             if ( IOBpredBGs.length > insulinPeak5m && (IOBpredBG < minIOBPredBG) ) { minIOBPredBG = round(IOBpredBG); }
             if ( IOBpredBG > maxIOBPredBG ) { maxIOBPredBG = IOBpredBG; }
             // wait 85-105m before setting COB and 60m for UAM minPredBGs


### PR DESCRIPTION
Per @PieterGit the current 0.6.0-dev code seems a bit too aggressive in some situations for some users on rapid-acting insulin.  In order to make it somewhat less aggressive, this reverts some changes that attempted to tie the minPredBG lookahead (where we ignore the first X minutes of predBGs when setting minPredBG) to the insulinPeakTime, and therefore makes eSMB less aggressive for non-Fiasp users.

Would like to hear input from others using SMBs with rapid-acting insulin and discuss if this is a change we want to make, or if it would make eSMB less effective and perhaps we should focus elsewhere.