### PR TITLE
Retry microbolus before next BG if needed

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -532,6 +532,8 @@ function refresh_profile {
 function wait_for_bg {
     if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
         echo "MDT CGM configured; not waiting"
+    elif egrep -q "Waiting 0.[0-9]m to microbolus again." enact/smb-suggested.json; then
+        echo "Retrying microbolus without waiting for new BG"
     else
         echo -n "Waiting up to 4 minutes for new BG: "
         for i in `seq 1 24`; do


### PR DESCRIPTION
When an SMB pump-loop finishes right before a new BG comes in, the next SMB can't be issued unless it's been 2 minutes since the last bolus.  Previously, that would result in that SMB being skipped, and the rig waiting for the next BG after that to get back on schedule.  This allows oref0-pump-loop to skip the wait for new BG if it's waiting to do an SMB.