### PR TITLE
Fix oref0-autotune-recommends-report for DST

### DIFF
--- a/bin/oref0-autotune-recommends-report.sh
+++ b/bin/oref0-autotune-recommends-report.sh
@@ -85,7 +85,7 @@ minutes_list=()
 end_time=23:30
 time=00:00
 minutes=0
-for h in $(seq 0 23); do
+for h in $(seq -w 0 23); do
     for m in 00 30; do
         time="$h:$m"
         minutes=$(echo "60 * $h + $m" | bc)

--- a/bin/oref0-autotune-recommends-report.sh
+++ b/bin/oref0-autotune-recommends-report.sh
@@ -85,16 +85,14 @@ minutes_list=()
 end_time=23:30
 time=00:00
 minutes=0
-while :
-do
-  time_list+=( "$time" )
-  minutes_list+=( "$minutes" )
-  if [ $time != "$end_time" ]; then
-    time="$(date --date="$time 30 minutes" +%R)";
-    minutes=$(expr $minutes + 30)
-  else
-    break
-  fi
+for h in $(seq 0 23); do
+    for m in 00 30; do
+        time="$h:$m"
+        minutes=$(echo "60 * $h + $m" | bc)
+        #echo $time $minutes
+        time_list+=( "$time" )
+        minutes_list+=( "$minutes" )
+    done
 done
 
 for (( i=0; i<${#minutes_list[@]}; i++ ))


### PR DESCRIPTION
The way oref0-autotune-recommends-report currently builds its time_list array of H:M in 30 minute increments to mirror pump basal schedule doesn't work on the day that DST ends and the clock falls back: it goes into an infinite loop from 1am to 1:30am and back instead of proceeding to 2am.

This builds that array much more simply without using `date`,with two nested `for` loops instead, to bypass that problem.