### PR TITLE
reset pump clock if >55s off; better error messaging

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -110,14 +110,13 @@ function smb_reservoir_before {
     && openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1 \
     && echo -n "Checking pump clock: " && (cat monitor/clock-zoned.json; echo) | tr -d '\n' \
     && echo -n " is within 1m of current time: " && date \
-    && if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -60 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 60 )); then
-        echo Pump clock is more than 1m off: attempting to reset it
+    && if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -55 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 55 )); then
+        echo Pump clock is more than 55s off: attempting to reset it
         oref0-set-device-clocks
        fi \
-    && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > -60 )) \
-    && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < 60 )) \
-    && echo -n "and that pumphistory is less than 1m old.  " \
-    && (find monitor/ -mmin -1 -size +5c | grep -q pumphistory)
+    (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > -60 )) \
+    && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < 60 )) || (echo "Error: pump clock mismatch"; fail "$@")
+    find monitor/ -mmin -1 -size +5c | grep -q pumphistory || (echo "Error: pumphistory too old"; fail "$@")
 
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -113,11 +113,10 @@ function smb_reservoir_before {
     && if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -55 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 55 )); then
         echo Pump clock is more than 55s off: attempting to reset it
         oref0-set-device-clocks
-       fi \
+       fi
     (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > -60 )) \
     && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < 60 )) || (echo "Error: pump clock mismatch"; fail "$@")
     find monitor/ -mmin -1 -size +5c | grep -q pumphistory || (echo "Error: pumphistory too old"; fail "$@")
-
 }
 
 # check if the temp was read more than 5m ago, or has been running more than 10m


### PR DESCRIPTION
Per https://gitter.im/nightscout/intend-to-bolus?at=59fd9d41b20c642429880228 we should try to reset the pump clock before it drifts a full 60s.  This also gets rid of an extra debug statement and replaces it with proper error messaging if the pump clock is mismatched.