### PR TITLE
make maxZeroTempLength configurable via hidden preference

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1077,8 +1077,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 durationReq = 0;
             // don't set a temp longer than 120 minutes
             } else if (durationReq >= 30) {
+                var maxZeroTempLength = 120
+                if (profile.maxZeroTempLength >= 30) {
+                    maxZeroTempLength = profile.maxZeroTempLength;
+                }
                 durationReq = round(durationReq/30)*30;
-                durationReq = Math.min(120,Math.max(0,durationReq));
+                durationReq = Math.min(maxZeroTempLength,Math.max(0,durationReq));
             } else {
                 // if SMB durationReq is less than 30m, set a nonzero low temp
                 smbLowTempReq = round( basal * durationReq/30 ,2);

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -50,6 +50,7 @@ function defaults ( ) {
     , insulinPeakTime: 75 // number of minutes after a bolus activity peaks.  defaults to 55m for Fiasp if useCustomPeakTime: false
     , carbsReqThreshold: 1 // grams of carbsReq to trigger a pushover
     , offline_hotspot: false // enabled an offline-only local wifi hotspot if no Internet available
+    , maxZeroTempLength: 120 // maximum zero temp length to set for hypo safety, in minutes. >= 60m recommended
   };
   return profile;
 }


### PR DESCRIPTION
Lots of people complain about the 120m zero temps set when SMBing.  I think most of them are either misunderstanding how SMB works, or don't want to use its safety features as designed (and would prefer increased risk of post-meal lows for convenience).  This PR adds a hidden preference to placate them.

Changing maxZeroTempLength from 120m to 90m or even 60m won't make much difference, and is probably pretty safe.  I do not recommend setting it to 30m, as that is likely too short to prevent post-meal lows when carbs are overestimated and the pump walks away from the rig.