### PR TITLE
match on spidev5.1 to indicate explorer (for runagain); fix if syntax

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -26,7 +26,6 @@ DIR=""
 directory=""
 EXTRAS=""
 radio_locale="US"
-explorer1="NO"
 
 #this makes the confirmation echo text a color when you use echocolor instead of echo
 function echocolor() { # $1 = string
@@ -186,7 +185,6 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
     read -p "Are you using an Explorer Board? y/[N] " -r
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         ttyport=/dev/spidev5.1
-        explorer1="YES"
         echocolor "Ok, yay for Explorer Board! "
         echo
     else
@@ -874,7 +872,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     sudo sysctl -p
     
     # Install EdisonVoltage
-    if explorer1 == "YES"; then
+    if [[ "$ttyport" =~ "spidev5.1" ]]; then
         if egrep -i "edison" /etc/passwd 2>/dev/null; then
             echo "Checking if EdisonVoltage is already installed"
             if [ -d "$HOME/src/EdisonVoltage/" ]; then
@@ -1038,7 +1036,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
         (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
         fi
-        if explorer1 == "YES"; then
+        if [[ "$ttyport" =~ "spidev5.1" ]]; then
            # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
            if egrep -i "edison" /etc/passwd 2>/dev/null; then
            (crontab -l; crontab -l | grep -q "cd $directory && openaps battery-status" || echo "*/15 * * * * cd $directory && openaps battery-status; cat $directory/monitor/edison-battery.json | json batteryVoltage | awk '{if (\$1<=3050)system(\"sudo shutdown -h now\")}'") | crontab -


### PR DESCRIPTION
PR #622 introduced a syntax error (bash if comparisons require square brackets) and failed to match when run non-interactively via oref0-runagain.  This changes the conditional to just match on spidev5.1 as we do elsewhere to indicate that we're on an Edison + Explorer Block rig.  cc @jsmurray1