### PR TITLE
timeout ns-get curls after 30s

### DIFF
--- a/bin/ns-get.sh
+++ b/bin/ns-get.sh
@@ -57,7 +57,7 @@ case $1 in
     fi
     test -z "$NIGHTSCOUT_HOST" && usage && exit 1;
 
-    curl ${CURL_AUTH} ${CURL_FLAGS} $REPORT_ENDPOINT | $NIGHTSCOUT_FORMAT
+    curl -m 30 ${CURL_AUTH} ${CURL_FLAGS} $REPORT_ENDPOINT | $NIGHTSCOUT_FORMAT
 
     ;;
   type)
@@ -69,7 +69,7 @@ case $1 in
     ;;
   *)
     test -z "$NIGHTSCOUT_HOST" && usage && exit 1;
-    curl ${CURL_AUTH} ${CURL_FLAGS} $REPORT_ENDPOINT | $NIGHTSCOUT_FORMAT
+    curl -m 30 ${CURL_AUTH} ${CURL_FLAGS} $REPORT_ENDPOINT | $NIGHTSCOUT_FORMAT
     ;;
 esac
 


### PR DESCRIPTION
@cbrenner reported at https://gitter.im/nightscout/intend-to-bolus?at=59e6566ad6c36fca31635aeb that his rigs have been losing connectivity and ns-loop has been getting stuck and not recovering, stopping his loop.  This is likely because a curl gets into a state where it never completes until timing out.  We already limit ns-upload curls to 30s, so this does the same for ns-get.