### PR TITLE
change default curve to rapid-acting

### DIFF
--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -39,7 +39,7 @@ function defaults ( ) {
     , enableSMB_after_carbs: false // enable supermicrobolus for 6h after carbs, even with 0 COB
     , allowSMB_with_high_temptarget: false // allow supermicrobolus (if otherwise enabled) even with high temp targets
     , maxSMBBasalMinutes: 30 // maximum minutes of basal that can be delivered as a single SMB with uncovered COB
-    , curve: "bilinear"
+    , curve: "rapid-acting"
     , useCustomPeakTime: false
     , insulinPeakTime: 75
     , carbsReqThreshold: 1


### PR DESCRIPTION
Everyone who's noticed any difference with exponential curves has reported it as an improvement, so I think it's best to go ahead and change the default curve from bilinear to rapid-acting before we release 0.6.0.