### PR TITLE
Add a note with the latest calculated IOB after boluses.

### DIFF
--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -90,6 +90,17 @@ function reduce (treatments) {
         annotate("Normal bolus (solo, no bolus wizard).");
       }
 
+      if (has_insulin) {
+        var iobFile = "./monitor/iob.json";
+        var fs = require('fs');
+        if (fs.existsSync(iobFile)) {
+	  var iob = JSON.parse(fs.readFileSync(iobFile));
+          if (iob && Array.isArray(iob) && iob.length) {
+            annotate("Calculated IOB:", iob[0].iob);
+          }
+        }
+      }
+
       if (state.bolus) {
         annotate("Programmed bolus", state.bolus.programmed);
         annotate("Delivered bolus", state.bolus.amount);


### PR DESCRIPTION
This is useful when multiple small micro boluses are being
administered. The notes will be visible in the pushover notifications from
nightscout.