### PR TITLE
set >30m zero temps when needed for low minGuardBG

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -480,7 +480,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var minIOBPredBG = 999;
     var minCOBPredBG = 999;
     var minUAMPredBG = 999;
-    var minGuardBG = 999;
+    var minGuardBG = bg;
     var minCOBGuardBG = 999;
     var minUAMGuardBG = 999;
     var minIOBGuardBG = 999;
@@ -843,33 +843,16 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (bg < threshold && iob_data.iob < -profile.current_basal*20/60 && minDelta > 0 && minDelta > expectedDelta) {
         rT.reason += "IOB "+iob_data.iob+" < " + round(-profile.current_basal*20/60,2);
         rT.reason += " and minDelta " + minDelta + " > " + "expectedDelta " + expectedDelta + "; ";
-    // predictive low glucose suspend mode: BG is projected to be < threshold
-    } else if ( minGuardBG < threshold ) {
-        rT.reason += "minGuardBG " + convert_bg(minGuardBG, profile) + "<" + convert_bg(threshold, profile);
-        // always set a 30m zero temp (oref0-pump-loop will let any longer SMB zero temp run)
-        return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
-    // low glucose suspend mode: BG is < ~80
+    // predictive low glucose suspend mode: BG is / is projected to be < threshold
     } else if ( bg < threshold || minGuardBG < threshold ) {
-        rT.reason += "BG " + convert_bg(bg, profile) + "<" + convert_bg(threshold, profile);
-        if ((glucose_status.delta <= 0 && minDelta <= 0) || (glucose_status.delta < expectedDelta && minDelta < expectedDelta) || bg < 60 ) {
-            // BG is still falling / rising slower than predicted
-            if ( minDelta < expectedDelta ) {
-                rT.reason += ", minDelta " + minDelta + " < " + "expectedDelta " + expectedDelta + "; ";
-            }
-            return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
-        }
-        if (glucose_status.delta > minDelta) {
-            rT.reason += ", delta " + glucose_status.delta + ">0";
-        } else {
-            rT.reason += ", min delta " + minDelta.toFixed(2) + ">0";
-        }
-        if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-            rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
-            return rT;
-        } else {
-            rT.reason += "; setting current basal of " + basal + " as temp. ";
-            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-        }
+        rT.reason += "minGuardBG " + convert_bg(minGuardBG, profile) + "<" + convert_bg(threshold, profile);
+        var bgUndershoot = target_bg - minGuardBG;
+        var worstCaseInsulinReq = bgUndershoot / sens;
+        var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
+        durationReq = round(durationReq/30)*30;
+        // always set a 30-120m zero temp (oref0-pump-loop will let any longer SMB zero temp run)
+        durationReq = Math.min(120,Math.max(30,durationReq));
+        return tempBasalFunctions.setTempBasal(0, durationReq, profile, rT, currenttemp);
     }
 
     if (eventualBG < min_bg) { // if eventual BG is below target:


### PR DESCRIPTION
Up until now, minGuardBG < threshold has always set 30m zero temps, even when more than 30m of zero temping would be required to bring BG back up to target.  This sets longer zero temps (30-120m) as needed in those situations.

I also realized that since we added minGuardBG, low glucose suspend mode can only be triggered if BG < threshold but BG is predicted to be >= threshold in 5 minutes.  Rather than continue to special-case that corner case, I set minGuardBG = bg initially (so minGuardBG should always be <= bg), and consolidated the old bg < threshold code into the minGuardBG < threshold case.