### PR TITLE
Time-aware carbsReq

### DIFF
--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -5,11 +5,12 @@ USER=$2
 FILE=${3-enact/smb-suggested.json}
 SOUND=${4-none}
 SNOOZE=${5-15}
+ONLYFOR=${6-carbs}
 
 #echo "Running: $0 $TOKEN $USER $FILE $SOUND $SNOOZE"
 
 if [ -z $TOKEN ] || [ -z $USER ]; then
-    echo "Usage: $0 <TOKEN> <USER> [enact/smb-suggested.json] [none] [15]"
+    echo "Usage: $0 <TOKEN> <USER> [enact/smb-suggested.json] [none] [15] [carbs|insulin]"
     exit
 fi
 
@@ -20,6 +21,10 @@ elif ! find $FILE -mmin -$SNOOZE | grep -q $FILE; then
     echo "$FILE more than $SNOOZE minutes old"
 elif ! cat $FILE | egrep "add'l|maxBolus"; then
     echo "No additional carbs or bolus required."
+elif [[ $ONLYFOR =~ "carb" ]] && ! cat $FILE | egrep "add'l"; then
+    echo "No additional carbs required."
+elif [[ $ONLYFOR =~ "insulin" ]] && ! cat $FILE | egrep "maxBolus"; then
+    echo "No additional insulin required."
 else
     curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
 fi

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -362,7 +362,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     acid = Math.max(0, meal_data.mealCOB * csf / aci );
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
     console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (~2h peak):",round(remainingCIpeak,1),"mg/dL per 5m");
-    console.error("Accel. Carb Impact:",aci,"mg/dL per 5m; ACI Duration:",round(acid*5/60*2,1),"hours");
+    //console.error("Accel. Carb Impact:",aci,"mg/dL per 5m; ACI Duration:",round(acid*5/60*2,1),"hours");
     var minIOBPredBG = 999;
     var minCOBPredBG = 999;
     var minUAMPredBG = 999;
@@ -570,7 +570,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // make sure minPredBG isn't higher than avgPredBG
     minPredBG = Math.min( minPredBG, avgPredBG );
 
-    process.stderr.write("naive_eventualBG: "+naive_eventualBG+" minPredBG: "+minPredBG+" minIOBPredBG: "+minIOBPredBG);
+    process.stderr.write("minPredBG: "+minPredBG+" minIOBPredBG: "+minIOBPredBG);
     if (minCOBPredBG < 999) {
         process.stderr.write(" minCOBPredBG: "+minCOBPredBG);
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -602,7 +602,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     rT.reason += "; ";
     //var bgUndershoot = threshold - Math.min(minGuardBG, Math.max( naive_eventualBG, eventualBG ));
     // use naive_eventualBG if above 40, but switch to minGuardBG if both eventualBGs hit floor of 39
-    var carbsReqBG = Math.max( naive_eventualBG, eventualBG );
+    //var carbsReqBG = Math.max( naive_eventualBG, eventualBG );
+    var carbsReqBG = naive_eventualBG;
     if ( carbsReqBG < 40 ) {
         carbsReqBG = Math.min( minGuardBG, carbsReqBG );
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -664,8 +664,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var zeroTempDuration = minutesAboveThreshold;
     // BG undershoot, minus effect of zero temps until hitting min_bg, converted to grams, minus COB
     var zeroTempEffect = profile.current_basal*sens*zeroTempDuration/60;
-    // don't count the last 25% of COB against carbsReq
-    var COBforCarbsReq = Math.max(0, meal_data.mealCOB - 0.25*meal_data.carbs);
+    // don't count the last 30% of COB against carbsReq
+    var COBforCarbsReq = Math.max(0, meal_data.mealCOB - 0.3*meal_data.carbs);
     var carbsReq = (bgUndershoot - zeroTempEffect) / csf - COBforCarbsReq;
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -600,7 +600,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += ", UAMpredBG " + convert_bg(lastUAMpredBG, profile)
     }
     rT.reason += "; ";
-    var bgUndershoot = target_bg - Math.max( naive_eventualBG, eventualBG, lastIOBpredBG );
+    var bgUndershoot = target_bg - Math.max( naive_eventualBG, eventualBG );
     // calculate how long until COB (or IOB) predBGs drop below min_bg
     var minutesAboveMinBG = 240;
     var minutesAboveThreshold = 240;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -600,8 +600,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += ", UAMpredBG " + convert_bg(lastUAMpredBG, profile)
     }
     rT.reason += "; ";
