### PR TITLE
fix logic fail for ! enableUAM case to set minGuardBG from COB

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -590,7 +590,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     // if we have both minCOBGuardBG and minUAMGuardBG, blend according to fractionCarbsLeft
-    if ( (cid || remainingCIpeak > 0) && enableUAM ) {
+    if ( (cid || remainingCIpeak > 0) ) {
         if ( enableUAM ) {
             minGuardBG = fractionCarbsLeft*minCOBGuardBG + (1-fractionCarbsLeft)*minUAMGuardBG;
         } else {


### PR DESCRIPTION
Per https://gitter.im/nightscout/intend-to-bolus?at=59e44ad9614889d475bcf91b @mackwe was seeing excessive zero temping after meal carb entry.  Turns out minGuardBG was getting set based on minIOBGuardBG instead of minCOBGuardBG due to a logic flaw.  This should fix that.