### PR TITLE
curl openaps-install.sh

### DIFF
--- a/bin/openaps-bootstrap.sh
+++ b/bin/openaps-bootstrap.sh
@@ -29,6 +29,6 @@ ifdown wlan0; ifup wlan0
 sleep 10
 echo -ne "\nWifi SSID: "; iwgetid -r
 sleep 5
-curl https://raw.githubusercontent.com/openaps/docs/dev/scripts/openaps-install.sh > /tmp/openaps-install.sh
+curl https://raw.githubusercontent.com/openaps/oref0/master/bin/openaps-install.sh > /tmp/openaps-install.sh
 bash /tmp/openaps-install.sh
 )

--- a/bin/openaps-bootstrap.sh
+++ b/bin/openaps-bootstrap.sh
@@ -29,6 +29,6 @@ ifdown wlan0; ifup wlan0
 sleep 10
 echo -ne "\nWifi SSID: "; iwgetid -r
 sleep 5
-# TODO check for options to fix the certificate activation error message for https
-cd /tmp/; wget --no-check-certificate https://raw.githubusercontent.com/openaps/docs/dev/scripts/openaps-install.sh; bash ./openaps-install.sh
+curl https://raw.githubusercontent.com/openaps/docs/dev/scripts/openaps-install.sh > /tmp/openaps-install.sh
+bash /tmp/openaps-install.sh
 )


### PR DESCRIPTION
This just updates the oref0 copy of openaps-bootstrap.sh to match what's in the OpenAPS docs.  So far nothing  is using this copy yet.