### PR TITLE
oref0-version

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1000,6 +1000,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         (crontab -l; crontab -l | grep -q "PATH=" || echo "PATH=$PATH" ) | crontab -
         (crontab -l; crontab -l | grep -q "oref0-online $BT_MAC" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-online '$BT_MAC'" || oref0-online '$BT_MAC' 2>&1 >> /var/log/openaps/network.log' ) | crontab -
         (crontab -l; crontab -l | grep -q "sudo wpa_cli scan" || echo '* * * * * sudo wpa_cli scan') | crontab -
+        (crontab -l; crontab -l | grep -q "oref0-version" || echo "0 * * * * oref0-version --check-for-updates 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
         (crontab -l; crontab -l | grep -q "killall -g --older-than 30m oref0" || echo '* * * * * ( killall -g --older-than 30m openaps; killall -g --older-than 30m oref0-pump-loop; killall -g --older-than 30m openaps-report )') | crontab -
         # kill pump-loop after 5 minutes of not writing to pump-loop.log
         (crontab -l; crontab -l | grep -q "killall -g --older-than 5m oref0" || echo '* * * * * find /var/log/openaps/pump-loop.log -mmin +5 | grep pump && ( killall -g --older-than 5m openaps; killall -g --older-than 5m oref0-pump-loop; killall -g --older-than 5m openaps-report )') | crontab -

--- a/bin/oref0-version.js
+++ b/bin/oref0-version.js
@@ -1,0 +1,27 @@
+// Simple script to check current version / branch of oref0 installed and check for updates
+const execSync = require('child_process').execSync;
+const argv = require('yargs').argv;
+
+var branch = execSync(`cd $HOME/src/oref0/ && git rev-parse --abbrev-ref HEAD`).toString().trim().toLowerCase();
+var version = execSync(`jq .version "$HOME/src/oref0/package.json"`).toString().trim().substr(1).slice(0, -1);
+
+
+if (argv.checkForUpdates) {
+	execSync(`cd $HOME/src/oref0/ && git fetch`); // pull latest remote info
+	var behind = execSync(`cd $HOME/src/oref0/ && git rev-list --count ${branch}...origin/${branch}`).toString().trim();
+	if (parseInt(behind) > 0) {
+		// we are out of date
+		console.log(`Your instance of oref0 [${version}, ${branch}] is out-of-date by ${behind} commits, and you may consider updating.`);
+		if (branch !== "master") {
+			console.log(`\nNOTICE: You are currently running a branch of oref0 that is not an official release!`);
+			console.log(`PLEASE UPDATE TO THE LATEST REVISION OF THIS BRANCH BEFORE SUBMITTING A BUG REPORT!\n`);
+		} else {
+			console.log(`Please make sure to read any new documentation that may accompany update, as some things may have changed.`);
+		}
+	} else {
+		console.log(`Your instance of oref0 [${version}, ${branch}] is up-to-date!`);
+	}
+} else {
+	// simple version check and report.
+	console.log(`${version} [${branch}]`);
+}

--- a/bin/oref0-version.js
+++ b/bin/oref0-version.js
@@ -13,15 +13,15 @@ if (argv.checkForUpdates) {
 	var behind = execSync(`cd $HOME/src/oref0/ && git rev-list --count ${branch}...origin/${branch}`).toString().trim();
 	if (parseInt(behind) > 0) {
 		// we are out of date
-		console.log(`Your instance of oref0 [${version}, ${branch}] is out-of-date by ${behind} commits, and you may consider updating.`);
+		console.log(`Your instance of oref0 [${version}, ${branch}] is out-of-date by ${behind} commits, you may want to consider updating.`);
 		if (branch !== "master") {
-			console.log(`\nNOTICE: You are currently running a branch of oref0 that is not an official release!`);
-			console.log(`PLEASE UPDATE TO THE LATEST REVISION OF THIS BRANCH BEFORE SUBMITTING A BUG REPORT!\n`);
+			console.log(`\nYou are currently running a development branch of oref0.  Such branches change frequently.`);
+			console.log(`Please read the latest PR notes and update with the latest commits to dev before reporting any issues.\n`);
 		} else {
 			console.log(`Please make sure to read any new documentation that may accompany update, as some things may have changed.`);
 		}
 	} else {
-		console.log(`Your instance of oref0 [${version}, ${branch}] is up-to-date!`);
+		console.log(`Your instance of oref0 [${version}, ${branch}] is up-to-date.`);
 	}
 } else {
 	// simple version check and report.

--- a/bin/oref0-version.js
+++ b/bin/oref0-version.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 // Simple script to check current version / branch of oref0 installed and check for updates
 const execSync = require('child_process').execSync;
 const argv = require('yargs').argv;

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "oref0-truncate-git-history": "bin/oref0-truncate-git-history.sh",
     "oref0-upload-entries": "./bin/oref0-upload-entries.sh",
     "oref0-upload-profile": "./bin/oref0-upload-profile.js",
+    "oref0-version": "./bin/oref0-version.js",
     "peb-urchin-status": "./bin/peb-urchin-status.sh",
     "wifi": "./bin/oref0-tail-wifi.sh"
   },


### PR DESCRIPTION
`oref0-version` Returns version [branch] by default.
 
With `--check-for-updates` it will fetch and compare local to remote, and alert user if they are up to date or should update.

Added this to report to pump-loop (the one everyone actually watches) every hour, with instructions to update before posting any issue requests if `branch != master`.