### PR TITLE
oref0-ns-loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ coverage/
 
 npm-debug.log
 bin/__pycache__
+
+package-lock.json

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -47,7 +47,8 @@ function ns_temptargets {
     openaps report invoke settings/temptargets.json settings/profile.json >/dev/null
     # TODO: merge local-temptargets.json with ns-temptargets.json
     #openaps report invoke settings/ns-temptargets.json settings/profile.json
-    echo Refreshed temptargets
+    echo -n "Refreshed temptargets: "
+    cat settings/temptargets.json | jq -c -C '.[0] | { target: .targetBottom, duration: .duration }'
 }
 
 # openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #echo Starting ns-loop at $(date): && openaps get-ns-bg; sensors -u 2>/dev/null | awk '$NF > 85' | grep input || ( openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload )
 
-# main pump-loop
+# main ns-loop
 main() {
     echo
     echo Starting oref0-ns-loop at $(date):

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -16,7 +16,7 @@ main() {
 function overtemp {
     # check for CPU temperature above 85°C
     sensors -u 2>/dev/null | awk '$NF > 85' | grep input \
-    && echo Rig is too hot: waiting for it to cool down at $(date)\
+    && echo Edison is too hot: waiting for it to cool down at $(date)\
     && echo Please ensure rig is properly ventilated
 }
 
@@ -55,7 +55,7 @@ function ns_meal_carbs {
     openaps report invoke monitor/carbhistory.json >/dev/null
     oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
     grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
-    echo -n "COB: "
+    echo -n "Refreshed carbhistory; COB: "
     grep COB monitor/meal.json | jq .mealCOB
 }
 

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -11,7 +11,6 @@ main() {
     ns_meal_carbs || die "ns_meal_carbs failed"
     echo " and meal carbs"
     upload
-    fi
 }
 
 function overtemp {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -3,12 +3,14 @@
 
 # main pump-loop
 main() {
+    echo
     echo Starting oref0-ns-loop at $(date):
     get_ns_bg
     overtemp && exit 1
     ns_temptargets || die "ns_temptargets failed"
     ns_meal_carbs || die ", but ns_meal_carbs failed"
     upload
+    echo Completed oref0-ns-loop at $(date)
 }
 
 function overtemp {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -3,7 +3,7 @@
 
 # main pump-loop
 main() {
-    echo Starting ns-loop at $(date):
+    echo Starting oref0-ns-loop at $(date):
     get_ns_bg
     overtemp && exit 1
     ns_temptargets || die "ns_temptargets failed"
@@ -65,7 +65,7 @@ function upload {
 
 # grep -q iob monitor/iob.json && find enact/ -mmin -5 -size +5c | grep -q suggested.json && openaps format-ns-status && grep -q iob upload/ns-status.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json
 function upload_ns_status {
-    echo Uploading devicestatus
+    #echo Uploading devicestatus
     grep -q iob monitor/iob.json || die "IOB not found"
     if ! find enact/ -mmin -5 -size +5c | grep -q suggested.json; then
         echo -n "No recent suggested.json found; last updated "
@@ -83,7 +83,7 @@ function format_ns_status {
 
 #openaps format-latest-nightscout-treatments && test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0 && (ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json ) || echo \\\"No recent treatments to upload\\\"
 function upload_recent_treatments {
-    echo Uploading treatments
+    #echo Uploading treatments
     format_latest_nightscout_treatments || die "Couldn't format latest NS treatments"
     if test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0; then
         ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json || die "Couldn't upload latest treatments to NS"

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -60,7 +60,8 @@ function ns_meal_carbs {
 # echo -n Upload && ( openaps upload-ns-status; openaps upload-pumphistory-entries; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed
 function upload {
     echo -n Upload
-    ( upload_ns_status; upload_recent_treatments ) 2>/dev/null >/dev/null || die " failed"
+    upload_ns_status >/dev/null || die "; NS status upload failed"
+    upload_recent_treatments >/dev/null || die "; NS treatments upload failed"
     echo ed
 }
 

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#echo Starting ns-loop at $(date): && openaps get-ns-bg; sensors -u 2>/dev/null | awk '$NF > 85' | grep input || ( openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload )
+
+# main pump-loop
+main() {
+    echo Starting ns-loop at $(date):
+    get_ns_bg
+    overtemp && exit 1
+    ns_temptargets || die "ns_temptargets failed"
+    echo -n Refreshed temptargets
+    ns_meal_carbs || die "ns_meal_carbs failed"
+    echo " and meal carbs"
+    upload
+    fi
+}
+
+function overtemp {
+    # check for CPU temperature above 85°C
+    sensors -u 2>/dev/null | awk '$NF > 85' | grep input \
+    && echo Rig is too hot: waiting for it to cool down at $(date)\
+    && echo Please ensure rig is properly ventilated
+}
+
+#openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json
+function get_ns_glucose {
+    # if ns-glucose.json data is <10m old, no more than 5m in the future, and valid (>38),
+    # copy cgm/ns-glucose.json over to cgm/glucose.json if it's newer
+    cat cgm/ns-glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json
+    # copy cgm/glucose.json over to monitor/glucose.json if it's newer
+    cp -pu cgm/glucose.json monitor/glucose.json
+}
+
+function ns_temptargets {
+    openaps report invoke settings/ns-temptargets.json settings/profile.json
+    # TODO: merge local-temptargets.json with ns-temptargets.json
+}
+
+# openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0
+function ns_meal_carbs {
+    openaps report invoke monitor/carbhistory.json
+    oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
+    grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
+    exit 0
+}
+
+# echo -n Upload && ( openaps upload-ns-status; openaps upload-pumphistory-entries; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed
+function upload {
+    echo -n Upload 
+    ( upload_ns_status; upload_recent_treatments ) 2>/dev/null >/dev/null || die " failed"
+    echo ed
+}
+
+# grep -q iob monitor/iob.json && find enact/ -mmin -5 -size +5c | grep -q suggested.json && openaps format-ns-status && grep -q iob upload/ns-status.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json
+function upload_ns_status {
+    grep -q iob monitor/iob.json \
+    && find enact/ -mmin -5 -size +5c | grep -q suggested.json \
+    && format_ns_status \
+    && grep -q iob upload/ns-status.json \
+    && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json
+}
+
+#ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json
+function format_ns_status {
+    ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json
+}
+
+#openaps format-latest-nightscout-treatments && test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0 && (ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json ) || echo \\\"No recent treatments to upload\\\"
+function upload_recent_treatments {
+    format_latest_nightscout_treatments \
+    && test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0 \
+    && (ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json ) || echo \\\"No recent treatments to upload\\\"
+}
+
+#nightscout cull-latest-openaps-treatments monitor/pumphistory-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
+function format_latest_nightscout_treatments {
+    nightscout cull-latest-openaps-treatments monitor/pumphistory-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
+}
+
+die() {
+    echo "$@"
+    exit 1
+}
+
+main "$@"

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -8,7 +8,7 @@ main() {
     overtemp && exit 1
     ns_temptargets || die "ns_temptargets failed"
     echo -n Refreshed temptargets
-    ns_meal_carbs || die "ns_meal_carbs failed"
+    ns_meal_carbs || die ", but ns_meal_carbs failed"
     echo " and meal carbs"
     upload
 }
@@ -54,7 +54,7 @@ function ns_meal_carbs {
     openaps report invoke monitor/carbhistory.json >/dev/null
     oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
     grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
-    exit 0
+    return 0
 }
 
 # echo -n Upload && ( openaps upload-ns-status; openaps upload-pumphistory-entries; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -7,9 +7,7 @@ main() {
     get_ns_bg
     overtemp && exit 1
     ns_temptargets || die "ns_temptargets failed"
-    echo -n Refreshed temptargets
     ns_meal_carbs || die ", but ns_meal_carbs failed"
-    echo " and meal carbs"
     upload
 }
 
@@ -47,6 +45,7 @@ function ns_temptargets {
     openaps report invoke settings/temptargets.json settings/profile.json >/dev/null
     # TODO: merge local-temptargets.json with ns-temptargets.json
     #openaps report invoke settings/ns-temptargets.json settings/profile.json
+    echo Refreshed temptargets
 }
 
 # openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0
@@ -54,7 +53,8 @@ function ns_meal_carbs {
     openaps report invoke monitor/carbhistory.json >/dev/null
     oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
     grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
-    return 0
+    echo -n "COB: "
+    grep COB monitor/meal.json | jq .mealCOB
 }
 
 # echo -n Upload && ( openaps upload-ns-status; openaps upload-pumphistory-entries; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -31,8 +31,9 @@ function get_ns_bg {
 }
 
 function ns_temptargets {
-    openaps report invoke settings/ns-temptargets.json settings/profile.json
+    openaps report invoke settings/temptargets.json settings/profile.json
     # TODO: merge local-temptargets.json with ns-temptargets.json
+    #openaps report invoke settings/ns-temptargets.json settings/profile.json
 }
 
 # openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -26,11 +26,11 @@ function get_ns_bg {
     valid_glucose=$(find_valid_ns_glucose)
     if echo $valid_glucose | grep -q glucose; then
         echo Found recent valid BG:
-        echo $valid_glucose | jq -c '.[0] | { glucose: .glucose, dateString: .dateString }'
+        echo $valid_glucose | jq -c -C '.[0] | { glucose: .glucose, dateString: .dateString }'
         cp -pu cgm/ns-glucose.json cgm/glucose.json
     else
         echo No recent valid BG found. Most recent:
-        cat cgm/ns-glucose.json | jq -c '.[0] | { glucose: .glucose, dateString: .dateString }'
+        cat cgm/ns-glucose.json | jq -c -C '.[0] | { glucose: .glucose, dateString: .dateString }'
     fi
 
     # copy cgm/glucose.json over to monitor/glucose.json if it's newer
@@ -73,7 +73,7 @@ function upload_ns_status {
         return 1
     fi
     format_ns_status && grep -q iob upload/ns-status.json || die "Couldn't generate ns-status.json"
-    ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json | jq '.[0].openaps.suggested | {BG: .bg, IOB: .IOB, rate: .rate, duration: .duration, units: .units}' -c || die "Couldn't upload devicestatus to NS"
+    ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json | jq -C -c '.[0].openaps.suggested | {BG: .bg, IOB: .IOB, rate: .rate, duration: .duration, units: .units}' || die "Couldn't upload devicestatus to NS"
 }
 
 #ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -60,8 +60,8 @@ function ns_meal_carbs {
 # echo -n Upload && ( openaps upload-ns-status; openaps upload-pumphistory-entries; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed
 function upload {
     echo -n Upload
-    upload_ns_status >/dev/null || die "; NS status upload failed"
-    upload_recent_treatments >/dev/null || die "; NS treatments upload failed"
+    upload_ns_status || die "; NS status upload failed"
+    upload_recent_treatments || die "; NS treatments upload failed"
 }
 
 # grep -q iob monitor/iob.json && find enact/ -mmin -5 -size +5c | grep -q suggested.json && openaps format-ns-status && grep -q iob upload/ns-status.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -44,14 +44,14 @@ function find_valid_ns_glucose {
 }
 
 function ns_temptargets {
-    openaps report invoke settings/temptargets.json settings/profile.json
+    openaps report invoke settings/temptargets.json settings/profile.json >/dev/null
     # TODO: merge local-temptargets.json with ns-temptargets.json
     #openaps report invoke settings/ns-temptargets.json settings/profile.json
 }
 
 # openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0
 function ns_meal_carbs {
-    openaps report invoke monitor/carbhistory.json
+    openaps report invoke monitor/carbhistory.json >/dev/null
     oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
     grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
     exit 0

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -21,7 +21,8 @@ function overtemp {
 }
 
 #openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json
-function get_ns_glucose {
+function get_ns_bg {
+    openaps get-ns-glucose
     # if ns-glucose.json data is <10m old, no more than 5m in the future, and valid (>38),
     # copy cgm/ns-glucose.json over to cgm/glucose.json if it's newer
     cat cgm/ns-glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -59,18 +59,17 @@ function ns_meal_carbs {
 
 # echo -n Upload && ( openaps upload-ns-status; openaps upload-pumphistory-entries; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed
 function upload {
-    echo -n Upload
     upload_ns_status || die "; NS status upload failed"
     upload_recent_treatments || die "; NS treatments upload failed"
 }
 
 # grep -q iob monitor/iob.json && find enact/ -mmin -5 -size +5c | grep -q suggested.json && openaps format-ns-status && grep -q iob upload/ns-status.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json
 function upload_ns_status {
-    grep -q iob monitor/iob.json \
-    && find enact/ -mmin -5 -size +5c | grep -q suggested.json \
-    && format_ns_status \
-    && grep -q iob upload/ns-status.json \
-    && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json | jq '.[0].openaps.suggested | {BG: .bg, IOB: .IOB, rate: .rate, duration: .duration, units: .units}' -c
+    echo Uploading devicestatus
+    grep -q iob monitor/iob.json || die "IOB not found"
+    find enact/ -mmin -5 -size +5c | grep -q suggested.json || die "suggested.json not found"
+    format_ns_status && grep -q iob upload/ns-status.json || die "Couldn't generate ns-status.json"
+    ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json | jq '.[0].openaps.suggested | {BG: .bg, IOB: .IOB, rate: .rate, duration: .duration, units: .units}' -c || die "Couldn't upload devicestatus to NS"
 }
 
 #ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -70,7 +70,7 @@ function upload_ns_status {
     && find enact/ -mmin -5 -size +5c | grep -q suggested.json \
     && format_ns_status \
     && grep -q iob upload/ns-status.json \
-    && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json
+    && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json upload/ns-status.json | jq '.[0].openaps.suggested | {BG: .bg, IOB: .IOB, rate: .rate, duration: .duration, units: .units}' -c
 }
 
 #ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -359,7 +359,7 @@ function mmtune {
     for i in $(seq 1 800); do
         echo -n .
         any_pump_comms 40 2>/dev/null | egrep -v subg | egrep -q No \
-        && echo "No interfering pump comms detected from other rigs (this is a good thing!)"
+        && echo "No interfering pump comms detected from other rigs (this is a good thing!)" \
         && break
     done
     echo {} > monitor/mmtune.json
@@ -412,7 +412,7 @@ function wait_for_silence {
     for i in $(seq 1 800); do
         echo -n .
         any_pump_comms $waitfor 2>/dev/null | egrep -v subg | egrep -q No \
-        && echo "No interfering pump comms detected from other rigs (this is a good thing!)"
+        && echo "No interfering pump comms detected from other rigs (this is a good thing!)" \
         && break
     done
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -358,7 +358,8 @@ function mmtune {
     echo -n "Listening for 40s silence before mmtuning: "
     for i in $(seq 1 800); do
         echo -n .
-        any_pump_comms 40 2>/dev/null | egrep -v subg | egrep No \
+        any_pump_comms 40 2>/dev/null | egrep -v subg | egrep -q No \
+        && echo "No interfering pump comms detected from other rigs (this is a good thing!)"
         && break
     done
     echo {} > monitor/mmtune.json
@@ -371,6 +372,8 @@ function mmtune {
         echo "waiting for $rssi_wait second silence before continuing"
         wait_for_silence $rssi_wait
         echo "Done waiting for rigs with better signal."
+    else
+        echo "No wait required."
     fi
 }
 
@@ -408,7 +411,8 @@ function wait_for_silence {
     echo -n "Listening: "
     for i in $(seq 1 800); do
         echo -n .
-        any_pump_comms $waitfor 2>/dev/null | egrep -v subg | egrep No \
+        any_pump_comms $waitfor 2>/dev/null | egrep -v subg | egrep -q No \
+        && echo "No interfering pump comms detected from other rigs (this is a good thing!)"
         && break
     done
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -378,8 +378,6 @@ function maybe_mmtune {
     if ( find /tmp/ -mmin -15 | egrep -q "pump_loop_completed" ); then
         # mmtune ~ 25% of the time
         [[ $(( ( RANDOM % 100 ) )) > 75 ]] \
-        && echo "Waiting for 40s silence before mmtuning" \
-        && wait_for_silence 40 \
         && mmtune
     else
         echo "pump_loop_completed more than 15m old; waiting for 40s silence before mmtuning"

--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -7,7 +7,7 @@
 # If it will restore within 5 minutes, then the reboot will be cancelled
 # Note that this is a workaround, until we found the root cause of why the rig pump communication fails
 
-radio_errors=`tail --lines=20 /var/log/openaps/pump-loop.log | egrep "spidev5.1 already in use|retry 0|TimeoutExpired. Killing process"`
+radio_errors=`tail --lines=20 /var/log/openaps/pump-loop.log | egrep "spidev.* already in use|retry 0|TimeoutExpired. Killing process"`
 logfile=/var/log/openaps/pump-loop.log
 if [ ! -z "$radio_errors" ]; then
     if [ ! -e /run/nologin ]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1010,7 +1010,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         elif ! [[ ${CGM,,} =~ "mdt" ]]; then # use nightscout for cgm
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
         fi
-        (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
+        (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'oref0-ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'oref0-ns-loop' || oref0-ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
         if [[ $ENABLE =~ autosens ]]; then
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens' || openaps autosens 2>&1" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens' || openaps autosens 2>&1 | tee -a /var/log/openaps/autosens-loop.log") | crontab -
         fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -640,7 +640,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         bluetoothdversioncompare=$(awk 'BEGIN{ print "'$bluetoothdversion'"<"'$bluetoothdminversion'" }')
         if [ "$bluetoothdversioncompare" -eq 1 ]; then
             killall bluetoothd &>/dev/null #Kill current running version if its out of date and we are updating it
-            cd $HOME/src/ && wget https://www.kernel.org/pub/linux/bluetooth/bluez-5.44.tar.gz && tar xvfz bluez-5.44.tar.gz || die "Couldn't download bluez"
+            cd $HOME/src/ && wget -4 https://www.kernel.org/pub/linux/bluetooth/bluez-5.44.tar.gz && tar xvfz bluez-5.44.tar.gz || die "Couldn't download bluez"
             cd $HOME/src/bluez-5.44 && ./configure --enable-experimental --disable-systemd && \
             make && sudo make install && sudo cp ./src/bluetoothd /usr/local/bin/ || die "Couldn't make bluez"
             oref0-bluetoothup

--- a/lib/oref0-setup/report.json
+++ b/lib/oref0-setup/report.json
@@ -1,7 +1,7 @@
 [
  {
     "type": "report",
-    "settings/ns-temptargets.json": {
+    "settings/temptargets.json": {
       "oper": "temp_targets",
       "use": "shell",
       "reporter": "JSON",
@@ -9,7 +9,7 @@
       "remainder": "-6hours",
       "json_default": "True"
     },
-    "name": "settings/ns-temptargets.json"
+    "name": "settings/temptargets.json"
   },
  {
     "type": "report",

--- a/lib/oref0-setup/report.json
+++ b/lib/oref0-setup/report.json
@@ -1,7 +1,7 @@
 [
  {
     "type": "report",
-    "settings/temptargets.json": {
+    "settings/ns-temptargets.json": {
       "oper": "temp_targets",
       "use": "shell",
       "reporter": "JSON",
@@ -9,7 +9,7 @@
       "remainder": "-6hours",
       "json_default": "True"
     },
-    "name": "settings/temptargets.json"
+    "name": "settings/ns-temptargets.json"
   },
  {
     "type": "report",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "oref0-log-shortcuts": "./bin/oref0-log-shortcuts.sh",
     "oref0-mdt-trend": "./bin/oref0-mdt-trend.js",
     "oref0-meal": "./bin/oref0-meal.js",
+    "oref0-ns-loop": "./bin/oref0-ns-loop.sh",
     "oref0-normalize-temps": "./bin/oref0-normalize-temps.js",
     "oref0_nightscout_check": "./bin/oref0_nightscout_check.py",
     "oref0-online": "./bin/oref0-online.sh",


### PR DESCRIPTION
Refactor `openaps ns-loop` into its own shell script, oref0-ns-loop.sh, and improve ns-loop logging significantly.

Also includes a fix for Pi Explorer HAT support, and some minor logging improvements to oref0-pump-loop.