### PR TITLE
Don't send stale pushovers

### DIFF
--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -16,12 +16,10 @@ fi
 date
 if find monitor/ -mmin -$SNOOZE | grep -q pushover-sent; then
     echo "Last pushover sent less than $SNOOZE minutes ago."
-elif ! find $FILE -mmin -$SNOOZE | grep -q $FILE; then
-    echo "$FILE more than $SNOOZE minutes old"
+elif ! find $FILE -mmin -5 | grep -q $FILE; then
+    echo "$FILE more than 5 minutes old"
 elif ! cat $FILE | egrep "add'l|maxBolus"; then
     echo "No additional carbs or bolus required."
 else
     curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
-    # delete smb-suggested.json to avoid duplicate notifications if this rig can't loop for 15m
-    rm $FILE
 fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -22,4 +22,6 @@ elif ! cat $FILE | egrep "add'l|maxBolus"; then
     echo "No additional carbs or bolus required."
 else
     curl -s -F "token=$TOKEN" -F "user=$USER" -F "sound=$SOUND" -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent
+    # delete smb-suggested.json to avoid duplicate notifications if this rig can't loop for 15m
+    rm $FILE
 fi


### PR DESCRIPTION
Previously, if a rig sent a pushover, then generated a new smb-suggested.json, and then stopped looping (because the pump walked away), it would send one more pushover alert with the last calculated carbsReq (and an old BG value) after 15m.  This instead forces the smb-suggested.json to be current (<5m old) to generate a pushover alert.