### PR TITLE
Calculate UAM and eventualBG when insufficient data for COB

### DIFF
--- a/bin/oref0-meal.js
+++ b/bin/oref0-meal.js
@@ -85,11 +85,6 @@ if (!module.parent) {
       basalprofile_data = temp;
     }
 
-    if (glucose_data.length < 36) {
-        console.error("Optional feature meal assist disabled: not enough glucose data to calculate carb absorption; found:", glucose_data.length);
-        return console.log('{ "carbs": 0, "reason": "not enough glucose data to calculate carb absorption" }');
-    }
-
     var inputs = {
         history: pumphistory_data
     , profile: profile_data
@@ -100,6 +95,13 @@ if (!module.parent) {
     };
 
     var recentCarbs = generate(inputs);
+
+    if (glucose_data.length < 36) {
+        console.error("Not enough glucose data to calculate carb absorption; found:", glucose_data.length);
+        recentCarbs.mealCOB = 0;
+        recentCarbs.reason = "not enough glucose data to calculate carb absorption";
+    }
+
     console.log(JSON.stringify(recentCarbs));
 }
 

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -42,7 +42,9 @@ function highload {
 #openaps get-ns-glucose && cat cgm/ns-glucose.json | json -c \\\"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38\\\" | grep -q glucose && cp -pu cgm/ns-glucose.json cgm/glucose.json; cp -pu cgm/glucose.json monitor/glucose.json
 function get_ns_bg {
     #openaps get-ns-glucose > /dev/null
-    if ! find cgm/ -mmin -55 | egrep -q cgm/ns-glucose-24h.json; then
+    # update 24h glucose file if it's 55m old or too small to calculate COB
+    if ! find cgm/ -mmin -54 | egrep -q cgm/ns-glucose-24h.json \
+        || ! grep -c glucose cgm/ns-glucose-24h.json | jq -e '. > 36' >/dev/null; then
         nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -24hours > cgm/ns-glucose-24h.json
     fi
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -1hour > cgm/ns-glucose-1h.json

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -577,7 +577,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
             rT.predBGs.UAM = UAMpredBGs;
             lastUAMpredBG=round(UAMpredBGs[UAMpredBGs.length-1]);
-            eventualBG = Math.max(eventualBG, round(UAMpredBGs[UAMpredBGs.length-1]) );
+            if (UAMpredBGs[UAMpredBGs.length-1]) {
+                eventualBG = Math.max(eventualBG, round(UAMpredBGs[UAMpredBGs.length-1]) );
+            }
         }
 
         // set eventualBG and snoozeBG based on COB or UAM predBGs


### PR DESCRIPTION
When there is less than 3h worth of glucose data available, oref0-meal can't calculate COB, so returns zero.  However, if UAM is enabled, it also fails to return UAM information, which was propagating through to undefined / NaN for eventualBG in that situation (basically turning oref0 into just a predictive low glucose suspend system). 

This change only sets COB to zero when insufficient glucose data is available, but still calculates the UAM data if it can.  It also adds an undefined check to prevent missing UAMpredBGs from causing an undefined/NaN eventualBG.  And it adds a check to the 24h glucose refresh to force it to retry every run until it gets enough glucose data to calculate COB.

This also includes various optimizations from #741 to make oref0-ns-loop run faster, particularly for Pi0 rigs. It also causes it to skip non-essential ns-loop functions (everything other than getting new BG data) if system load is too high, to ensure that oref0-pump-loop can run.