### PR TITLE
Optimize oref0-ns-loop.sh

### DIFF
--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -7,7 +7,7 @@ main() {
     echo
     echo Starting oref0-ns-loop at $(date):
     if glucose_fresh; then
-        echo Glucose is fresh
+        echo Glucose file is fresh
         cat cgm/ns-glucose.json | jq -c -C '.[0] | { glucose: .glucose, dateString: .dateString }'
     else
         get_ns_bg
@@ -63,8 +63,8 @@ function completed_recently {
 }
 
 function glucose_fresh {
-    # check whether last glucose reading is more than 5m old (or in the future) and needs updated
-    cat cgm/ns-glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 5 && minAgo > -1 && this.glucose > 38" | grep glucose
+    # check whether ns-glucose.json is less than 5m old
+    find cgm -mmin -5 | egrep -q "ns-glucose.json"
 }
 
 function find_valid_ns_glucose {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -96,7 +96,8 @@ function ns_temptargets {
 
 # openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0
 function ns_meal_carbs {
-    openaps report invoke monitor/carbhistory.json >/dev/null
+    #openaps report invoke monitor/carbhistory.json >/dev/null
+    nightscout ns $NIGHTSCOUT_HOST $API_SECRET carb_history > monitor/carbhistory.json
     oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
     grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
     echo -n "Refreshed carbhistory; COB: "

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -6,11 +6,11 @@
 main() {
     echo
     echo Starting oref0-ns-loop at $(date):
-    if glucose_5m_old; then
-        get_ns_bg
-    else
+    if glucose_fresh; then
         echo Glucose is fresh
         cat cgm/ns-glucose.json | jq -c -C '.[0] | { glucose: .glucose, dateString: .dateString }'
+    else
+        get_ns_bg
     fi
     overtemp && exit 1
     if highload && completed_recently; then
@@ -62,9 +62,9 @@ function completed_recently {
     find /tmp/ -mmin -5 | egrep -q "ns-loop-completed"
 }
 
-function glucose_5m_old {
+function glucose_fresh {
     # check whether last glucose reading is more than 5m old (or in the future) and needs updated
-    cat cgm/ns-glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo > 5 || minAgo < -1"
+    cat cgm/ns-glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 5 && minAgo > -1 && this.glucose > 38" | grep glucose
 }
 
 function find_valid_ns_glucose {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -69,6 +69,7 @@ function completed_recently {
 
 function glucose_fresh {
     # check whether ns-glucose.json is less than 5m old
+    touch -d "$(date -R -d @$(jq .[0].date/1000 cgm/ns-glucose.json))" cgm/ns-glucose.json
     find cgm -mmin -5 | egrep -q "ns-glucose.json"
 }
 

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -42,7 +42,7 @@ function highload {
 #openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json
 function get_ns_bg {
     #openaps get-ns-glucose > /dev/null
-    if ! find cgm/ -mmin -55 | egrep -q cgm/ns-glucose-24h.json
+    if ! find cgm/ -mmin -55 | egrep -q cgm/ns-glucose-24h.json; then
         nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -24hours > cgm/ns-glucose-24h.json
     fi
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -1hour > cgm/ns-glucose-1h.json

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -41,7 +41,12 @@ function highload {
 
 #openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json
 function get_ns_bg {
-    openaps get-ns-glucose > /dev/null
+    #openaps get-ns-glucose > /dev/null
+    if ! find cgm/ -mmin -55 | egrep -q cgm/ns-glucose-24h.json
+        nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -24hours > cgm/ns-glucose-24h.json
+    fi
+    nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -1hour > cgm/ns-glucose-1h.json
+    jq -s '.[0] + .[1]|unique|sort_by(.date)|reverse' cgm/ns-glucose-24h.json cgm/ns-glucose-1h.json > cgm/ns-glucose.json
     # if ns-glucose.json data is <10m old, no more than 5m in the future, and valid (>38),
     # copy cgm/ns-glucose.json over to cgm/glucose.json if it's newer
     valid_glucose=$(find_valid_ns_glucose)
@@ -68,6 +73,7 @@ function glucose_fresh {
 }
 
 function find_valid_ns_glucose {
+    # TODO: use jq for this if possible
     cat cgm/ns-glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38"
 }
 


### PR DESCRIPTION
This includes various optimizations to make oref0-ns-loop run faster, particularly for Pi0 rigs.  It also causes it to skip non-essential ns-loop functions (everything other than getting new BG data) if system load is too high, to ensure that oref0-pump-loop can run.