### PR TITLE
disable SMB if either avgDelta is >20%

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -168,6 +168,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     //var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
     var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta);
     var minAvgDelta = Math.min(glucose_status.short_avgdelta, glucose_status.long_avgdelta);
+    var maxDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
 
     var profile_sens = round(profile.sens,1)
     var sens = profile.sens;
@@ -752,9 +753,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //rT.reason += "minGuardBG "+minGuardBG+"<"+threshold+": SMB disabled; ";
         enableSMB = false;
     }
-    if ( glucose_status.delta > 0.20 * bg ) {
-        console.error("Delta",glucose_status.delta,"> 20% of BG",bg,"- disabling SMB");
-        rT.reason += "Delta "+glucose_status.delta+" > 20% of BG "+bg+": SMB disabled; ";
+    if ( maxDelta > 0.20 * bg ) {
+        console.error("maxDelta",maxDelta,"> 20% of BG",bg,"- disabling SMB");
+        rT.reason += "maxDelta "+maxDelta+" > 20% of BG "+bg+": SMB disabled; ";
         enableSMB = false;
     }
 


### PR DESCRIPTION
When hot-swapping a sensor and looping off raw data, there is a very large initial jump in the reported raw BG value, which then quickly comes down and levels out at whatever level the new sensor is reading.  The current SMB safety check disallows SMBs on the initial jump, but allows them on subsequent readings (if IOB is low enough to warrant dosing off the high value despite the downtick).  To prevent SMBing off a falsely high reading, this change disallows SMBs if any of the delta, short_avgdelta, or long_avgdelta is > 20% of the current BG. 