### PR TITLE
Sensitivity and targets

### DIFF
--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -280,8 +280,8 @@ function detectSensitivity(inputs) {
             //console.error(tempTarget)
         }
         if ( tempTarget > 100 ) {
-            // for a 110 temptarget, add a -1 deviation, for 160 add -6
-            tempDeviation=-(tempTarget-100)/10;
+            // for a 110 temptarget, add a -0.5 deviation, for 160 add -3
+            tempDeviation=-(tempTarget-100)/20;
             process.stderr.write("-");
             //console.error(tempDeviation)
             deviations.push(tempDeviation);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -302,6 +302,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         , 'insulinReq': 0
         , 'reservoir' : reservoir_data // The expected reservoir volume at which to deliver the microbolus (the reservoir volume from right before the last pumphistory run)
         , 'deliverAt' : deliverAt // The time at which the microbolus should be delivered
+        , 'sensitivityRatio' : sensitivityRatio // autosens ratio (fraction of normal basal)
     };
 
     // generate predicted future BGs based on IOB, COB, and current absorption rate

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -354,8 +354,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     ci = round((minDelta - bgi),1);
     uci = round((minDelta - bgi),1);
     // ISF (mg/dL/U) / CR (g/U) = CSF (mg/dL/g)
-    // use unadjusted profile.sens to allow activity mode sensitivityRatio to adjust CR
-    var csf = profile.sens / profile.carb_ratio;
+    if (profile.temptargetSet) {
+        // if temptargetSet, use unadjusted profile.sens to allow activity mode sensitivityRatio to adjust CR
+        var csf = profile.sens / profile.carb_ratio;
+    } else {
+        // otherwise, use autosens-adjusted sens to counteract autosens meal insulin dosing adjustments
+        // so that autotuned CR is still in effect even when basals and ISF are being adjusted by autosens
+        var csf = sens / profile.carb_ratio;
+    }
     var maxCarbAbsorptionRate = 30; // g/h; maximum rate to assume carbs will absorb if no CI observed
     // limit Carb Impact to maxCarbAbsorptionRate * csf in mg/dL per 5m
     maxCI = round(maxCarbAbsorptionRate*csf*5/60,1)

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -94,18 +94,23 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     var sensitivityRatio;
+    var high_temptarget_raises_sensitivity = profile.exercise_mode || profile.high_temptarget_raises_sensitivity;
     var normalTarget = 100; // evaluate high/low temptarget against 100, not scheduled basal (which might change)
     if ( profile.half_basal_exercise_target ) {
         var halfBasalTarget = profile.half_basal_exercise_target;
     } else {
         var halfBasalTarget = 160; // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
+        // 80 mg/dL with low_temptarget_lowers_sensitivity would give 1.5x basal, but is limited to autosens_max (1.2x by default)
     }
