### PR TITLE
check validity of iob.json and profile.json and refresh if invalid

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -156,8 +156,9 @@ function smb_suggest {
     rm -rf enact/smb-suggested.json
     ls enact/smb-suggested.json 2>/dev/null >/dev/null && die "enact/suggested.json present"
     # Run determine-basal
-    echo -n Temp refresh && openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json monitor/iob.json 2>&1 >/dev/null | tail -1 && echo ed
-    openaps report invoke enact/smb-suggested.json 2>&1 >/dev/null \
+    echo -n Temp refresh
+    openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json monitor/iob.json 2>&1 >/dev/null | tail -1
+    test ${PIPESTATUS[0]} -eq 0 && echo ed && openaps report invoke enact/smb-suggested.json 2>&1 >/dev/null \
     && cp -up enact/smb-suggested.json enact/suggested.json \
     && smb_verify_suggested
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -158,7 +158,8 @@ function smb_suggest {
     # Run determine-basal
     echo -n Temp refresh
     openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json monitor/iob.json 2>&1 >/dev/null | tail -1
-    test ${PIPESTATUS[0]} -eq 0 && echo ed && openaps report invoke enact/smb-suggested.json 2>&1 >/dev/null \
+    test ${PIPESTATUS[0]} -eq 0 && echo ed && \
+    oref0-determine-basal monitor/iob.json monitor/temp_basal.json monitor/glucose.json settings/profile.json settings/autosens.json monitor/meal.json --microbolus --reservoir monitor/reservoir.json > enact/smb-suggested.json \
     && cp -up enact/smb-suggested.json enact/suggested.json \
     && smb_verify_suggested
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -498,10 +498,10 @@ function refresh_old_profile {
         #if ! cat monitor/iob.json | jq . | grep -q iob; then
             #echo -n "Invalid iob.json: "
         #fi
+        set -x
         if cat settings/profile.json | jq . | grep -q basal; then
             : # do nothing
         else
-            set -x
             if cat settings/profile.json | jq . | grep -q basal; then
                 echo -n "Invalid profile.json: "
                 ls -lart settings/profile.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -506,12 +506,14 @@ function refresh_old_profile {
 
 # get-settings report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json settings/pumpprofile.json settings/profile.json
 function get_settings {
-    openaps report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json settings/pumpprofile.json
+    openaps report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json settings/pumpprofile.json 2>&1 >/dev/null | tail -1
     oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json | jq . > settings/profile.json.new || (echo "Couldn't refresh profile"; fail "$@")
     if cat settings/profile.json.new | jq . | grep -q basal; then
         mv settings/profile.json.new settings/profile.json
     else
-        echo "Invalid profile.json.new after refresh"; fail "$@"
+        echo "Invalid profile.json.new after refresh"
+        cat settings/profile.json.new | jq .current_basal
+        # fail "$@"
     fi
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -498,18 +498,22 @@ function refresh_old_profile {
         #if ! cat monitor/iob.json | jq . | grep -q iob; then
             #echo -n "Invalid iob.json: "
         #fi
-        set -x
+        #set -x
+        cp settings/profile.json /tmp/profile1.json
         if cat settings/profile.json | jq . | grep -q basal; then
             : # do nothing
         else
+            cp settings/profile.json /tmp/profile2.json
             if cat settings/profile.json | jq . | grep -q basal; then
                 echo -n "Invalid profile.json: "
-                ls -lart settings/profile.json
+                ls -lart settings/profile.json /tmp/profile*.json
                 cat settings/profile.json | jq . -C -c
+                cat /tmp/profile1.json | jq . -C -c
+                cat /tmp/profile2.json | jq . -C -c
             fi
             #echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
         fi
-        set +x
+        #set +x
     #fi
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -495,7 +495,7 @@ function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old" \
         || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed" )
     if cat settings/profile.json | jq . | grep -q basal; then
-        echo -n " and valid."
+        echo -n " and valid. "
     else
         echo -n " but invalid: "
         ls -lart settings/profile.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -492,29 +492,16 @@ function refresh_old_pumphistory_24h {
 
 # refresh settings/profile if it's more than 1h old
 function refresh_old_profile {
-    find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old. " \
-        || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. " )
-    #if ! cat monitor/iob.json | jq . | grep -q iob || ! cat settings/profile.json | jq . | grep -q basal; then
-        #if ! cat monitor/iob.json | jq . | grep -q iob; then
-            #echo -n "Invalid iob.json: "
-        #fi
-        #set -x
-        cp settings/profile.json /tmp/profile1.json
-        if cat settings/profile.json | jq . | grep -q basal; then
-            : # do nothing
-        else
-            cp settings/profile.json /tmp/profile2.json
-            if cat settings/profile.json | jq . | grep -q basal; then
-                echo -n "Invalid profile.json: "
-                ls -lart settings/profile.json /tmp/profile*.json
-                cat settings/profile.json | jq . -C -c
-                cat /tmp/profile1.json | jq . -C -c
-                cat /tmp/profile2.json | jq . -C -c
-            fi
-            #echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
-        fi
-        #set +x
-    #fi
+    find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old" \
+        || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed" )
+    if cat settings/profile.json | jq . | grep -q basal; then
+        echo -n " and valid."
+    else
+        echo -n " but invalid: "
+        ls -lart settings/profile.json
+        cat settings/profile.json | jq . -C -c
+        echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
+    fi
 }
 
 function refresh_smb_temp_and_enact {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -499,7 +499,7 @@ function refresh_old_profile {
     else
         echo -n " but invalid: "
         ls -lart settings/profile.json
-        cat settings/profile.json | jq . -C -c
+        cat settings/profile.json | jq -C -c .current_basal
         echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
     fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -496,11 +496,11 @@ function refresh_old_profile {
         #if ! cat monitor/iob.json | jq . | grep -q iob; then
             #echo -n "Invalid iob.json: "
         #fi
-        if ! cat settings/profile.json | jq . | grep -q basal; then
+        if ! cat settings/profile.json | jq . | grep basal; then
             echo -n "Invalid profile.json: "
             ls -lart settings/profile.json
             cat settings/profile.json | jq . -C -c
-            echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
+            #echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
         fi
     #fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -493,14 +493,14 @@ function refresh_old_pumphistory_24h {
 # refresh settings/profile if it's more than 1h old
 function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old" \
-        || (echo -n Old settings refresh && get_settings && echo -n "ed" )
+        || (echo -n "Old settings: " && get_settings )
     if cat settings/profile.json | jq . >/dev/null; then
         echo -n " and valid. "
     else
         echo -n " but invalid: "
         ls -lart settings/profile.json
         cat settings/profile.json | jq -C -c .current_basal
-        echo -n "refresh" && get_settings && echo -n "ed. "
+        get_settings
     fi
 }
 
@@ -510,6 +510,7 @@ function get_settings {
     oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json | jq . > settings/profile.json.new || (echo "Couldn't refresh profile"; fail "$@")
     if cat settings/profile.json.new | jq . >/dev/null; then
         mv settings/profile.json.new settings/profile.json
+        echo -n "Settings refreshed. "
     else
         echo "Invalid profile.json.new after refresh"
         cat settings/profile.json.new | jq .current_basal
@@ -566,7 +567,7 @@ function refresh_profile {
         profileage=$1
     fi
     find settings/ -mmin -$profileage -size +5c | grep -q settings.json && echo -n "Settings less than $profileage minutes old. " \
-    || (echo -n Settings refresh && get_settings && echo -n "ed. ")
+    || get_settings
 }
 
 function wait_for_bg {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -497,7 +497,10 @@ function refresh_old_profile {
             #echo -n "Invalid iob.json: "
         #fi
         if ! cat settings/profile.json | jq . | grep -q basal; then
-            echo -n "Invalid profile.json: refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
+            echo -n "Invalid profile.json: "
+            ls -lart settings/profile.json
+            cat settings/profile.json | jq . -C -c
+            echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
         fi
     #fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -506,7 +506,10 @@ function refresh_old_profile {
 
 # get-settings report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json settings/pumpprofile.json settings/profile.json
 function get_settings {
-    openaps report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json settings/pumpprofile.json 2>&1 >/dev/null | tail -1
+    openaps report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json 2>&1 >/dev/null | tail -1
+    # generate settings/pumpprofile.json without autotune
+    oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json settings/autotune.json | jq . > settings/pumpprofile.json || (echo "Couldn't refresh pumpprofile"; fail "$@")
+    # generate settings/profile.json.new with autotune
     oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json | jq . > settings/profile.json.new || (echo "Couldn't refresh profile"; fail "$@")
     if cat settings/profile.json.new | jq . >/dev/null; then
         mv settings/profile.json.new settings/profile.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -492,9 +492,7 @@ function refresh_old_pumphistory_24h {
 function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old. " \
         || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. " )
-    if cat monitor/iob.json | jq . | grep -q iob && cat settings/profile.json | jq . | grep -q basal; then
-        # iob.json and profile.json are both valid
-    else
+    if ! cat monitor/iob.json | jq . | grep -q iob || ! cat settings/profile.json | jq . | grep -q basal; then
         echo -n Invalid iob.json or profile.json: refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
     fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -492,15 +492,14 @@ function refresh_old_pumphistory_24h {
 function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old. " \
         || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. " )
-    if ! cat monitor/iob.json | jq . | grep -q iob || ! cat settings/profile.json | jq . | grep -q basal; then
-        if ! cat monitor/iob.json | jq . | grep -q iob; then
-            echo -n "Invalid iob.json: "
-        fi
+    #if ! cat monitor/iob.json | jq . | grep -q iob || ! cat settings/profile.json | jq . | grep -q basal; then
+        #if ! cat monitor/iob.json | jq . | grep -q iob; then
+            #echo -n "Invalid iob.json: "
+        #fi
         if ! cat settings/profile.json | jq . | grep -q basal; then
-            echo -n "Invalid profile.json: "
+            echo -n "Invalid profile.json: refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
         fi
-        echo -n refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
-    fi
+    #fi
 }
 
 function refresh_smb_temp_and_enact {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -494,7 +494,7 @@ function refresh_old_pumphistory_24h {
 function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old" \
         || (echo -n Old settings refresh && get_settings && echo -n "ed" )
-    if cat settings/profile.json | jq . | grep -q basal; then
+    if cat settings/profile.json | jq . >/dev/null; then
         echo -n " and valid. "
     else
         echo -n " but invalid: "
@@ -508,7 +508,7 @@ function refresh_old_profile {
 function get_settings {
     openaps report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json settings/pumpprofile.json 2>&1 >/dev/null | tail -1
     oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json | jq . > settings/profile.json.new || (echo "Couldn't refresh profile"; fail "$@")
-    if cat settings/profile.json.new | jq . | grep -q basal; then
+    if cat settings/profile.json.new | jq . >/dev/null; then
         mv settings/profile.json.new settings/profile.json
     else
         echo "Invalid profile.json.new after refresh"

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -501,9 +501,13 @@ function refresh_old_profile {
         if cat settings/profile.json | jq . | grep -q basal; then
             : # do nothing
         else
-            echo -n "Invalid profile.json: "
-            ls -lart settings/profile.json
-            cat settings/profile.json | jq . -C -c
+            set -x
+            if cat settings/profile.json | jq . | grep -q basal; then
+                echo -n "Invalid profile.json: "
+                ls -lart settings/profile.json
+                cat settings/profile.json | jq . -C -c
+            fi
+            set +x
             #echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
         fi
     #fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -493,7 +493,13 @@ function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old. " \
         || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. " )
     if ! cat monitor/iob.json | jq . | grep -q iob || ! cat settings/profile.json | jq . | grep -q basal; then
-        echo -n Invalid iob.json or profile.json: refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
+        if ! cat monitor/iob.json | jq . | grep -q iob
+            echo -n "Invalid iob.json: "
+        fi
+        if ! cat settings/profile.json | jq . | grep -q basal; then
+            echo -n "Invalid profile.json: "
+        fi
+        echo -n refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
     fi
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -498,7 +498,9 @@ function refresh_old_profile {
         #if ! cat monitor/iob.json | jq . | grep -q iob; then
             #echo -n "Invalid iob.json: "
         #fi
-        if ! ( cat settings/profile.json | jq . | grep -q basal ); then
+        if cat settings/profile.json | jq . | grep -q basal; then
+            : # do nothing
+        else
             echo -n "Invalid profile.json: "
             ls -lart settings/profile.json
             cat settings/profile.json | jq . -C -c

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -499,7 +499,7 @@ function refresh_old_profile {
     else
         echo -n " but invalid: "
         ls -lart settings/profile.json
-        cat settings/profile.json | jq -C -c .current_basal
+        #cat settings/profile.json | jq -C -c .current_basal
         get_settings
     fi
 }
@@ -513,7 +513,8 @@ function get_settings {
         echo -n "Settings refreshed. "
     else
         echo "Invalid profile.json.new after refresh"
-        cat settings/profile.json.new | jq .current_basal
+        ls -lart settings/profile.json.new
+        #cat settings/profile.json.new | jq .current_basal
         # fail "$@"
     fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -493,7 +493,7 @@ function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old. " \
         || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. " )
     if ! cat monitor/iob.json | jq . | grep -q iob || ! cat settings/profile.json | jq . | grep -q basal; then
-        if ! cat monitor/iob.json | jq . | grep -q iob
+        if ! cat monitor/iob.json | jq . | grep -q iob; then
             echo -n "Invalid iob.json: "
         fi
         if ! cat settings/profile.json | jq . | grep -q basal; then

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -507,9 +507,9 @@ function refresh_old_profile {
                 ls -lart settings/profile.json
                 cat settings/profile.json | jq . -C -c
             fi
-            set +x
             #echo -n "refresh" && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
         fi
+        set +x
     #fi
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -156,8 +156,8 @@ function smb_suggest {
     rm -rf enact/smb-suggested.json
     ls enact/smb-suggested.json 2>/dev/null >/dev/null && die "enact/suggested.json present"
     # Run determine-basal
-    echo -n Temp refresh && openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json monitor/iob.json 2>&1 >/dev/null | tail -1 && echo ed \
-    && openaps report invoke enact/smb-suggested.json 2>&1 >/dev/null \
+    echo -n Temp refresh && openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json monitor/iob.json 2>&1 >/dev/null | tail -1 && echo ed
+    openaps report invoke enact/smb-suggested.json 2>&1 >/dev/null \
     && cp -up enact/smb-suggested.json enact/suggested.json \
     && smb_verify_suggested
 }
@@ -491,7 +491,12 @@ function refresh_old_pumphistory_24h {
 # refresh settings/profile if it's more than 1h old
 function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old. " \
-    || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. " )
+        || (echo -n Old settings refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. " )
+    if cat monitor/iob.json | jq . | grep -q iob && cat settings/profile.json | jq . | grep -q basal; then
+        # iob.json and profile.json are both valid
+    else
+        echo -n Invalid iob.json or profile.json: refresh && openaps get-settings 2>&1 >/dev/null | tail -1 && echo -n "ed. "
+    fi
 }
 
 function refresh_smb_temp_and_enact {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -498,7 +498,7 @@ function refresh_old_profile {
         #if ! cat monitor/iob.json | jq . | grep -q iob; then
             #echo -n "Invalid iob.json: "
         #fi
-        if ! cat settings/profile.json | jq . | grep basal; then
+        if ! ( cat settings/profile.json | jq . | grep -q basal ); then
             echo -n "Invalid profile.json: "
             ls -lart settings/profile.json
             cat settings/profile.json | jq . -C -c


### PR DESCRIPTION
Sometimes `get-settings` fails to refresh something from the pump, resulting in a bad/empty iob.json or profile.json.  Rather than letting the loop fail and waiting for it to refresh naturally, this does so before trying to use it.

This also refactors the `openaps get-settings` alias into a function in oref0-pump-loop for better logging, efficiency, and to make things easier to tweak in the future.