### PR TITLE
Dev

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -640,8 +640,8 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         bluetoothdminversion=5.47
         bluetoothdversioncompare=$(awk 'BEGIN{ print "'$bluetoothdversion'"<"'$bluetoothdminversion'" }')
         if [ "$bluetoothdversioncompare" -eq 1 ]; then
-            killall bluetoothd &>/dev/null #Kill current running version if its out of date and we are updating it
             cd $HOME/src/ && wget -4 https://www.kernel.org/pub/linux/bluetooth/bluez-5.47.tar.gz && tar xvfz bluez-5.47.tar.gz || die "Couldn't download bluez"
+            killall bluetoothd &>/dev/null #Kill current running version if its out of date and we are updating it
             cd $HOME/src/bluez-5.47 && ./configure --enable-experimental --disable-systemd && \
             make && sudo make install || die "Couldn't make bluez"
             killall bluetoothd &>/dev/null #Kill current running version if its out of date and we are updating it


### PR DESCRIPTION
revise oref0-setup.sh so that, in case openaps WAN is using bluetooth while bluetoothd is updated, wget happens before bluetoothd is killed