### PR TITLE
pad up to 90m of zero deviations after site change

### DIFF
--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -309,12 +309,12 @@ function detectSensitivity(inputs) {
     process.stderr.write(" ");
     //console.log(JSON.stringify(avgDeltas));
     //console.log(JSON.stringify(bgis));
-    // when we have less than 8h worth of deviation data, add up to 1h of zero deviations
+    // when we have less than 8h worth of deviation data, add up to 90m of zero deviations
     // this dampens any large sensitivity changes detected based on too little data, without ignoring them completely
     console.error("");
     console.error("Using most recent",deviations.length,"deviations since",lastSiteChange);
     if (deviations.length < 96) {
-        pad = Math.round((1 - deviations.length/96) * 12);
+        pad = Math.round((1 - deviations.length/96) * 18);
         console.error("Adding",pad,"more zero deviations");
         for (var d=0; d<pad; d++) {
             //process.stderr.write(".");


### PR DESCRIPTION
Last night we saw an example of a site change followed by lots of positive deviations (likely meal-related, but not all excluded as such) that caused autosens to detect its maximum allowed resistance, and subsequently caused oref0 to be a bit too aggressive with SMB.  This change makes autosens pad up to 6 additional zero deviations after a site change, so it'd be less likely to detect resistance based on too-little data.