### PR TITLE
Run autosens in ns-loop

### DIFF
--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -99,12 +99,12 @@ if (!module.parent) {
         , temptargets: temptarget_data
         //, clock: clock_data
     };
-    // calculate sensitivity using 8h of non-exluded data
+    console.error("Calculating sensitivity using 8h of non-exluded data");
     detection_inputs.deviations = 96;
     detect(detection_inputs);
     ratio8h = ratio;
     newisf8h = newisf;
-    // calculate sensitivity using all non-exluded data (up to 24h)
+    console.error("Calculating sensitivity using all non-exluded data (up to 24h)");
     detection_inputs.deviations = 288;
     detect(detection_inputs);
     ratio24h = ratio;

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -183,6 +183,7 @@ function autosens {
         else
             echo -n Failed to refresh autosens: using old autosens.json
         fi
+    else
         echo -n No need to refresh autosens yet
     fi
     cat settings/autosens.json | jq . -C -c

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -24,7 +24,7 @@ main() {
     upload
     # if glucose is stale, refresh before running autosens
     if ! glucose_fresh; then get_ns_bg; fi
-    autosens
+    autosens 2>&1
     # check one last time to see if glucose got stale while running everything else
     if ! glucose_fresh; then get_ns_bg; fi
     touch /tmp/ns-loop-completed

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -177,7 +177,7 @@ function autosens {
         || find settings/ -size -5c | grep -q autosens.json \
         || ! find settings/ | grep -q autosens \
         || ! find settings/autosens.json; then
-        if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
+        if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json | tee settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
             mv settings/autosens.json.new settings/autosens.json
             echo -n "Autosens refreshed: "
         else

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -22,6 +22,14 @@ main() {
     ns_meal_carbs || die ", but ns_meal_carbs failed"
     battery_status
     upload
+    # only run autosens if we don't need to refresh glucose first
+    if glucose_fresh; then
+        autosens
+    fi
+    # check one last time to see if glucose got stale while running everything else
+    if ! glucose_fresh; then
+        get_ns_bg
+    fi
     touch /tmp/ns-loop-completed
     echo Completed oref0-ns-loop at $(date)
 }
@@ -162,6 +170,20 @@ function upload_recent_treatments {
 #nightscout cull-latest-openaps-treatments monitor/pumphistory-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
 function format_latest_nightscout_treatments {
     nightscout cull-latest-openaps-treatments monitor/pumphistory-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
+}
+
+# find settings/ -newer settings/autosens.json | grep -q pumphistory-24h-zoned.json || find settings/ -size -5c | grep -q autosens.json || ! find settings/ | grep -q autosens || ! find settings/autosens.json
+# openaps use detect-sensitivity shell monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json
+function autosens {
+    # only run autosens if pumphistory-24h is newer than autosens
+    if find settings/ -newer settings/autosens.json | grep -q pumphistory-24h-zoned.json \
+        || find settings/ -size -5c | grep -q autosens.json \
+        || ! find settings/ | grep -q autosens \
+        || ! find settings/autosens.json; then
+        if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep [0-9]; then
+            mv settings/autosens.json.new settings/autosens.json
+        fi
+    fi
 }
 
 die() {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -177,14 +177,14 @@ function autosens {
         || find settings/ -size -5c | grep -q autosens.json \
         || ! find settings/ | grep -q autosens \
         || ! find settings/autosens.json; then
-        if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep [0-9]; then
+        if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
             mv settings/autosens.json.new settings/autosens.json
-            echo -n Autosens refreshed
+            echo -n "Autosens refreshed: "
         else
-            echo -n Failed to refresh autosens: using old autosens.json
+            echo -n "Failed to refresh autosens: using old autosens.json: "
         fi
     else
-        echo -n No need to refresh autosens yet
+        echo -n "No need to refresh autosens yet: "
     fi
     cat settings/autosens.json | jq . -C -c
 }

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -177,7 +177,7 @@ function autosens {
         || find settings/ -size -5c | grep -q autosens.json \
         || ! find settings/ | grep -q autosens \
         || ! find settings/autosens.json; then
-        if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json | tee settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
+        if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
             mv settings/autosens.json.new settings/autosens.json
             echo -n "Autosens refreshed: "
         else

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -185,7 +185,7 @@ function autosens {
         fi
         echo -n No need to refresh autosens yet
     fi
-    cat settings/autosens.json | jq .
+    cat settings/autosens.json | jq . -C -c
 }
 
 die() {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -176,7 +176,7 @@ function autosens {
     if find settings/ -newer settings/autosens.json | grep -q pumphistory-24h-zoned.json \
         || find settings/ -size -5c | grep -q autosens.json \
         || ! find settings/ | grep -q autosens \
-        || ! find settings/autosens.json; then
+        || ! find settings/autosens.json >/dev/null; then
         if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
             mv settings/autosens.json.new settings/autosens.json
             echo -n "Autosens refreshed: "

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -243,6 +243,7 @@ function smb_bolus {
     find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
     && if (grep -q '"units":' enact/smb-suggested.json); then
         # press ESC three times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
+        echo -n "Sending ESC ESC ESC to exit any open menus before SMBing: "
         openaps use pump press_keys esc esc esc | jq .completed | grep true \
         && openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -77,7 +77,16 @@ main() {
             touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
             echo
         else
-            fail "$@"
+            # don't treat suspended pump as a complete failure
+            if grep -q '"suspended": true' monitor/status.json; then
+                refresh_profile 15; refresh_pumphistory_24h
+                refresh_after_bolus_or_enact
+                echo "Incomplete oref0-pump-loop (pump suspended) at $(date)"
+                echo
+            else
+                # pump-loop errored out for some other reason
+                fail "$@"
+            fi
         fi
     fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -242,7 +242,9 @@ function smb_bolus {
     # and administer the supermicrobolus
     find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
     && if (grep -q '"units":' enact/smb-suggested.json); then
-        openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
+        # press ESC three times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
+        openaps use pump press_keys esc esc esc | jq .completed | grep true \
+        && openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \
         && rm -rf enact/smb-suggested.json
     else

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1048,9 +1048,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         else
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'oref0-ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'oref0-ns-loop' || oref0-ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
         fi
-        if [[ $ENABLE =~ autosens ]]; then
-            (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens' || openaps autosens 2>&1" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens' || openaps autosens 2>&1 | tee -a /var/log/openaps/autosens-loop.log") | crontab -
-        fi
+        #if [[ $ENABLE =~ autosens ]]; then
+            #(crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens' || openaps autosens 2>&1" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps autosens' || openaps autosens 2>&1 | tee -a /var/log/openaps/autosens-loop.log") | crontab -
+        #fi
         if [[ $ENABLE =~ autotune ]]; then
             # autotune nightly at 12:05am using data from NS
             (crontab -l; crontab -l | grep -q "oref0-autotune -d=$directory -n=$NIGHTSCOUT_HOST" || echo "5 0 * * * ( oref0-autotune -d=$directory -n=$NIGHTSCOUT_HOST && cat $directory/autotune/profile.json | json | grep -q start && cp $directory/autotune/profile.json $directory/settings/autotune.json) 2>&1 | tee -a /var/log/openaps/autotune.log") | crontab -

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -316,21 +316,64 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // SMB is disabled by default, unless explicitly enabled in preferences.json
     var enableSMB=false;
     // disable SMB when a high temptarget is set
-    if (! profile.allowSMB_with_high_temptarget && profile.temptargetSet && target_bg > 100) {
+    if (! microBolusAllowed) {
+        console.error("SMB disabled")
+    } else if (! profile.allowSMB_with_high_temptarget && profile.temptargetSet && target_bg > 100) {
+        console.error("SMB disabled due to high temptarget of",target_bg);
         enableSMB=false;
-    // enable SMB/UAM if always-on (unless previously disabled for high temptarget)
-    } else if (profile.enableSMB_always) {
-        enableSMB=true;
     // enable SMB/UAM (if enabled in preferences) while we have COB
     } else if (profile.enableSMB_with_COB && meal_data.mealCOB) {
-        enableSMB=true;
-    // enable SMB/UAM (if enabled in preferences) if a low temptarget is set
-    } else if (profile.enableSMB_with_temptarget && (profile.temptargetSet && target_bg < 100)) {
-        enableSMB=true;
+        if (meal_data.bwCarbs) {
+            if (A52_risk_enable) {
+                console.error("Warning: SMB enabled with Bolus Wizard carbs: be sure to easy bolus 30s before using Bolus Wizard")
+                enableSMB=true;
+            } else {
+                console.error("SMB not enabled for Bolus Wizard COB");
+            }
+        } else {
+            console.error("SMB enabled for COB of",meal_data.mealCOB);
+            enableSMB=true;
+        }
     // enable SMB/UAM (if enabled in preferences) for a full 6 hours after any carb entry
     // (6 hours is defined in carbWindow in lib/meal/total.js)
-    } else if (profile.enableSMB_after_carbs && meal_data.carbs) {
-        enableSMB=true;
+    } else if (profile.enableSMB_after_carbs && meal_data.carbs ) {
+        if (meal_data.bwCarbs) {
+            if (A52_risk_enable) {
+            console.error("Warning: SMB enabled with Bolus Wizard carbs: be sure to easy bolus 30s before using Bolus Wizard")
+            enableSMB=true;
+            } else {
+                console.error("SMB not enabled for Bolus Wizard carbs");
+            }
+        } else {
+            console.error("SMB enabled for 6h after carb entry");
+            enableSMB=true;
+        }
+    // enable SMB/UAM (if enabled in preferences) if a low temptarget is set
+    } else if (profile.enableSMB_with_temptarget && (profile.temptargetSet && target_bg < 100)) {
+        if (meal_data.bwFound) {
+            if (A52_risk_enable) {
+                console.error("Warning: SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard")
+                enableSMB=true;
+            } else {
+                console.error("enableSMB_with_temptarget not supported within 6h of using Bolus Wizard");
+            }
+        } else {
+            console.error("SMB enabled for temptarget of",target_bg);
+            enableSMB=true;
+        }
+    // enable SMB/UAM if always-on (unless previously disabled for high temptarget)
+    } else if (profile.enableSMB_always) {
+        if (meal_data.bwFound) {
+            if (A52_risk_enable) {
+                console.error("Warning: SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard")
+                enableSMB=true;
+            } else {
+                console.error("enableSMB_always not supported within 6h of using Bolus Wizard");
+            }
+        } else {
+            console.error("SMB enabled due to enableSMB_always");
+            enableSMB=true;
+        }
     }
     // enable UAM (if enabled in preferences) if SMB is enabled
     var enableUAM=(profile.enableUAM && enableSMB);

--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -22,6 +22,7 @@ function findMealInputs (inputs) {
             var temp = {};
             temp.timestamp = current.created_at;
             temp.carbs = current.carbs;
+            temp.nsCarbs = current.carbs;
             
         if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.created_at,"carbs")) {
                 mealInputs.push(temp);
@@ -48,12 +49,14 @@ function findMealInputs (inputs) {
             var temp = {};
             temp.timestamp = current.timestamp;
             temp.carbs = current.carb_input;
+            temp.bwCarbs = current.carbs;
             
             // don't enter the treatment if there's another treatment with the same exact timestamp
             // to prevent duped carb entries from multiple sources
             if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"carbs")) {
                 if (arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"bolus")) {
                     mealInputs.push(temp);
+                    //bwCarbs += temp.carbs;
                 } else {
                     console.error("skipping bolus wizard entry with",current.carb_input,"g carbs and no insulin");
                 }
@@ -66,10 +69,11 @@ function findMealInputs (inputs) {
             var temp = {};
             temp.timestamp = current.created_at;
             temp.carbs = current.carbs;
+            temp.nsCarbs = current.carbs;
             // don't enter the treatment if there's another treatment with the same exact timestamp
             // to prevent duped carb entries from multiple sources
             if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.created_at,"carbs")) {
-                    mealInputs.push(temp);
+                mealInputs.push(temp);
             } else {
                 duplicates += 1;
             }
@@ -77,6 +81,7 @@ function findMealInputs (inputs) {
             var temp = {};
             temp.timestamp = current.created_at;
             temp.carbs = current.carbs;
+            temp.nsCarbs = current.carbs;
             temp.bolus = current.insulin;
             if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"carbs")) {
                 mealInputs.push(temp);
@@ -86,6 +91,7 @@ function findMealInputs (inputs) {
         } else if (current.carbs > 0) {
             var temp = {};
             temp.carbs = current.carbs;
+            temp.nsCarbs = current.carbs;
             temp.timestamp = current.created_at;
             if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"carbs")) {
                 mealInputs.push(temp);

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -8,6 +8,9 @@ function recentCarbs(opts, time) {
         var glucose_data = opts.glucose;
     }
     var carbs = 0;
+    var nsCarbs = 0;
+    var bwCarbs = 0;
+    var bwFound = false;
     var carbDelay = 20 * 60 * 1000;
     var maxCarbs = 0;
     var mealCarbTime = time.getTime();
@@ -36,6 +39,8 @@ function recentCarbs(opts, time) {
     });
 
     var carbsToRemove = 0;
+    var nsCarbsToRemove = 0;
+    var bwCarbsToRemove = 0;
     treatments.forEach(function(treatment) {
         var now = time.getTime();
         // consider carbs from up to 6 hours ago in calculating COB
@@ -44,6 +49,12 @@ function recentCarbs(opts, time) {
         var treatmentTime = treatmentDate.getTime();
         if (treatmentTime > carbWindow && treatmentTime <= now) {
             if (treatment.carbs >= 1) {
+                if (treatment.nsCarbs >= 1) {
+                    nsCarbs += parseFloat(treatment.nsCarbs);
+                } else if (treatment.bwCarbs >= 1) {
+                    bwCarbs += parseFloat(treatment.bwCarbs);
+                    bwFound = true;
+                }
                 //console.error(treatment.carbs, maxCarbs, treatmentDate);
                 carbs += parseFloat(treatment.carbs);
                 COB_inputs.mealTime = treatmentTime;
@@ -54,8 +65,15 @@ function recentCarbs(opts, time) {
                 //console.error("myMealCOB:",myMealCOB, "mealCOB:",mealCOB, "carbs:",carbs,"myCarbsAbsorbed:",myCarbsAbsorbed);
                 if (myMealCOB < mealCOB) {
                     carbsToRemove += parseFloat(treatment.carbs);
+                    if (treatment.nsCarbs >= 1) {
+                        nsCarbsToRemove += parseFloat(treatment.nsCarbs);
+                    } else if (treatment.bwCarbs >= 1) {
+                        bwCarbsToRemove += parseFloat(treatment.bwCarbs);
+                    }
                 } else {
                     carbsToRemove = 0;
+                    nsCarbsToRemove = 0;
+                    bwCarbsToRemove = 0;
                 }
                 //console.error(carbs, carbsToRemove);
                 //console.error("COB:",mealCOB);
@@ -64,6 +82,8 @@ function recentCarbs(opts, time) {
     });
     // only include carbs actually used in calculating COB
     carbs -= carbsToRemove;
+    nsCarbs -= nsCarbsToRemove;
+    bwCarbs -= bwCarbsToRemove;
 
     // calculate the current deviation and steepest deviation downslope over the last hour
     COB_inputs.ciTime = time.getTime();
@@ -87,6 +107,8 @@ function recentCarbs(opts, time) {
 
     return {
         carbs: Math.round( carbs * 1000 ) / 1000
+    ,   nsCarbs: Math.round( nsCarbs * 1000 ) / 1000
+    ,   bwCarbs: Math.round( bwCarbs * 1000 ) / 1000
     ,   mealCOB: Math.round( mealCOB )
     ,   currentDeviation: Math.round( c.currentDeviation * 100 ) / 100
     ,   maxDeviation: Math.round( c.maxDeviation * 100 ) / 100
@@ -95,6 +117,7 @@ function recentCarbs(opts, time) {
     ,   slopeFromMinDeviation: Math.round( c.slopeFromMinDeviation * 1000 ) / 1000
     ,   allDeviations: c.allDeviations
     ,   lastCarbTime: lastCarbTime
+    ,   bwFound: bwFound
     };
 }
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -32,6 +32,7 @@ function defaults ( ) {
     , remainingCarbsCap: 90 // max carbs we'll assume will absorb over 4h if we don't yet see carb absorption
     // WARNING: the following are advanced oref1 features, and are not yet tested for general use
     , enableUAM: true // enable detection of unannounced meal carb absorption
+    , A52_risk_enable: false
     , enableSMB_always: false // always enable supermicrobolus (unless disabled by high temptarget)
     , enableSMB_with_COB: false // enable supermicrobolus while COB is positive
     , enableSMB_with_temptarget: false // enable supermicrobolus for eating soon temp targets

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oref0",
-  "version": "0.6.0-dev3",
+  "version": "0.6.0-dev4",
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",


### PR DESCRIPTION
Currently we run autosens in its own loop in cron.  This results in autosens occasionally running at the same time that ns-loop is refreshing carbhistory.json, which causes autosens to generate different results (since it can't properly exclude meal periods).

This PR updates oref-ns-loop.sh to run autosens after uploading to NS, which ensures that it happens after the carbhistory refresh.  It also checks that glucose data is fresh before and after running autosens, to ensure that a slow autosens run doesn't prevent us from getting new BG data for long.