### PR TITLE
Remove unnecessary verbose logging of the oref0-subg-ww-radio-paramet…

### DIFF
--- a/bin/oref0-subg-ww-radio-parameters.sh
+++ b/bin/oref0-subg-ww-radio-parameters.sh
@@ -14,7 +14,6 @@ SUBG_RFSPY_DIR=$HOME/src/subg_rfspy
 
 ################################################################################
 set -e
-set -x
 
 echo
 echo The CC111x is located at $SERIAL_PORT

--- a/bin/oref0-subg-ww-radio-parameters.sh
+++ b/bin/oref0-subg-ww-radio-parameters.sh
@@ -14,6 +14,8 @@ SUBG_RFSPY_DIR=$HOME/src/subg_rfspy
 
 ################################################################################
 set -e
+# use set -x to debug oref0 ww pump communication errors
+# set -x
 
 echo
 echo The CC111x is located at $SERIAL_PORT


### PR DESCRIPTION
…ers.

This logs every line being executed, which is probably overkill and in most cases adds too much noise to  the pump loop logs.