### PR TITLE
raise SMB-disable threshold to > 20% of bg to catch fast carb rises

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -714,9 +714,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //rT.reason += "minGuardBG "+minGuardBG+"<"+threshold+": SMB disabled; ";
         enableSMB = false;
     }
-    if ( glucose_status.delta > 0.1 * bg ) {
-        console.error("Delta",glucose_status.delta,"> 10% of BG",bg,"- disabling SMB");
-        rT.reason += "Delta "+glucose_status.delta+" > 10% of BG "+bg+": SMB disabled; ";
+    if ( glucose_status.delta > 0.20 * bg ) {
+        console.error("Delta",glucose_status.delta,"> 20% of BG",bg,"- disabling SMB");
+        rT.reason += "Delta "+glucose_status.delta+" > 20% of BG "+bg+": SMB disabled; ";
         enableSMB = false;
     }
 


### PR DESCRIPTION
We added a safety check to avoid SMBing when delta is >10% of BG, in order to avoid overreacting to a noisy sensor, calibration jump, or other "fake" rise.  However, that threshold also prevented SMBing when it's needed most: when BG is rising fast from uncovered fast carbs.  This changes the threshold to 20%, which we've found is sufficiently high to allow SMBs when really needed.