-    if ( profile.exercise_mode && profile.temptargetSet && target_bg > normalTarget + 10 ) {
+    if ( high_temptarget_raises_sensitivity && profile.temptargetSet && target_bg > normalTarget + 10
+        || profile.low_temptarget_lowers_sensitivity && profile.temptargetSet && target_bg < normalTarget ) {
         // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
         // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
         //sensitivityRatio = 2/(2+(target_bg-normalTarget)/40);
         var c = halfBasalTarget - normalTarget;
         sensitivityRatio = c/(c+target_bg-normalTarget);
+        // limit sensitivityRatio to profile.autosens_max (1.2x by default)
+        sensitivityRatio = Math.min(sensitivityRatio, profile.autosens_max);
         sensitivityRatio = round(sensitivityRatio,2);
         process.stderr.write("Sensitivity ratio set to "+sensitivityRatio+" based on temp target of "+target_bg+"; ");
     } else if (typeof autosens_data !== 'undefined' ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -123,23 +123,23 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     // adjust min, max, and target BG for sensitivity, such that 50% increase in ISF raises target from 100 to 120
-    if (typeof autosens_data !== 'undefined' && profile.autosens_adjust_targets) {
-      if (profile.temptargetSet) {
+    if (profile.temptargetSet) {
         //process.stderr.write("Temp Target set, not adjusting with autosens; ");
-      } else {
-        // with a target of 100, default 0.7-1.2 autosens min/max range would allow a 93-117 target range
-        min_bg = round((min_bg - 60) / autosens_data.ratio) + 60;
-        max_bg = round((max_bg - 60) / autosens_data.ratio) + 60;
-        new_target_bg = round((target_bg - 60) / autosens_data.ratio) + 60;
-        // don't allow target_bg below 80
-        new_target_bg = Math.max(80, new_target_bg);
-        if (target_bg == new_target_bg) {
-            process.stderr.write("target_bg unchanged: "+new_target_bg+"; ");
-        } else {
-            process.stderr.write("target_bg from "+target_bg+" to "+new_target_bg+"; ");
+    } else if (typeof autosens_data !== 'undefined' ) {
+        if ( profile.sensitivity_raises_target && autosens_data.ratio < 1 || profile.resistance_lowers_target && autosens_data.ratio > 1 ) {
+            // with a target of 100, default 0.7-1.2 autosens min/max range would allow a 93-117 target range
+            min_bg = round((min_bg - 60) / autosens_data.ratio) + 60;
+            max_bg = round((max_bg - 60) / autosens_data.ratio) + 60;
+            new_target_bg = round((target_bg - 60) / autosens_data.ratio) + 60;
+            // don't allow target_bg below 80
+            new_target_bg = Math.max(80, new_target_bg);
+            if (target_bg == new_target_bg) {
+                process.stderr.write("target_bg unchanged: "+new_target_bg+"; ");
+            } else {
+                process.stderr.write("target_bg from "+target_bg+" to "+new_target_bg+"; ");
+            }
+            target_bg = new_target_bg;
         }
-        target_bg = new_target_bg;
-      }
     }
 
     if (typeof iob_data === 'undefined' ) {

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -242,7 +242,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             } else {
                 var halfBasalTarget = 160; // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
             }
-            if ( profile.exercise_mode && profile.temptargetSet && target_bg > normalTarget + 10 ) {
+            if ( profile.exercise_mode && profile.temptargetSet && target_bg >= normalTarget + 5 ) {
                 // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
                 // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
                 var c = halfBasalTarget - normalTarget;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -19,7 +19,7 @@ function defaults ( ) {
     , sensitivity_raises_target: true // raise BG target when autosens detects sensitivity
     , resistance_lowers_target: false // lower BG target when autosens detects resistance
     , adv_target_adjustments: false // lower target automatically when BG and eventualBG are high
-    , exercise_mode: false // when true, > 110 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before. synonmym for high_temptarget_raises_sensitivity
+    , exercise_mode: false // when true, > 105 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before. synonmym for high_temptarget_raises_sensitivity
     , half_basal_exercise_target: 160 // when temptarget is 160 mg/dL *and* exercise_mode=true, run 50% basal at this level (120 = 75%; 140 = 60%)
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -15,11 +15,11 @@ function defaults ( ) {
     , rewind_resets_autosens: true // reset autosensitivity to neutral for awhile after each pump rewind
     // , autosens_adjust_targets: false // when autosens detects sensitivity/resistance, also adjust BG target accordingly
     , high_temptarget_raises_sensitivity: false // raise sensitivity for temptargets >= 111.  synonym for exercise_mode
-    , low_temptarget_lowers_sensitivity: false // lower sensitivity for temptargets <= 94.
+    , low_temptarget_lowers_sensitivity: false // lower sensitivity for temptargets <= 99.
     , sensitivity_raises_target: true // raise BG target when autosens detects sensitivity
     , resistance_lowers_target: false // lower BG target when autosens detects resistance
     , adv_target_adjustments: false // lower target automatically when BG and eventualBG are high
-    , exercise_mode: false // when true, > 110 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before. synonmym for high_target_raises_sensitivity
+    , exercise_mode: false // when true, > 110 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before. synonmym for high_temptarget_raises_sensitivity
     , half_basal_exercise_target: 160 // when temptarget is 160 mg/dL *and* exercise_mode=true, run 50% basal at this level (120 = 75%; 140 = 60%)
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -13,9 +13,13 @@ function defaults ( ) {
     , autosens_max: 1.2
     , autosens_min: 0.7
     , rewind_resets_autosens: true // reset autosensitivity to neutral for awhile after each pump rewind
-    , autosens_adjust_targets: false // when autosens detects sensitivity/resistance, also adjust BG target accordingly
+    // , autosens_adjust_targets: false // when autosens detects sensitivity/resistance, also adjust BG target accordingly
+    , high_temptarget_raises_sensitivity: false // raise sensitivity for temptargets >= 111.  synonym for exercise_mode
+    , low_temptarget_lowers_sensitivity: false // lower sensitivity for temptargets <= 94.
+    , sensitivity_raises_target: true // raise BG target when autosens detects sensitivity
+    , resistance_lowers_target: false // lower BG target when autosens detects resistance
     , adv_target_adjustments: false // lower target automatically when BG and eventualBG are high
-    , exercise_mode: false // when true, > 110 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before.
+    , exercise_mode: false // when true, > 110 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before. synonmym for high_target_raises_sensitivity
     , half_basal_exercise_target: 160 // when temptarget is 160 mg/dL *and* exercise_mode=true, run 50% basal at this level (120 = 75%; 140 = 60%)
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.
@@ -58,6 +62,7 @@ function displayedDefaults () {
     profile.rewind_resets_autosens = allDefaults.rewind_resets_autosens;
     profile.adv_target_adjustments = allDefaults.adv_target_adjustments;
     profile.exercise_mode = allDefaults.exercise_mode;
+    profile.sensitivity_raises_target = allDefaults.sensitivity_raises_target;
     profile.unsuspend_if_no_temp = allDefaults.unsuspend_if_no_temp;
     profile.enableSMB_with_COB = allDefaults.enableSMB_with_COB;
     profile.enableSMB_with_temptarget = allDefaults.enableSMB_with_temptarget;


### PR DESCRIPTION
Currently autosens_adjust_targets is false by default, as autosens now adjusts the basals used in calculating IOB, eliminating the need to adjust targets to compensate for IOB previously not reflecting sensitivity.  However, there are still cases where autosens doesn't react strongly enough, such as for persistent low BG due to sensitivity.  To help address that, this splits autosens_adjust_targets into two preferences: sensitivity_raises_target (true by default) and resistance_lowers_target (false by default).  As before, temp targets override any autosens-based target adjustments.

Additionally, some people find that 80 mg/dL temp targets are insufficient to bring BG down when they're running resistant, so this adds a low_temptarget_lowers_sensitivity preference (false by default) to allow people to use low temp targets (>=99) to signal resistance mode.   This is the converse of what exercise_mode does (for >=111), so for consistency I've added high_temptarget_raises_sensitivity as well as a (hidden) synonym for exercise_mode.