### PR TITLE
don't treat suspended pump as a complete failure

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -77,7 +77,16 @@ main() {
             touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
             echo
         else
-            fail "$@"
+            # don't treat suspended pump as a complete failure
+            if grep -q '"suspended": true' monitor/status.json; then
+                refresh_profile 15; refresh_pumphistory_24h
+                refresh_after_bolus_or_enact
+                echo "Incomplete oref0-pump-loop (pump suspended) at $(date)"
+                echo
+            else
+                # pump-loop errored out for some other reason
+                fail "$@"
+            fi
         fi
     fi
 }


### PR DESCRIPTION
When pump is suspended, the rig currently treats that as a failure and mmtunes unnecessary when pump comms are fine.  This changes that behavior to continue to refresh profile, pumphistory, etc. instead of failing out if the pump is suspended.