### PR TITLE
Fix bluez upgrade

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -643,7 +643,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             killall bluetoothd &>/dev/null #Kill current running version if its out of date and we are updating it
             cd $HOME/src/ && wget -4 https://www.kernel.org/pub/linux/bluetooth/bluez-5.47.tar.gz && tar xvfz bluez-5.47.tar.gz || die "Couldn't download bluez"
             cd $HOME/src/bluez-5.47 && ./configure --enable-experimental --disable-systemd && \
-            make && sudo make install && sudo cp ./src/bluetoothd /usr/local/bin/ || die "Couldn't make bluez"
+            make && sudo make install || die "Couldn't make bluez"
+            killall bluetoothd &>/dev/null #Kill current running version if its out of date and we are updating it
+            sudo cp ./src/bluetoothd /usr/local/bin/ || die "Couldn't install bluez"
             oref0-bluetoothup
         else
             echo bluez v ${bluetoothdversion} already installed


### PR DESCRIPTION
If Bluetooth is already installed, oref0-online will attempt to start it back up while we're downloading and making bluez (to upgrade it per #724).  This change adds another killall bluetoothd again immediately before trying to install the newly compiled binary to prevent the copy from failing.