### PR TITLE
Limit carb impact predictions to 30g/h

### DIFF
--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -116,7 +116,7 @@ function detectCarbAbsorption(inputs) {
         var delta;
         if (typeof(bucketed_data[i].glucose) != 'undefined') {
             bg = bucketed_data[i].glucose;
-            if ( bg < 40 || bucketed_data[i+3].glucose < 40) {
+            if ( bg < 39 || bucketed_data[i+3].glucose < 39) {
                 process.stderr.write("!");
                 continue;
             }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -345,6 +345,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // calculate current carb absorption rate, and how long to absorb all carbs
     // CI = current carb impact on BG in mg/dL/5m
     ci = round((minDelta - bgi),1);
+    // limit Carb Impact to 12 mg/dL per 5m
+    ci = Math.min(12, ci);
     uci = round((minDelta - bgi),1);
     // ISF (mg/dL/U) / CR (g/U) = CSF (mg/dL/g)
     // use autosens-adjusted sens to counteract autosens meal insulin dosing adjustmenst
@@ -414,8 +416,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else {
         cid = Math.min(remainingCATime*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
     }
-    // limit Carb Impact to 12 mg/dL per 5m
-    ci = Math.min(12, ci);
     acid = Math.max(0, meal_data.mealCOB * csf / aci );
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
     console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (~2h peak):",round(remainingCIpeak,1),"mg/dL per 5m");

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -345,13 +345,18 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // calculate current carb absorption rate, and how long to absorb all carbs
     // CI = current carb impact on BG in mg/dL/5m
     ci = round((minDelta - bgi),1);
-    // limit Carb Impact to 12 mg/dL per 5m
-    ci = Math.min(12, ci);
     uci = round((minDelta - bgi),1);
     // ISF (mg/dL/U) / CR (g/U) = CSF (mg/dL/g)
     // use autosens-adjusted sens to counteract autosens meal insulin dosing adjustmenst
     // so that autotuned CR is still in effect even when basals and ISF are being adjusted by autosens
     var csf = sens / profile.carb_ratio;
+    var maxCarbAbsorptionRate = 30; // g/h; maximum rate to assume carbs will absorb if no CI observed
+    // limit Carb Impact to maxCarbAbsorptionRate * csf in mg/dL per 5m
+    maxCI = round(maxCarbAbsorptionRate*csf*5/60,1)
+    if (ci > maxCI) {
+        console.error("Limiting carb impact from",ci,"to",maxCI,"mg/dL/5m (",maxCarbAbsorptionRate,"g/h )");
+        ci = maxCI;
+    }
     // set meal_carbimpact high enough to absorb all meal carbs over 6 hours
     // total_impact (mg/dL) = CSF (mg/dL/g) * carbs (g)
     //console.error(csf * meal_data.carbs);
@@ -362,12 +367,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     remainingCATimeMin = remainingCATimeMin / sensitivityRatio;
     // 20 g/h means that anything <= 60g will get a remainingCATimeMin, 80g will get 4h, and 120g 6h
     // when actual absorption ramps up it will take over from remainingCATime
-    var carbAbsorptionRate = 20; // g/h; maximum rate to assume carbs will absorb if no CI observed
+    var assumedCarbAbsorptionRate = 20; // g/h; maximum rate to assume carbs will absorb if no CI observed
     var remainingCATime;
     if (meal_data.carbs) {
-        // if carbs * carbAbsorptionRate > remainingCATimeMin, raise it
+        // if carbs * assumedCarbAbsorptionRate > remainingCATimeMin, raise it
         // so <= 90g is assumed to take 3h, and 120g=4h
-        remainingCATimeMin = Math.max(remainingCATimeMin, meal_data.mealCOB/carbAbsorptionRate);
+        remainingCATimeMin = Math.max(remainingCATimeMin, meal_data.mealCOB/assumedCarbAbsorptionRate);
         var lastCarbAge = round(( new Date().getTime() - meal_data.lastCarbTime ) / 60000);
         //console.error(meal_data.lastCarbTime, lastCarbAge);
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -414,6 +414,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else {
         cid = Math.min(remainingCATime*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
     }
+    // limit Carb Impact to 12 mg/dL per 5m
+    ci = Math.min(12, ci);
     acid = Math.max(0, meal_data.mealCOB * csf / aci );
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
     console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (~2h peak):",round(remainingCIpeak,1),"mg/dL per 5m");


### PR DESCRIPTION
When SMB'ing for very large meals of 120g (the maximum COB oref0 allows by default before capping it), we've seen low BG situations with lots of COB, presumably because insulin activity is so high that the liver starts storing all the incoming carbs as glycogen.  In order to help mitigate this, we want to prevent oref0 from assuming that very high current deviations will continue.  This change caps the maximum projected deviations at a rate equivalent to 30g/h for purposes of calculating COBpredBGs.  The slightly lower projected deviations slightly reduce how much it SMBs up front, and instead causes it to predict the carbs to hit a bit later on.  This does not affect UAMpredBGs, so they can start out rising faster than COBpredBGs, but are limited to 3h of total impact, so end up lower in this scenario.