### PR TITLE
 press ESC three times on the pump to exit Bolus Wizard before SMBing

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -240,6 +240,10 @@ function smb_bolus {
     # and administer the supermicrobolus
     find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
     && if (grep -q '"units":' enact/smb-suggested.json); then
+        # press ESC three times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
+        openaps use pump press_keys esc
+        openaps use pump press_keys esc
+        openaps use pump press_keys esc
         openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \
         && rm -rf enact/smb-suggested.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -241,6 +241,7 @@ function smb_bolus {
     find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
     && if (grep -q '"units":' enact/smb-suggested.json); then
         # press ESC three times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
+        echo -n "Sending ESC ESC ESC to exit any open menus before SMBing: "
         openaps use pump press_keys esc esc esc | jq .completed | grep true \
         && openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -241,9 +241,9 @@ function smb_bolus {
     find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
     && if (grep -q '"units":' enact/smb-suggested.json); then
         # press ESC three times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
-        openaps use pump press_keys esc
-        openaps use pump press_keys esc
-        openaps use pump press_keys esc
+        openaps use pump press_keys esc | jq .completed | tr '\n' ' '
+        openaps use pump press_keys esc | jq .completed | tr '\n' ' '
+        openaps use pump press_keys esc | jq .completed | tr '\n' ' '
         openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \
         && rm -rf enact/smb-suggested.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -241,10 +241,8 @@ function smb_bolus {
     find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
     && if (grep -q '"units":' enact/smb-suggested.json); then
         # press ESC three times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
-        openaps use pump press_keys esc | jq .completed | tr '\n' ' '
-        openaps use pump press_keys esc | jq .completed | tr '\n' ' '
-        openaps use pump press_keys esc | jq .completed | tr '\n' ' '
-        openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
+        openaps use pump press_keys esc esc esc | jq .completed | grep true \
+        && openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \
         && rm -rf enact/smb-suggested.json
     else


### PR DESCRIPTION
To reduce the risk of A52 errors, @mgranberryto resurrected the idea in https://github.com/openaps/oref0/pull/749#issuecomment-339441573 of having OpenAPS send ESC key presses before issuing SMBs.  This does so, three times, to make sure the pump is out of the pump Bolus Wizard before SMB'ing.  That will force the user to go back into the bolus wizard after the SMB completes, when it is again safe to do so.  This might also help with accidentally leaving the pump in the fixed prime screen after a rewind, but that will need to be tested.