### PR TITLE
Fixed handling of x12 pumps - now forces them to use old_main instead…

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -194,10 +194,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m","tempModulus:",tempModulus,"m");
     rT.temp = 'absolute';
     rT.deliverAt = deliverAt;
-    if ( currenttemp && iob_data.lastTemp && currenttemp.rate != iob_data.lastTemp.rate ) {
-        rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; setting neutral temp of "+basal+".";
-        return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-    }
+   // This breaks 512/712 loops. 
+   // if ( currenttemp && iob_data.lastTemp && currenttemp.rate != iob_data.lastTemp.rate ) {
+   //     rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; setting neutral temp of "+basal+".";
+   //     return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+   // }
     if ( currenttemp && iob_data.lastTemp && currenttemp.duration > 0 ) {
         // TODO: fix this (lastTemp.duration is how long it has run; currenttemp.duration is time left
         //if ( currenttemp.duration < iob_data.lastTemp.duration - 2) {


### PR DESCRIPTION
2 separate changes, one you guys will probably like, the other you very well may not:

1) oref0-pump-loop

 = Rewrote preflight to work off of 'openaps-use pump model', so it doesn't break x12 pumps
 = Changed behavior of 'main' loop, so that (A) it preflights first (sparing extra calls to prep & stuff for new_main, if we are just going to jump off to old_main because the pump is an x12), and (b) it detects x12 pumps and boots them off into old_main (which works for the x12, provided that 2 other things are fixed (the 'simulated' status call in decocare/commands.py, and the removal of the 'currenttemp != lastTemp from pumphistory' check)

The reason for forcing x12 to old_main, is that 'new main' uses a bunch of reports/commands from SMB that are not available once you say 'Yes' to x12 in the setup script (eg, x12 has enact/suggested.json, but not enact/smb_suggested.json in it's valid-report list - so the 'new' loop fails with an openaps-report syntax error). 


Feel free to use anything you like & trash what you don't.

If I have time, I'll try to come up with cleaner fixes, but at present, the ones I have here (Combined with the modification to the status function in decocare) produce a reliable loop.

One other note: 
At least on the x12, the 'currenttemp' check has the effect of randomly reverting to the hardcoded basal targets for long periods of time. 

A user who isn't watching the log obsessively may think they are looping (because the check doesn't always go haywire (defined-as: Overrides the previously enacted temp-basal with the hardcoded value at the end of every loop because it doesn't like what it sees for the last-known rate in pumphistory - even though everything was 'OK' when the now-overridden rate was enacted a few lines of code back in the same 'run' of the loop), but they are really on their (maybe too high? maybe too low?) hardcoded basal rates from settings/basal_profile.json - which could lead to excessive insulin delivery if the basal rate is on the high-side...