### PR TITLE
only display API_SECRET not set warning if autotune fails

### DIFF
--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -27,8 +27,13 @@
 # THE SOFTWARE.
 
 die() {
-  echo "$@"
-  exit 1
+    if [[ -z "$API_SECRET" ]]; then
+        echo "Warning: API_SECRET is not set when calling oref0-autotune.sh"
+        echo "(this is only a problem if you have locked down read-only access to your NS)."
+    fi
+
+    echo "$@"
+    exit 1
 }
 
 # defaults
@@ -46,11 +51,6 @@ UNKNOWN_OPTION=""
 
 if [ -n "${API_SECRET_READ}" ]; then 
    echo "WARNING: API_SECRET_READ is deprecated starting with oref 0.6.x. The Nightscout authentication information is now used from the API_SECRET environment variable"
-fi
-
-if [[ -z "$API_SECRET" ]]; then
-  echo "Warning: API_SECRET is not set when calling oref0-autotune.sh"
-  # exit 1
 fi
 
 # If we are running OS X, we need to use a different version


### PR DESCRIPTION
Per #736, the current "Warning: API_SECRET is not set when calling oref0-autotune.sh" message is confusing, as it only needs to be set if someone has locked down read-only access to their NS using token auth.  This PR moves the warning line to only display if autotune fails, and to clarify that the warning is only a problem if you have locked down read-only access to your NS.