### PR TITLE
Pumphistory safety checks

### DIFF
--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -219,7 +219,7 @@ if (!module.parent) {
     }
 
     console.error(JSON.stringify(glucose_status));
-    console.error(JSON.stringify(currenttemp));
+    //console.error(JSON.stringify(currenttemp));
     //console.error(JSON.stringify(profile));
 
     var tempBasalFunctions = require('oref0/lib/basal-set-temp');

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -45,7 +45,6 @@ smb_main() {
             && ( preflight || preflight ) \
             && if_mdt_get_bg \
             && refresh_old_pumphistory_24h \
-            && refresh_old_pumphistory \
             && refresh_old_profile \
             && touch /tmp/pump_loop_enacted -r monitor/glucose.json \
             && ( smb_check_everything \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -48,7 +48,6 @@ smb_main() {
             && refresh_old_pumphistory \
             && refresh_old_profile \
             && touch /tmp/pump_loop_enacted -r monitor/glucose.json \
-            && refresh_smb_temp_and_enact \
             && ( smb_check_everything \
                 && if (grep -q '"units":' enact/smb-suggested.json); then
                     ( smb_bolus && \

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -166,7 +166,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // compare currenttemp to iob_data.lastTemp and cancel temp if they don't match
     var lastTempAge = round(( new Date().getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
     //console.error("currenttemp:",currenttemp,"lastTemp:",JSON.stringify(iob_data.lastTemp),"lastTempAge:",lastTempAge,"m");
-    console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m");
+    tempModulus = (lastTempAge + currenttemp.duration) % 30;
+    console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m","tempModulus:",tempModulus,"m");
     if ( currenttemp.rate != iob_data.lastTemp.rate ) {
         rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; setting neutral temp of "+basal+".";
         return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
@@ -177,13 +178,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
         //console.error(lastTempAge, round(iob_data.lastTemp.duration,1), round(lastTempAge - iob_data.lastTemp.duration,1));
-        if ( lastTempAge - iob_data.lastTemp.duration > 5 ) {
-            rT.reason = "Warning: currenttemp running but lastTemp from pumphistory ended >5m ago; setting neutral temp of "+basal+".";
+        var lastTempEnded = lastTempAge - iob_data.lastTemp.duration
+        if ( lastTempEnded > 5 ) {
+            rT.reason = "Warning: currenttemp running but lastTemp from pumphistory ended "+lastTempEnded+"m ago; setting neutral temp of "+basal+".";
             //console.error(currenttemp, round(iob_data.lastTemp,1), round(lastTempAge,1));
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
-        tempModulus = (lastTempAge + currenttemp.duration) % 30;
-        console.error("tempModulus:",tempModulus);
         if ( tempModulus < 25 && tempModulus > 5 ) {
             rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" + lastTempAge "+lastTempAge+" isn't a multiple of 30m; setting neutral temp of "+basal+".";
             console.error(rT.reason);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -164,17 +164,20 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("");
 
     // compare currenttemp to iob_data.lastTemp and cancel temp if they don't match
-    var lastTempAge = round(( new Date().getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
+    var lastTempAge;
+    if (typeof iob_data.lastTemp !== 'undefined' ) {
+        lastTempAge = round(( new Date().getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
+    }
     //console.error("currenttemp:",currenttemp,"lastTemp:",JSON.stringify(iob_data.lastTemp),"lastTempAge:",lastTempAge,"m");
     tempModulus = (lastTempAge + currenttemp.duration) % 30;
     console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m","tempModulus:",tempModulus,"m");
     rT.temp = 'absolute';
     rT.deliverAt = deliverAt;
-    if ( currenttemp.rate != iob_data.lastTemp.rate ) {
+    if ( currenttemp && iob_data.lastTemp && currenttemp.rate != iob_data.lastTemp.rate ) {
         rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; setting neutral temp of "+basal+".";
         return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
     }
-    if ( currenttemp.duration > 0 ) {
+    if ( currenttemp && iob_data.lastTemp && currenttemp.duration > 0 ) {
         if ( currenttemp.duration < iob_data.lastTemp.duration - 2) {
             rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" << lastTemp duration "+round(iob_data.lastTemp.duration,1)+" from pumphistory; setting neutral temp of "+basal+".";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -169,22 +169,26 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     tempModulus = (lastTempAge + currenttemp.duration) % 30;
     console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m","tempModulus:",tempModulus,"m");
     if ( currenttemp.rate != iob_data.lastTemp.rate ) {
+        rT.deliverAt = deliverAt;
         rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; setting neutral temp of "+basal+".";
         return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
     }
     if ( currenttemp.duration > 0 ) {
         if ( currenttemp.duration < iob_data.lastTemp.duration - 2) {
+            rT.deliverAt = deliverAt;
             rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" << lastTemp duration "+round(iob_data.lastTemp.duration,1)+" from pumphistory; setting neutral temp of "+basal+".";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
         //console.error(lastTempAge, round(iob_data.lastTemp.duration,1), round(lastTempAge - iob_data.lastTemp.duration,1));
         var lastTempEnded = lastTempAge - iob_data.lastTemp.duration
         if ( lastTempEnded > 5 ) {
+            rT.deliverAt = deliverAt;
             rT.reason = "Warning: currenttemp running but lastTemp from pumphistory ended "+lastTempEnded+"m ago; setting neutral temp of "+basal+".";
             //console.error(currenttemp, round(iob_data.lastTemp,1), round(lastTempAge,1));
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
         if ( tempModulus < 25 && tempModulus > 5 ) {
+            rT.deliverAt = deliverAt;
             rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" + lastTempAge "+lastTempAge+" isn't a multiple of 30m; setting neutral temp of "+basal+".";
             console.error(rT.reason);
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -163,6 +163,27 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
     console.error("");
 
+    // compare currenttemp to iob_data.lastTemp and cancel temp if they don't match
+    var lastTempAge = round(( new Date().getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
+    //console.error("currenttemp:",currenttemp,"lastTemp:",JSON.stringify(iob_data.lastTemp),"lastTempAge:",lastTempAge,"m");
+    console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m");
+    if ( currenttemp.rate != iob_data.lastTemp.rate ) {
+        console.error("Warning: currenttemp rate",currenttemp.rate,"!= lastTemp rate",iob_data.lastTemp.rate,"from pumphistory; canceling temp basal");
+        return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+    }
+    if ( currenttemp.duration > 0 ) {
+        if ( currenttemp.duration < iob_data.lastTemp.duration - 2) {
+            console.error("Warning: currenttemp duration",currenttemp.duration,"<< lastTemp duration",round(iob_data.lastTemp.duration,1),"from pumphistory; canceling temp basal");
+            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+        }
+        //console.error(lastTempAge, round(iob_data.lastTemp.duration,1), round(lastTempAge - iob_data.lastTemp.duration,1));
+        if ( lastTempAge - iob_data.lastTemp.duration > 5 ) {
+            console.error("Warning: currenttemp running but lastTemp from pumphistory ended >5m ago; canceling temp basal");
+            //console.error(currenttemp, round(iob_data.lastTemp,1), round(lastTempAge,1));
+            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+        }
+    }
+
     //calculate BG impact: the amount BG "should" be rising or falling based on insulin activity alone
     var bgi = round(( -iob_data.activity * sens * 5 ), 2);
     // project deviations for 30 minutes

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -168,19 +168,26 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     //console.error("currenttemp:",currenttemp,"lastTemp:",JSON.stringify(iob_data.lastTemp),"lastTempAge:",lastTempAge,"m");
     console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m");
     if ( currenttemp.rate != iob_data.lastTemp.rate ) {
-        console.error("Warning: currenttemp rate",currenttemp.rate,"!= lastTemp rate",iob_data.lastTemp.rate,"from pumphistory; canceling temp basal");
-        return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+        rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; setting neutral temp of "+basal+".";
+        return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
     }
     if ( currenttemp.duration > 0 ) {
         if ( currenttemp.duration < iob_data.lastTemp.duration - 2) {
-            console.error("Warning: currenttemp duration",currenttemp.duration,"<< lastTemp duration",round(iob_data.lastTemp.duration,1),"from pumphistory; canceling temp basal");
-            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+            rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" << lastTemp duration "+round(iob_data.lastTemp.duration,1)+" from pumphistory; setting neutral temp of "+basal+".";
+            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
         //console.error(lastTempAge, round(iob_data.lastTemp.duration,1), round(lastTempAge - iob_data.lastTemp.duration,1));
         if ( lastTempAge - iob_data.lastTemp.duration > 5 ) {
-            console.error("Warning: currenttemp running but lastTemp from pumphistory ended >5m ago; canceling temp basal");
+            rT.reason = "Warning: currenttemp running but lastTemp from pumphistory ended >5m ago; setting neutral temp of "+basal+".";
             //console.error(currenttemp, round(iob_data.lastTemp,1), round(lastTempAge,1));
-            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+        }
+        tempModulus = (lastTempAge + currenttemp.duration) % 30;
+        console.error("tempModulus:",tempModulus);
+        if ( tempModulus < 25 && tempModulus > 5 ) {
+            rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" + lastTempAge "+lastTempAge+" isn't a multiple of 30m; setting neutral temp of "+basal+".";
+            console.error(rT.reason);
+            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
     }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -189,11 +189,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             //console.error(currenttemp, round(iob_data.lastTemp,1), round(lastTempAge,1));
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
-        if ( tempModulus < 25 && tempModulus > 5 ) {
-            rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" + lastTempAge "+lastTempAge+" isn't a multiple of 30m; setting neutral temp of "+basal+".";
-            console.error(rT.reason);
-            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-        }
+        // TODO: figure out a way to do this check that doesn't fail across basal schedule boundaries
+        //if ( tempModulus < 25 && tempModulus > 5 ) {
+            //rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" + lastTempAge "+lastTempAge+" isn't a multiple of 30m; setting neutral temp of "+basal+".";
+            //console.error(rT.reason);
+            //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+        //}
     }
 
     //calculate BG impact: the amount BG "should" be rising or falling based on insulin activity alone

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -178,10 +178,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
     }
     if ( currenttemp && iob_data.lastTemp && currenttemp.duration > 0 ) {
-        if ( currenttemp.duration < iob_data.lastTemp.duration - 2) {
-            rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" << lastTemp duration "+round(iob_data.lastTemp.duration,1)+" from pumphistory; setting neutral temp of "+basal+".";
-            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-        }
+        // TODO: fix this (lastTemp.duration is how long it has run; currenttemp.duration is time left
+        //if ( currenttemp.duration < iob_data.lastTemp.duration - 2) {
+            //rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" << lastTemp duration "+round(iob_data.lastTemp.duration,1)+" from pumphistory; setting neutral temp of "+basal+".";
+            //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+        //}
         //console.error(lastTempAge, round(iob_data.lastTemp.duration,1), round(lastTempAge - iob_data.lastTemp.duration,1));
         var lastTempEnded = lastTempAge - iob_data.lastTemp.duration
         if ( lastTempEnded > 5 ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -168,27 +168,25 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     //console.error("currenttemp:",currenttemp,"lastTemp:",JSON.stringify(iob_data.lastTemp),"lastTempAge:",lastTempAge,"m");
     tempModulus = (lastTempAge + currenttemp.duration) % 30;
     console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m","tempModulus:",tempModulus,"m");
+    rT.temp = 'absolute';
+    rT.deliverAt = deliverAt;
     if ( currenttemp.rate != iob_data.lastTemp.rate ) {
-        rT.deliverAt = deliverAt;
         rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; setting neutral temp of "+basal+".";
         return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
     }
     if ( currenttemp.duration > 0 ) {
         if ( currenttemp.duration < iob_data.lastTemp.duration - 2) {
-            rT.deliverAt = deliverAt;
             rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" << lastTemp duration "+round(iob_data.lastTemp.duration,1)+" from pumphistory; setting neutral temp of "+basal+".";
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
         //console.error(lastTempAge, round(iob_data.lastTemp.duration,1), round(lastTempAge - iob_data.lastTemp.duration,1));
         var lastTempEnded = lastTempAge - iob_data.lastTemp.duration
         if ( lastTempEnded > 5 ) {
-            rT.deliverAt = deliverAt;
             rT.reason = "Warning: currenttemp running but lastTemp from pumphistory ended "+lastTempEnded+"m ago; setting neutral temp of "+basal+".";
             //console.error(currenttemp, round(iob_data.lastTemp,1), round(lastTempAge,1));
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         }
         if ( tempModulus < 25 && tempModulus > 5 ) {
-            rT.deliverAt = deliverAt;
             rT.reason = "Warning: currenttemp duration "+currenttemp.duration+" + lastTempAge "+lastTempAge+" isn't a multiple of 30m; setting neutral temp of "+basal+".";
             console.error(rT.reason);
             return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
@@ -263,7 +261,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var threshold = min_bg - 0.5*(min_bg-40);
 
     //console.error(reservoir_data);
-    var deliverAt = new Date();
 
     rT = {
         'temp': 'absolute'

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -34,6 +34,7 @@ function generate (inputs, currentIOBOnly, treatments) {
         } else if (typeof(treatment.rate) === 'number' && treatment.duration ) {
             if ( treatment.date > lastTemp.date ) {
                 lastTemp = treatment;
+                lastTemp.duration = Math.round(lastTemp.duration*100)/100;
             }
 
             //console.error(treatment.rate, treatment.duration, treatment.started_at,lastTemp.started_at)

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -24,12 +24,21 @@ function generate (inputs, currentIOBOnly, treatments) {
     var clock = new Date(tz(inputs.clock));
 
     var lastBolusTime = new Date(0).getTime(); //clock.getTime());
+    var lastTemp = {};
+    lastTemp.date = new Date(0).getTime(); //clock.getTime());
     //console.error(treatments[treatments.length-1]);
     treatments.forEach(function(treatment) {
         if (treatment.insulin && treatment.started_at) {
             lastBolusTime = Math.max(lastBolusTime,treatment.started_at);
             //console.error(treatment.insulin,treatment.started_at,lastBolusTime);
+        } else if (typeof(treatment.rate) === 'number' && treatment.duration ) {
+            if ( treatment.date > lastTemp.date ) {
+                lastTemp = treatment;
+            }
+
+            //console.error(treatment.rate, treatment.duration, treatment.started_at,lastTemp.started_at)
         }
+        //console.error(treatment.rate, treatment.duration, treatment.started_at,lastTemp.started_at)
         //if (treatment.insulin && treatment.started_at) { console.error(treatment.insulin,treatment.started_at,lastBolusTime); }
     });
     var iStop;
@@ -48,6 +57,7 @@ function generate (inputs, currentIOBOnly, treatments) {
     }
     //console.error(lastBolusTime);
     iobArray[0].lastBolusTime = lastBolusTime;
+    iobArray[0].lastTemp = lastTemp;
     return iobArray;
 }
 


### PR DESCRIPTION
@hilarykoch recently experienced an A52 error that rebooted the pump and somehow caused decocare/openaps to prematurely stop parsing pumphistory such that it didn't return an error but didn't include recent events.  This in turn resulted in incorrect IOB, causing OpenAPS to overdose insulin, providing Leo with an unscheduled pump break and dessert.

This PR adds some safety checks to make sure that pumphistory is being updated, and that the lastTemp in pumphistory matches the currently running temp basal on the pump.