### PR TITLE
Only SMB every 3m; retry up to 2m

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -549,7 +549,7 @@ function refresh_profile {
 function wait_for_bg {
     if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
         echo "MDT CGM configured; not waiting"
-    elif egrep -q "Waiting 0.[0-9]m to microbolus again." enact/smb-suggested.json; then
+    elif egrep -q "Waiting [01].[0-9]m to microbolus again." enact/smb-suggested.json; then
         echo "Retrying microbolus without waiting for new BG"
     else
         echo -n "Waiting up to 4 minutes for new BG: "

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1033,11 +1033,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
             rT.reason += ". ";
 
-            //allow SMBs every 2 minutes
-            var nextBolusMins = round(2-lastBolusAge,1);
+            //allow SMBs every 3 minutes
+            var nextBolusMins = round(3-lastBolusAge,1);
             //console.error(naive_eventualBG, insulinReq, worstCaseInsulinReq, durationReq);
             console.error("naive_eventualBG",naive_eventualBG+",",durationReq+"m "+smbLowTempReq+"U/h temp needed; last bolus",lastBolusAge+"m ago; maxBolus: "+maxBolus);
-            if (lastBolusAge > 2) {
+            if (lastBolusAge > 3) {
                 if (microBolus > 0) {
                     rT.units = microBolus;
                     rT.reason += "Microbolusing " + microBolus + "U. ";


### PR DESCRIPTION
Now that we have a mechanism to retry SMBs when we are Waiting to microbolus again, we can allow SMBs a little less frequently, to reduce the chance of getting two SMBs based on the same BG data (and potentially delivering the full insulinReq, not just half of it).