### PR TITLE
fix BG interpolation for COB calculation

### DIFF
--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -67,26 +67,26 @@ function detectCarbAbsorption(inputs) {
             }
         }
         var elapsed_minutes = (bgTime - lastbgTime)/(60*1000);
-//if (foundPreMealBG) { console.error(bgTime, lastbgTime, elapsed_minutes); }
+    //console.error(bgTime, lastbgTime, elapsed_minutes);
         if(Math.abs(elapsed_minutes) > 8) {
             // interpolate missing data points
             lastbg = glucose_data[i-1].glucose;
             elapsed_minutes = Math.abs(elapsed_minutes);
             //console.error(elapsed_minutes);
             while(elapsed_minutes > 5) {
-                nextbgTime = new Date(lastbgTime.getTime() + 5 * 60*1000);
+                previousbgTime = new Date(lastbgTime.getTime() - 5 * 60*1000);
                 j++;
                 bucketed_data[j] = [];
-                bucketed_data[j].date = nextbgTime.getTime();
+                bucketed_data[j].date = previousbgTime.getTime();
                 gapDelta = glucose_data[i].glucose - lastbg;
                 //console.error(gapDelta, lastbg, elapsed_minutes);
-                nextbg = lastbg + (5/elapsed_minutes * gapDelta);
-                bucketed_data[j].glucose = Math.round(nextbg);
+                previousbg = lastbg + (5/elapsed_minutes * gapDelta);
+                bucketed_data[j].glucose = Math.round(previousbg);
                 //console.error("Interpolated", bucketed_data[j]);
 
                 elapsed_minutes = elapsed_minutes - 5;
-                lastbg = nextbg;
-                lastbgTime = new Date(nextbgTime);
+                lastbg = previousbg;
+                lastbgTime = new Date(previousbgTime);
             }
 
         } else if(Math.abs(elapsed_minutes) > 2) {
@@ -96,6 +96,7 @@ function detectCarbAbsorption(inputs) {
         } else {
             bucketed_data[j].glucose = (bucketed_data[j].glucose + glucose_data[i].glucose)/2;
         }
+        //console.error(bucketed_data[j].date)
     }
     var currentDeviation;
     var slopeFromMaxDeviation = 0;
@@ -174,6 +175,7 @@ function detectCarbAbsorption(inputs) {
             ci = Math.max(deviation, currentDeviation/2, profile.min_5m_carbimpact);
             absorbed = ci * profile.carb_ratio / sens;
             // and add that to the running total carbsAbsorbed
+            //console.error("carbsAbsorbed:",carbsAbsorbed,"absorbed:",absorbed,"bgTime:",bgTime,"BG:",bucketed_data[i].glucose)
             carbsAbsorbed += absorbed;
         }
     }

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -51,7 +51,7 @@ function recentCarbs(opts, time) {
                 var myCarbsAbsorbed = calcMealCOB(COB_inputs).carbsAbsorbed;
                 var myMealCOB = Math.max(0, carbs - myCarbsAbsorbed);
                 mealCOB = Math.max(mealCOB, myMealCOB);
-                //console.error(myMealCOB, mealCOB, carbs);
+                //console.error("myMealCOB:",myMealCOB, "mealCOB:",mealCOB, "carbs:",carbs,"myCarbsAbsorbed:",myCarbsAbsorbed);
                 if (myMealCOB < mealCOB) {
                     carbsToRemove += parseFloat(treatment.carbs);
                 } else {


### PR DESCRIPTION
This fixes a bug in COB calculation that was causing COB to decay to zero too quickly (and in other cases can cause it to decay too slowly) when carbs were entered during a sensor restart or other BG data gap.