### PR TITLE
Fix edisonbattery for MDT and xDrip.

### DIFF
--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-#echo Starting ns-loop at $(date): && openaps get-ns-bg; sensors -u 2>/dev/null | awk '$NF > 85' | grep input || ( openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload )
+# echo Starting ns-loop at $(date): && openaps get-ns-bg; sensors -u 2>/dev/null | awk '$NF > 85' | grep input || ( openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload )
+# echo Starting ns-loop at $(date): && openaps get-ns-bg; openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps battery-status; cat monitor/edison-battery.json; echo; openaps upload
 
 # main ns-loop
 main() {
@@ -9,6 +10,7 @@ main() {
     overtemp && exit 1
     ns_temptargets || die "ns_temptargets failed"
     ns_meal_carbs || die ", but ns_meal_carbs failed"
+    battery_status
     upload
     echo Completed oref0-ns-loop at $(date)
 }
@@ -60,6 +62,13 @@ function ns_meal_carbs {
     grep COB monitor/meal.json | jq .mealCOB
 }
 
+#sudo ~/src/EdisonVoltage/voltage json batteryVoltage battery > monitor/edison-battery.json
+function battery_status {
+    if [ -e ~/src/EdisonVoltage/voltage ]; then
+        sudo ~/src/EdisonVoltage/voltage json batteryVoltage battery | tee monitor/edison-battery.json | jq -C -c .
+    fi
+}
+
 # echo -n Upload && ( openaps upload-ns-status; openaps upload-pumphistory-entries; openaps upload-recent-treatments ) 2>/dev/null >/dev/null && echo ed
 function upload {
     upload_ns_status
@@ -80,8 +89,9 @@ function upload_ns_status {
 }
 
 #ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json
+# ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --uploader monitor/edison-battery.json > upload/ns-status.json
 function format_ns_status {
-    ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json
+    ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --uploader monitor/edison-battery.json > upload/ns-status.json
 }
 
 #openaps format-latest-nightscout-treatments && test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0 && (ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json ) || echo \\\"No recent treatments to upload\\\"
@@ -89,10 +99,9 @@ function upload_recent_treatments {
     #echo Uploading treatments
     format_latest_nightscout_treatments || die "Couldn't format latest NS treatments"
     if test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0; then
-        ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json || die "Couldn't upload latest treatments to NS"
-        echo ed successfully
+        ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json | jq -C -c . || die "Couldn't upload latest treatments to NS"
     else
-        echo "No recent treatments to upload"
+        echo "No new treatments to upload"
     fi
 }
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -888,6 +888,13 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             # Add module needed for EdisonVoltage to work on jubilinux 0.2.0
             grep iio_basincove_gpadc /etc/modules-load.d/modules.conf || echo iio_basincove_gpadc >> /etc/modules-load.d/modules.conf
         fi
+        if [[ ${CGM,,} =~ "mdt" ]]; then
+            cd $directory || die "Can't cd $directory"
+            for type in edisonbattery; do
+                echo importing $type file
+                cat $HOME/src/oref0/lib/oref0-setup/$type.json | openaps import || die "Could not import $type.json"
+            done
+        fi
     fi
     # Install Pancreabble
     echo Checking for BT Pebble Mac

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -888,7 +888,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             # Add module needed for EdisonVoltage to work on jubilinux 0.2.0
             grep iio_basincove_gpadc /etc/modules-load.d/modules.conf || echo iio_basincove_gpadc >> /etc/modules-load.d/modules.conf
         fi
-        if [[ ${CGM,,} =~ "mdt" ]]; then
+        if [[ ${CGM,,} =~ "mdt" ]] || [[ ${CGM,,} =~ "xdrip" ]]; then # still need this for the old ns-loop for now
             cd $directory || die "Can't cd $directory"
             for type in edisonbattery; do
                 echo importing $type file
@@ -1018,7 +1018,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         elif ! [[ ${CGM,,} =~ "mdt" ]]; then # use nightscout for cgm
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
         fi
-        if [[ ${CGM,,} =~ "mdt" ]]; then # use old ns-loop for now
+        if [[ ${CGM,,} =~ "mdt" ]] || [[ ${CGM,,} =~ "xdrip" ]]; then # use old ns-loop for now
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
         else
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'oref0-ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'oref0-ns-loop' || oref0-ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -

--- a/lib/oref0-setup/edisonbattery.json
+++ b/lib/oref0-setup/edisonbattery.json
@@ -1,0 +1,23 @@
+[
+{
+    "type": "alias",
+    "name": "format-ns-status",
+    "format-ns-status": {
+      "command": "! bash -c \"ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --uploader monitor/edison-battery.json > upload/ns-status.json\""
+    }
+},
+{
+    "type": "alias",
+    "name": "battery-status",
+    "battery-status": {
+      "command": "! bash -c \"sudo ~/src/EdisonVoltage/voltage json batteryVoltage battery > monitor/edison-battery.json\""
+    }
+  },
+  {
+    "type": "alias",
+    "name": "ns-loop",
+    "ns-loop": {
+      "command": "! bash -c \"echo Starting ns-loop at $(date): && openaps get-ns-bg; openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps battery-status; cat monitor/edison-battery.json; echo; openaps upload\""
+    }
+  }    
+]


### PR DESCRIPTION
When I removed the edisonbattery import, that broke MDT (and xDrip) CGM users who still need the old `openaps ns-loop` for now until we update oref0-ns-loop.sh to support them.

This restores edisonbattery upload functionality for MDT, and restores that plus ns-loop functionality for xDrip.