### PR TITLE
round insulinReq down to safely allow eSMB on small basals

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -985,8 +985,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //console.error(lastBolusAge);
         //console.error(profile.temptargetSet, target_bg, rT.COB);
         // only allow microboluses with COB or low temp targets, or within DIA hours of a bolus
-        // only microbolus if 0.1U SMB represents 20m or less of basal (0.3U/hr or higher)
-        if (microBolusAllowed && enableSMB && profile.current_basal >= 0.3 && bg > threshold) {
+        if (microBolusAllowed && enableSMB && bg > threshold) {
             // never bolus more than maxSMBBasalMinutes worth of basal
             mealInsulinReq = round( meal_data.mealCOB / profile.carb_ratio ,3);
             if (typeof profile.maxSMBBasalMinutes == 'undefined' ) {
@@ -1000,8 +999,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 console.error("profile.maxSMBBasalMinutes:",profile.maxSMBBasalMinutes,"profile.current_basal:",profile.current_basal); 
                 maxBolus = round( profile.current_basal * profile.maxSMBBasalMinutes / 60 ,1);
             }
-            // bolus 1/2 the insulinReq, up to maxBolus
-            microBolus = round(Math.min(insulinReq/2,maxBolus),1);
+            // bolus 1/2 the insulinReq, up to maxBolus, rounding down to nearest 0.1U
+            microBolus = Math.floor(Math.min(insulinReq/2,maxBolus)*10)/10;
             // calculate a long enough zero temp to eventually correct back up to target
             var smbTarget = target_bg;
             var worstCaseInsulinReq = (smbTarget - (naive_eventualBG + minIOBPredBG)/2 ) / sens;


### PR DESCRIPTION
Now that eSMB allows maxSMBBasalMinutes > 30, and ZTpredBGs do a better job of preventing excess insulinReq from UAM unless there's enough carbs or time to zero temp to prevent a low, it should now be safe to allow the use of SMB on smaller basals.  The main change required to support that is that we need to round down all SMB amounts, such that (when in insulinReq/2 mode) a 0.1U SMB is not given until insulinReq reaches 0.2U, and 0.2U requires 0.4U, etc.  (Previously, a 0.11U insulinReq would generate a 0.06U SMB suggestion, which would be rounded to the nearest 0.1U.  Now, that will be rounded down to zero.)

All the same "please be careful and test everything thoroughly" caveats for SMB and eSMB still apply, but there should no longer be any technical limitation on how small basals can be to allow SMBs.  (If basals are small, SMBs will be rare, except when larger amounts of insulin are required, such as if you want to use no-bolus eSMB and enter carbs but don't bolus, for example).

We may want to keep the recommendation in place for now against SMB on small basals, but this should make things safer for anyone whose basals are near the threshold, and allow SMB to kick in when really needed.

Thoughts?  I'd like to get some discussion on this one before merging.