### PR TITLE
check preferences.json is valid json

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -88,7 +88,9 @@ function fail {
         echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
     fi
     maybe_mmtune
-    cat preferences.json | jq . || echo Error: syntax error in preferences.json
+    if ! cat preferences.json | jq . >/dev/null; then
+        echo Error: syntax error in preferences.json: please go correct your typo.
+    fi
     echo Unsuccessful $looptype pump-loop at $(date)
     exit 1
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -88,6 +88,7 @@ function fail {
         echo "Pssst! Your pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Change it to absolute u/hr, and temporary basal rates will then be able to be set."
     fi
     maybe_mmtune
+    cat preferences.json | jq . || echo Error: syntax error in preferences.json
     echo Unsuccessful $looptype pump-loop at $(date)
     exit 1
 }


### PR DESCRIPTION
Lots of people mess up their json syntax and then get cryptic errors that don't make it obvious that's what they've done.  This adds an explicit `jq .` check of preferences.json if the loop fails, and prints a clearer error message if so.

Is this clear enough?

```
ValueError: No JSON object could be decoded
supermicrobolus pump-loop failed. pump_loop_completed more than 15m old; waiting for 40s silence before mmtuning
Radio ok. Listening: ...............................................................................................No interfering pump comms detected from other rigs (this is a good thing!)
Listening for 40s silence before mmtuning: .No interfering pump comms detected from other rigs (this is a good thing!)
mmtune: "916.636", 5, -72 waiting for 24 second silence before continuing
Radio ok. Listening: .No interfering pump comms detected from other rigs (this is a good thing!)
Preflight OK. Done waiting for rigs with better signal.
parse error: Expected separator between values at line 20, column 12
Error: syntax error in preferences.json: please go correct your typo.
Unsuccessful supermicrobolus pump-loop at Sat Oct 21 22:17:25 MST 2017
```