### PR TITLE
Attempting to --nogit by default for existing user installs

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -499,6 +499,11 @@ echocolor-n "Continue? y/[N] "
 read -r
 if [[ $REPLY =~ ^[Yy]$ ]]; then
 
+    # Attempting to remove git to make install --nogit by default for existing users
+    echo Removing any existing git
+    rm -rf ~/myopenaps/.git
+    echo Removed any existing git
+
     # TODO: delete this after openaps 0.2.1 release
     echo Checking openaps 0.2.1 installation with --nogit support
     if ! openaps --version 2>&1 | egrep "0.[2-9].[1-9]"; then
@@ -507,9 +512,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 
     echo -n "Checking $directory: "
     mkdir -p $directory
-    if ( cd $directory && ls openaps.ini 2>/dev/null >/dev/null && openaps use -h >/dev/null ); then
-        echo $directory already exists
-    elif openaps init $directory --nogit; then
+    # if ( cd $directory && ls openaps.ini 2>/dev/null >/dev/null && openaps use -h >/dev/null ); then
+     #   echo $directory already exists
+    if openaps init $directory --nogit; then
         echo $directory initialized
     else
         die "Can't init $directory"


### PR DESCRIPTION
Thanks to the amazing @Kdisimone as always for the first round of testing, confirmed it successfully installs and removes an existing git directory.

Looks like this after starting setup:
![screen shot 2017-10-06 at 2 25 36 pm](https://user-images.githubusercontent.com/7468165/31299257-672b9eac-aaa2-11e7-8ceb-3dc5b766a30e.png)

And then it successfully removed .git

For anyone else who wants to test:
1. `cd ~/myopenaps` and `ls -la` (you should see .git listed in the alphabetical list - we need this tested on rigs that still have git)
2. `cd ~/src/oref0/ && git fetch && git checkout no-git-default && git pull`
3. `npm run global-install`
4. `bash ~/myopenaps/oref0-runagain.sh`
5. Once done, `ls -la` again in `myopenaps` and confirm that .git no longer exists there.
*(If you're planning to stay on this branch vs. switching back to dev, make sure to re-set your preferences!)*