-    //var bgUndershoot = target_bg - Math.min(minGuardBG, Math.max( naive_eventualBG, eventualBG ));
-    var bgUndershoot = threshold - Math.min(minGuardBG, Math.max( naive_eventualBG, eventualBG ));
+    //var bgUndershoot = threshold - Math.min(minGuardBG, Math.max( naive_eventualBG, eventualBG ));
+    // use naive_eventualBG if above 40, but switch to minGuardBG if both eventualBGs hit floor of 39
+    var carbsReqBG = Math.max( naive_eventualBG, eventualBG );
+    if ( carbsReqBG < 40 ) {
+        carbsReqBG = Math.min( minGuardBG, carbsReqBG );
+    }
+    var bgUndershoot = threshold - carbsReqBG;
     // calculate how long until COB (or IOB) predBGs drop below min_bg
     var minutesAboveMinBG = 240;
     var minutesAboveThreshold = 240;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -670,7 +670,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);
     console.error("naive_eventualBG:",naive_eventualBG,"bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
-    if ( carbsReq >= profile.carbsReqThreshold && minutesAboveThreshold < 60 ) {
+    if ( carbsReq >= profile.carbsReqThreshold && minutesAboveThreshold <= 45 ) {
         rT.carbsReq = carbsReq;
         rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m; ";
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -660,7 +660,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);
     console.error("bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
-    if ( carbsReq >= profile.carbsReqThreshold ) {
+    if ( carbsReq >= profile.carbsReqThreshold && minutesAboveThreshold < 60 ) {
         rT.carbsReq = carbsReq;
         rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m + " + minutesAboveMinBG + "m zero temp; ";
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -577,7 +577,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (minUAMPredBG < 999) {
         process.stderr.write(" minUAMPredBG: "+minUAMPredBG);
     }
-    console.error(" avgPredBG:",avgPredBG,"COB:",meal_data.mealCOB,"carbs:",meal_data.carbs);
+    console.error(" avgPredBG:",avgPredBG,"COB:",meal_data.mealCOB,"/",meal_data.carbs);
     // But if the COB line falls off a cliff, don't trust UAM too much:
     // use maxCOBPredBG if it's been set and lower than minPredBG
     if ( maxCOBPredBG > bg ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -664,8 +664,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var zeroTempDuration = minutesAboveThreshold;
     // BG undershoot, minus effect of zero temps until hitting min_bg, converted to grams, minus COB
     var zeroTempEffect = profile.current_basal*sens*zeroTempDuration/60;
-    // don't count the last 30% of COB against carbsReq
-    var COBforCarbsReq = Math.max(0, meal_data.mealCOB - 0.3*meal_data.carbs);
+    // don't count the last 25% of COB against carbsReq
+    var COBforCarbsReq = Math.max(0, meal_data.mealCOB - 0.25*meal_data.carbs);
     var carbsReq = (bgUndershoot - zeroTempEffect) / csf - COBforCarbsReq;
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -658,7 +658,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var zeroTempDuration = minutesAboveThreshold;
     // BG undershoot, minus effect of zero temps until hitting min_bg, converted to grams, minus COB
     var zeroTempEffect = profile.current_basal*sens*zeroTempDuration/60;
-    var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;
+    // don't count the last 25% of COB against carbsReq
+    var COBforCarbsReq = Math.max(0, meal_data.mealCOB - 0.25*meal_data.carbs);
+    var carbsReq = (bgUndershoot - zeroTempEffect) / csf - COBforCarbsReq;
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);
     console.error("bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -600,7 +600,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += ", UAMpredBG " + convert_bg(lastUAMpredBG, profile)
     }
     rT.reason += "; ";
-    var bgUndershoot = target_bg - Math.max( naive_eventualBG, eventualBG );
+    var bgUndershoot = target_bg - Math.min(minGuardBG, Math.max( naive_eventualBG, eventualBG ));
     // calculate how long until COB (or IOB) predBGs drop below min_bg
     var minutesAboveMinBG = 240;
     var minutesAboveThreshold = 240;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -669,7 +669,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var carbsReq = (bgUndershoot - zeroTempEffect) / csf - COBforCarbsReq;
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);
-    console.error("bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
+    console.error("naive_eventualBG:",naive_eventualBG,"bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
     if ( carbsReq >= profile.carbsReqThreshold && minutesAboveThreshold < 60 ) {
         rT.carbsReq = carbsReq;
         rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m; ";

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -600,7 +600,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason += ", UAMpredBG " + convert_bg(lastUAMpredBG, profile)
     }
     rT.reason += "; ";
-    var bgUndershoot = target_bg - Math.min(minGuardBG, Math.max( naive_eventualBG, eventualBG ));
+    //var bgUndershoot = target_bg - Math.min(minGuardBG, Math.max( naive_eventualBG, eventualBG ));
+    var bgUndershoot = threshold - Math.min(minGuardBG, Math.max( naive_eventualBG, eventualBG ));
     // calculate how long until COB (or IOB) predBGs drop below min_bg
     var minutesAboveMinBG = 240;
     var minutesAboveThreshold = 240;
@@ -653,7 +654,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
     // include at least minutesAboveMinBG worth of zero temps in calculating carbsReq
     // always include at least 30m worth of zero temp (carbs to 80, low temp up to target)
-    var zeroTempDuration = Math.max(30,minutesAboveMinBG);
+    //var zeroTempDuration = Math.max(30,minutesAboveMinBG);
+    var zeroTempDuration = minutesAboveThreshold;
     // BG undershoot, minus effect of zero temps until hitting min_bg, converted to grams, minus COB
     var zeroTempEffect = profile.current_basal*sens*zeroTempDuration/60;
     var carbsReq = (bgUndershoot - zeroTempEffect) / csf - meal_data.mealCOB;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -603,6 +603,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var bgUndershoot = target_bg - Math.max( naive_eventualBG, eventualBG, lastIOBpredBG );
     // calculate how long until COB (or IOB) predBGs drop below min_bg
     var minutesAboveMinBG = 240;
+    var minutesAboveThreshold = 240;
     if (meal_data.mealCOB > 0 && ( ci > 0 || remainingCIpeak > 0 )) {
         for (var i=0; i<COBpredBGs.length; i++) {
             //console.error(COBpredBGs[i], min_bg);
@@ -611,11 +612,25 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 break;
             }
         }
+        for (var i=0; i<COBpredBGs.length; i++) {
+            //console.error(COBpredBGs[i], threshold);
+            if ( COBpredBGs[i] < threshold ) {
+                minutesAboveThreshold = 5*i;
+                break;
+            }
+        }
     } else {
         for (var i=0; i<IOBpredBGs.length; i++) {
             //console.error(IOBpredBGs[i], min_bg);
             if ( IOBpredBGs[i] < min_bg ) {
                 minutesAboveMinBG = 5*i;
+                break;
+            }
+        }
+        for (var i=0; i<IOBpredBGs.length; i++) {
+            //console.error(IOBpredBGs[i], threshold);
+            if ( IOBpredBGs[i] < threshold ) {
+                minutesAboveThreshold = 5*i;
                 break;
             }
         }
@@ -633,6 +648,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     console.error("BG projected to remain above",min_bg,"for",minutesAboveMinBG,"minutes");
+    if ( minutesAboveThreshold < 240 ) {
+        console.error("BG projected to remain above",threshold,"for",minutesAboveThreshold,"minutes");
+    }
     // include at least minutesAboveMinBG worth of zero temps in calculating carbsReq
     // always include at least 30m worth of zero temp (carbs to 80, low temp up to target)
     var zeroTempDuration = Math.max(30,minutesAboveMinBG);
@@ -644,7 +662,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
     if ( carbsReq >= profile.carbsReqThreshold ) {
         rT.carbsReq = carbsReq;
-        rT.reason += carbsReq + " add'l carbs req + " + minutesAboveMinBG + "m zero temp; ";
+        rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m + " + minutesAboveMinBG + "m zero temp; ";
     }
     // don't low glucose suspend if IOB is already super negative and BG is rising faster than predicted
     if (bg < threshold && iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -672,7 +672,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
     if ( carbsReq >= profile.carbsReqThreshold && minutesAboveThreshold < 60 ) {
         rT.carbsReq = carbsReq;
-        rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m + ";
+        rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m; ";
     }
     // don't low glucose suspend if IOB is already super negative and BG is rising faster than predicted
     if (bg < threshold && iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -465,7 +465,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (meal_data.mealCOB) {
         console.error("predCIs (mg/dL/5m):",predCIs.join(" "));
         console.error("remainingCIs:",remainingCIs.join(" "));
-        console.error("COB:",meal_data.mealCOB,"remainingCItotal/csf:",round(remainingCItotal/csf,2),"remainingCarbs:",round(remainingCarbs,2)); 
+        //console.error("COB:",meal_data.mealCOB,"remainingCItotal/csf:",round(remainingCItotal/csf,2),"remainingCarbs:",round(remainingCarbs,2)); 
     }
     //,"totalCA:",round(totalCA,2),"remainingCItotal/csf+totalCA:",round(remainingCItotal/csf+totalCA,2));
     rT.predBGs = {};

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -672,7 +672,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
     if ( carbsReq >= profile.carbsReqThreshold && minutesAboveThreshold < 60 ) {
         rT.carbsReq = carbsReq;
-        rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m + " + minutesAboveMinBG + "m zero temp; ";
+        rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m + ";
     }
     // don't low glucose suspend if IOB is already super negative and BG is rising faster than predicted
     if (bg < threshold && iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -570,7 +570,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // make sure minPredBG isn't higher than avgPredBG
     minPredBG = Math.min( minPredBG, avgPredBG );
 
-    process.stderr.write("minPredBG: "+minPredBG+" minIOBPredBG: "+minIOBPredBG);
+    process.stderr.write("naive_eventualBG: "+naive_eventualBG+" minPredBG: "+minPredBG+" minIOBPredBG: "+minIOBPredBG);
     if (minCOBPredBG < 999) {
         process.stderr.write(" minCOBPredBG: "+minCOBPredBG);
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -648,7 +648,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     console.error("BG projected to remain above",min_bg,"for",minutesAboveMinBG,"minutes");
-    if ( minutesAboveThreshold < 240 ) {
+    if ( minutesAboveThreshold < 240 || minutesAboveMinBG < 60 ) {
         console.error("BG projected to remain above",threshold,"for",minutesAboveThreshold,"minutes");
     }
     // include at least minutesAboveMinBG worth of zero temps in calculating carbsReq

--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -95,7 +95,7 @@ function findMealInputs (inputs) {
         }
     }
     
-    if (duplicates > 0) console.error("Removed duplicate bolus/carb entries:" + duplicates);
+    //if (duplicates > 0) console.error("Removed duplicate bolus/carb entries:" + duplicates);
     
     return mealInputs;
 }


### PR DESCRIPTION
The current carbsReq notifications tend to be too sensitive when carbs aren't likely to be needed for an hour or more.  This changes the carbsReq calculations to be based on how much time BG is predicted to remain above the minGuardBG threshold (which comes out to 70 for a target of 100).  It uses naive_eventualBG so as not to be too sensitive to current BG slope, and attempts to make sure that there will be enough time for zero-temping to get IOB down to zero by the time BG hits the threshold.  If there is not, it will recommend enough carbs to compensate, and also note how soon they'll likely to be needed, so the user can decide whether to do carbs right away or wait and see if BG flattens out on its own and they're not actually needed.

This also disables insulinReq pushover notifications by default now that eSMB can usually handle insulin dosing unassisted, so that only situations potentially requiring action generate notifications.

- [ ] TODO: add an option to oref0-setup to enable insulinReq pushover notifications as well.