### PR TITLE
Blend minGuardBG

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -552,6 +552,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else {
         minGuardBG = minIOBGuardBG;
     }
+    minGuardBG = round(minGuardBG);
     console.error(minCOBGuardBG, minUAMGuardBG, minIOBGuardBG, minGuardBG);
 
     // if any carbs have been entered recently

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -367,6 +367,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var minCOBPredBG = 999;
     var minUAMPredBG = 999;
     var minGuardBG = 999;
+    var minCOBGuardBG = 999;
+    var minUAMGuardBG = 999;
+    var minIOBGuardBG = 999;
     var minPredBG;
     var avgPredBG;
     var IOBpredBG = eventualBG;
@@ -426,14 +429,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             if ( COBpredBGs.length < 48) { COBpredBGs.push(COBpredBG); }
             if ( aCOBpredBGs.length < 48) { aCOBpredBGs.push(aCOBpredBG); }
             if ( UAMpredBGs.length < 48) { UAMpredBGs.push(UAMpredBG); }
-            // calculate minGuardBG without a wait from COB if available, or UAM, or IOB predBGs
-            if ( (cid || remainingCIpeak > 0) && fractionCOBAbsorbed < 0.75 ) {
-                if ( COBpredBG < minGuardBG ) { minGuardBG = round(COBpredBG); }
-            } else if ( enableUAM ) {
-                if ( UAMpredBG < minGuardBG ) { minGuardBG = round(UAMpredBG); }
-            } else {
-                if ( IOBpredBG < minGuardBG ) { minGuardBG = round(IOBpredBG); }
-            }
+            // calculate minGuardBGs without a wait from COB, UAM, IOB predBGs
+            if ( COBpredBG < minCOBGuardBG ) { minCOBGuardBG = round(COBpredBG); }
+            if ( UAMpredBG < minUAMGuardBG ) { minUAMGuardBG = round(UAMpredBG); }
+            if ( IOBpredBG < minIOBGuardBG ) { minIOBGuardBG = round(IOBpredBG); }
 
             // set minPredBGs starting when currently-dosed insulin activity will peak
             var insulinPeakTime = 75;
@@ -520,6 +519,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     console.error("UAM Impact:",uci,"mg/dL per 5m; UAM Duration:",UAMduration,"hours");
 
+
     minIOBPredBG = Math.max(39,minIOBPredBG);
     minCOBPredBG = Math.max(39,minCOBPredBG);
     minUAMPredBG = Math.max(39,minUAMPredBG);
@@ -539,6 +539,20 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else {
         avgPredBG = round( IOBpredBG );
     }
+
+    // if we have both minCOBGuardBG and minUAMGuardBG, blend according to fractionCarbsLeft
+    if ( (cid || remainingCIpeak > 0) && enableUAM ) {
+        if ( enableUAM ) {
+            minGuardBG = fractionCarbsLeft*minCOBGuardBG + (1-fractionCarbsLeft)*minUAMGuardBG;
+        } else {
+            minGuardBG = minCOBGuardBG;
+        }
+    } else if ( enableUAM ) {
+        minGuardBG = minUAMGuardBG;
+    } else {
+        minGuardBG = minIOBGuardBG;
+    }
+    console.error(minCOBGuardBG, minUAMGuardBG, minIOBGuardBG, minGuardBG);
 
     // if any carbs have been entered recently
     if (meal_data.carbs) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -553,7 +553,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         minGuardBG = minIOBGuardBG;
     }
     minGuardBG = round(minGuardBG);
-    console.error(minCOBGuardBG, minUAMGuardBG, minIOBGuardBG, minGuardBG);
+    //console.error(minCOBGuardBG, minUAMGuardBG, minIOBGuardBG, minGuardBG);
 
     // if any carbs have been entered recently
     if (meal_data.carbs) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -558,11 +558,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // if any carbs have been entered recently
     if (meal_data.carbs) {
         // average the minIOBPredBG and minUAMPredBG if available
+        /*
         if ( minUAMPredBG < 999 ) {
             avgMinPredBG = round( (minIOBPredBG+minUAMPredBG)/2 );
         } else {
             avgMinPredBG = minIOBPredBG;
         }
+        */
 
         // if UAM is disabled, use max of minIOBPredBG, minCOBPredBG
         if ( ! enableUAM && minCOBPredBG < 999 ) {
@@ -570,12 +572,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // if we have COB, use minCOBPredBG, or blendedMinPredBG if it's higher
         } else if ( minCOBPredBG < 999 ) {
             // calculate blendedMinPredBG based on how many carbs remain as COB
-            blendedMinPredBG = fractionCarbsLeft*minCOBPredBG + (1-fractionCarbsLeft)*avgMinPredBG;
+            blendedMinPredBG = fractionCarbsLeft*minCOBPredBG + (1-fractionCarbsLeft)*minUAMPredBG;
             // if blendedMinPredBG > minCOBPredBG, use that instead
             minPredBG = round(Math.max(minIOBPredBG, minCOBPredBG, blendedMinPredBG));
         // if carbs have been entered, but have expired, use avg of minIOBPredBG and minUAMPredBG
         } else {
-            minPredBG = avgMinPredBG;
+            minPredBG = minUAMPredBG;
         }
     // in pure UAM mode, use the higher of minIOBPredBG,minUAMPredBG
     } else if ( enableUAM ) {


### PR DESCRIPTION
Rather than using a hard cutoff of 75% of carbs to switch minGuardBG over from COBpredBGs to UAMpredBGs, this calculates a minGuardBG for each of COB, UAM, and IOB, and blends the minCOBGuardBG and minUAMGuardBG according to what % of carbs have absorbed.  This allows oref0 to be less aggressive (particularly with SMBs) when carbs are overestimated or CR is too low and UAMpredBGs are running much lower than COBpredBGs.

@PieterGit this one might also be helpful for you.