### PR TITLE
fix broken safety checks with a single pump-loop type

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# main pump-loop
-main() {
+# old pump-loop
+old_main() {
     prep
     if ! overtemp; then
         until( \
@@ -32,14 +32,19 @@ main() {
     fi
 }
 
-# main supermicrobolus loop
-smb_main() {
+# main pump-loop
+main() {
+    if [[ $1 == *"microbolus"* ]]; then
+        looptype="supermicrobolus";
+    else
+        looptype="basal-only";
+    fi
     prep
     if ! overtemp; then
         if ! ( \
             prep
             # checking to see if the log reports out that it is on % basal type, which blocks remote temps being set
-            echo && echo Starting supermicrobolus pump-loop at $(date) with $upto30s second wait_for_silence: \
+            echo && echo Starting $looptype pump-loop at $(date) with $upto30s second wait_for_silence: \
             && wait_for_bg \
             && wait_for_silence $upto30s \
             && ( preflight || preflight ) \
@@ -48,12 +53,12 @@ smb_main() {
             && refresh_old_profile \
             && touch /tmp/pump_loop_enacted -r monitor/glucose.json \
             && ( smb_check_everything \
-                && if (grep -q '"units":' enact/smb-suggested.json); then
+                && if ( [[ $1 == *"microbolus"* ]] && grep -q '"units":' enact/smb-suggested.json); then
                     ( smb_bolus && \
                         touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
                     ) \
                     || ( smb_old_temp && ( \
-                        echo "Falling back to normal pump-loop" \
+                        echo "Falling back to basal-only pump-loop" \
                         && refresh_temp_and_enact \
                         && refresh_pumphistory_and_enact \
                         && refresh_profile \
@@ -65,7 +70,7 @@ smb_main() {
                 ) \
                 && ( refresh_profile 15; refresh_pumphistory_24h; true ) \
                 && refresh_after_bolus_or_enact \
-                && echo Completed supermicrobolus pump-loop at $(date): \
+                && echo Completed $looptype pump-loop at $(date): \
                 && touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
                 && echo \
         ); then
@@ -581,8 +586,8 @@ die() {
     exit 1
 }
 
-if [[ $1 == *"microbolus"* ]]; then
-    smb_main "$@"
-else
+#if [[ $1 == *"microbolus"* ]]; then
+    #smb_main "$@"
+#else
     main "$@"
-fi
+#fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -55,7 +55,7 @@ main() {
             if ( grep -q '"units":' enact/smb-suggested.json); then
                 if [[ $1 == *"microbolus"* ]] ; then
                     if smb_bolus; then
-                        touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
+                        touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
                     else
                         smb_old_temp && ( \
                         echo "Falling back to basal-only pump-loop" \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -78,12 +78,12 @@ main() {
                 && touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
                 && echo \
         ); then
-            echo -n "SMB pump-loop failed. "
+            echo -n "$looptype pump-loop failed. "
             if grep -q "percent" monitor/temp_basal.json; then
                 echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
             fi
             maybe_mmtune
-            echo Unsuccessful supermicrobolus pump-loop at $(date)
+            echo Unsuccessful $looptype pump-loop at $(date)
         fi
     fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -68,7 +68,7 @@ main() {
                         )
                     fi
                 else
-                    touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
+                    touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
                 fi
             fi
             refresh_profile 15; refresh_pumphistory_24h

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -41,52 +41,57 @@ main() {
     fi
     prep
     if ! overtemp; then
-        if ! ( \
-            prep
-            # checking to see if the log reports out that it is on % basal type, which blocks remote temps being set
-            echo && echo Starting $looptype pump-loop at $(date) with $upto30s second wait_for_silence: \
-            && wait_for_bg \
-            && wait_for_silence $upto30s \
-            && ( preflight || preflight ) \
-            && if_mdt_get_bg \
-            && refresh_old_pumphistory_24h \
-            && refresh_old_profile \
-            && touch /tmp/pump_loop_enacted -r monitor/glucose.json \
-            && ( smb_check_everything \
-                && if ( grep -q '"units":' enact/smb-suggested.json); then
-                    if [[ $1 == *"microbolus"* ]]; then
-                        ( smb_bolus && \
-                            touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
-                        ) \
-                        || ( smb_old_temp && ( \
-                            echo "Falling back to basal-only pump-loop" \
-                            && refresh_temp_and_enact \
-                            && refresh_pumphistory_and_enact \
-                            && refresh_profile \
-                            && refresh_pumphistory_24h \
-                            && echo Completed pump-loop at $(date) \
-                            && echo \
-                            ))
-                    else
+        # checking to see if the log reports out that it is on % basal type, which blocks remote temps being set
+        prep
+        echo && echo "Starting $looptype pump-loop at $(date) with $upto30s second wait_for_silence:"
+        wait_for_bg || fail "$@"
+        wait_for_silence $upto30s || fail "$@"
+        preflight || preflight || fail "$@"
+        if_mdt_get_bg || fail "$@"
+        refresh_old_pumphistory_24h || fail "$@"
+        refresh_old_profile || fail "$@"
+        touch /tmp/pump_loop_enacted -r monitor/glucose.json || fail "$@"
+        if smb_check_everything; then
+            if ( grep -q '"units":' enact/smb-suggested.json); then
+                if [[ $1 == *"microbolus"* ]] ; then
+                    if smb_bolus; then
                         touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
+                    else
+                        smb_old_temp && ( \
+                        echo "Falling back to basal-only pump-loop" \
+                        && refresh_temp_and_enact \
+                        && refresh_pumphistory_and_enact \
+                        && refresh_profile \
+                        && refresh_pumphistory_24h \
+                        && echo Completed pump-loop at $(date) \
+                        && echo \
+                        )
                     fi
+                else
+                    touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
                 fi
-                ) \
-                && ( refresh_profile 15; refresh_pumphistory_24h; true ) \
-                && refresh_after_bolus_or_enact \
-                && echo Completed $looptype pump-loop at $(date): \
-                && touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
-                && echo \
-        ); then
-            echo -n "$looptype pump-loop failed. "
-            if grep -q "percent" monitor/temp_basal.json; then
-                echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
             fi
-            maybe_mmtune
-            echo Unsuccessful $looptype pump-loop at $(date)
+            refresh_profile 15; refresh_pumphistory_24h
+            refresh_after_bolus_or_enact
+            echo Completed $looptype pump-loop at $(date)
+            touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
+            echo
+        else
+            fail "$@"
         fi
     fi
 }
+
+function fail {
+    echo -n "$looptype pump-loop failed. "
+    if grep -q "percent" monitor/temp_basal.json; then
+        echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
+    fi
+    maybe_mmtune
+    echo Unsuccessful $looptype pump-loop at $(date)
+    exit 1
+}
+
 
 function overtemp {
     # check for CPU temperature above 85°C


### PR DESCRIPTION
Per https://github.com/openaps/oref0/issues/720 the recently added safety checks caused a regression for users of the non-SMB pump-loop.  To fix that, and make sure that future changes to oref0-pump-loop are more thoroughly tested, this deprecates the old pump-loop and consolidates both SMB and non-SMB use cases onto the one formerly known as smb_pump_loop.  The actual bolus commands are not executed if --microbolus is not passed, but everything else is done the same for both loop types.  This results in some extra status checks for non-SMB users, but that shouldn't hurt anything, and helps avoid problems like we saw with the safety checks making assumptions about the state of various data files that weren't met when the basal-only pump-loop did things in a different order.