### PR TITLE
don't SMB zero temp if insulinReq > 0 but too low for a microBolus

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -895,77 +895,61 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             }
         }
 
-        // if we've bolused recently, we can snooze until the bolus IOB decays (at double speed)
-        //if (snoozeBG > min_bg) { // if adding back in the bolus contribution BG would be above min
-            // If we're not in SMB mode with COB, or lastCOBpredBG > target_bg, bolus snooze
-            //if (! (microBolusAllowed && rT.COB) || lastCOBpredBG > target_bg) {
-                //rT.reason += ", bolus snooze: eventual BG range " + convert_bg(eventualBG, profile) + "-" + convert_bg(snoozeBG, profile);
-                //console.error(currenttemp, basal );
-                //if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                    //rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
-                    //return rT;
-                //} else {
-                    //rT.reason += "; setting current basal of " + basal + " as temp. ";
-                    //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
-                //}
-            //}
-        //} else {
-            // calculate 30m low-temp required to get projected BG up to target
-            // use snoozeBG to more gradually ramp in any counteraction of the user's boluses
-            // multiply by 2 to low-temp faster for increased hypo safety
-            //var insulinReq = 2 * Math.min(0, (snoozeBG - target_bg) / sens);
-            var insulinReq = 2 * Math.min(0, (eventualBG - target_bg) / sens);
-            insulinReq = round( insulinReq , 2);
-            // calculate naiveInsulinReq based on naive_eventualBG
-            var naiveInsulinReq = Math.min(0, (naive_eventualBG - target_bg) / sens);
-            naiveInsulinReq = round( naiveInsulinReq , 2);
-            if (minDelta < 0 && minDelta > expectedDelta) {
-                // if we're barely falling, newinsulinReq should be barely negative
-                //rT.reason += ", Snooze BG " + convert_bg(snoozeBG, profile);
-                var newinsulinReq = round(( insulinReq * (minDelta / expectedDelta) ), 2);
-                //console.error("Increasing insulinReq from " + insulinReq + " to " + newinsulinReq);
-                insulinReq = newinsulinReq;
-            }
-            // rate required to deliver insulinReq less insulin over 30m:
-            var rate = basal + (2 * insulinReq);
-            rate = round_basal(rate, profile);
-            // if required temp < existing temp basal
-            var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
-            // if current temp would deliver a lot (30% of basal) less than the required insulin,
-            // by both normal and naive calculations, then raise the rate
-            var minInsulinReq = Math.min(insulinReq,naiveInsulinReq);
-            if (insulinScheduled < minInsulinReq - basal*0.3) {
-                rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate).toFixed(2) + " is a lot less than needed. ";
-                return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
-            }
-            if (typeof currenttemp.rate !== 'undefined' && (currenttemp.duration > 5 && rate >= currenttemp.rate * 0.8)) {
-                rT.reason += ", temp " + currenttemp.rate + " ~< req " + rate + "U/hr. ";
-                return rT;
-            } else {
-                // calculate a long enough zero temp to eventually correct back up to target
-                if ( rate <=0 ) {
-                    var bgUndershoot = target_bg - naive_eventualBG;
-                    var worstCaseInsulinReq = bgUndershoot / sens;
-                    var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
-                    if (durationReq < 0) {
-                        durationReq = 0;
-                    // don't set a temp longer than 120 minutes
-                    } else {
-                        durationReq = round(durationReq/30)*30;
-                        durationReq = Math.min(120,Math.max(0,durationReq));
-                    }
-                    //console.error(durationReq);
-                    //rT.reason += "insulinReq " + insulinReq + "; "
-                    if (durationReq > 0) {
-                        rT.reason += ", setting " + durationReq + "m zero temp. ";
-                        return tempBasalFunctions.setTempBasal(rate, durationReq, profile, rT, currenttemp);
-                    }
+        // calculate 30m low-temp required to get projected BG up to target
+        // use snoozeBG to more gradually ramp in any counteraction of the user's boluses
+        // multiply by 2 to low-temp faster for increased hypo safety
+        //var insulinReq = 2 * Math.min(0, (snoozeBG - target_bg) / sens);
+        var insulinReq = 2 * Math.min(0, (eventualBG - target_bg) / sens);
+        insulinReq = round( insulinReq , 2);
+        // calculate naiveInsulinReq based on naive_eventualBG
+        var naiveInsulinReq = Math.min(0, (naive_eventualBG - target_bg) / sens);
+        naiveInsulinReq = round( naiveInsulinReq , 2);
+        if (minDelta < 0 && minDelta > expectedDelta) {
+            // if we're barely falling, newinsulinReq should be barely negative
+            //rT.reason += ", Snooze BG " + convert_bg(snoozeBG, profile);
+            var newinsulinReq = round(( insulinReq * (minDelta / expectedDelta) ), 2);
+            //console.error("Increasing insulinReq from " + insulinReq + " to " + newinsulinReq);
+            insulinReq = newinsulinReq;
+        }
+        // rate required to deliver insulinReq less insulin over 30m:
+        var rate = basal + (2 * insulinReq);
+        rate = round_basal(rate, profile);
+        // if required temp < existing temp basal
+        var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
+        // if current temp would deliver a lot (30% of basal) less than the required insulin,
+        // by both normal and naive calculations, then raise the rate
+        var minInsulinReq = Math.min(insulinReq,naiveInsulinReq);
+        if (insulinScheduled < minInsulinReq - basal*0.3) {
+            rT.reason += ", "+currenttemp.duration + "m@" + (currenttemp.rate).toFixed(2) + " is a lot less than needed. ";
+            return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
+        }
+        if (typeof currenttemp.rate !== 'undefined' && (currenttemp.duration > 5 && rate >= currenttemp.rate * 0.8)) {
+            rT.reason += ", temp " + currenttemp.rate + " ~< req " + rate + "U/hr. ";
+            return rT;
+        } else {
+            // calculate a long enough zero temp to eventually correct back up to target
+            if ( rate <=0 ) {
+                var bgUndershoot = target_bg - naive_eventualBG;
+                var worstCaseInsulinReq = bgUndershoot / sens;
+                var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
+                if (durationReq < 0) {
+                    durationReq = 0;
+                // don't set a temp longer than 120 minutes
                 } else {
-                    rT.reason += ", setting " + rate + "U/hr. ";
+                    durationReq = round(durationReq/30)*30;
+                    durationReq = Math.min(120,Math.max(0,durationReq));
                 }
-                return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
+                //console.error(durationReq);
+                //rT.reason += "insulinReq " + insulinReq + "; "
+                if (durationReq > 0) {
+                    rT.reason += ", setting " + durationReq + "m zero temp. ";
+                    return tempBasalFunctions.setTempBasal(rate, durationReq, profile, rT, currenttemp);
+                }
+            } else {
+                rT.reason += ", setting " + rate + "U/hr. ";
             }
-        //}
+            return tempBasalFunctions.setTempBasal(rate, 30, profile, rT, currenttemp);
+        }
     }
   
     // if eventual BG is above min but BG is falling faster than expected Delta
@@ -1001,7 +985,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
-    // eventual BG is at/above target (or bolus snooze disabled for SMB)
+    // eventual BG is at/above target
     // if iob is over max, just cancel any temps
     // if we're not here because of SMB, eventual BG is at/above target
     if (! (microBolusAllowed && rT.COB)) {
@@ -1019,8 +1003,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else { // otherwise, calculate 30m high-temp required to get projected BG down to target
 
         // insulinReq is the additional insulin required to get minPredBG down to target_bg
-        //console.error(minPredBG,snoozeBG,eventualBG);
-        //var insulinReq = round( (Math.min(minPredBG,snoozeBG,eventualBG) - target_bg) / sens, 2);
+        //console.error(minPredBG,eventualBG);
+        //var insulinReq = round( (Math.min(minPredBG,eventualBG) - target_bg) / sens, 2);
         var insulinReq = round( (Math.min(minPredBG,eventualBG) - target_bg) / sens, 2);
         // when dropping, but not as fast as expected, reduce insulinReq proportionally
         // to the what fraction of expectedDelta we're dropping at
@@ -1067,10 +1051,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             var worstCaseInsulinReq = (smbTarget - (naive_eventualBG + minIOBPredBG)/2 ) / sens;
             var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);
 
-            // if no microBolus required, snoozeBG > target_bg, and lastCOBpredBG > target_bg, don't set a zero temp
-            //if (microBolus < 0.1 && snoozeBG > target_bg && lastCOBpredBG > target_bg) {
-                //durationReq = 0;
-            //}
+            // if insulinReq > 0 but not enough for a microBolus, don't set an SMB zero temp
+            if (insulinReq > 0 && microBolus < 0.1) {
+                durationReq = 0;
+            }
 
             var smbLowTempReq = 0;
             if (durationReq <= 0) {


### PR DESCRIPTION
When SMB mode is active, zero temps are set based on naiveEventualBG, and actual insulin requirements are normally covered by SMBs.  However, as per #785, there are situations, particularly with tiny basals, where insulinReq is positive, but is not high enough (0.2U) to trigger the minimum SMB of 0.1U.  In those situations, extended zero temping can occur before insulinReq gets high enough to trigger an SMB.

This PR skips the SMB zero-temp when insulinReq > 0 but microBolus < 0.1, and instead falls through to setting temp basals normally.  This should also help avoid zero temping without SMBs in cases where maxSMBBasalMinutes is too low and maxBolus < 0.1.

(This is somewhat similar to the old SMB bolus snooze behavior, which checked for `snoozeBG > target_bg && lastCOBpredBG > target_bg` instead, so I uncommented and reused that code.  I also removed a bunch of other old commented-out snoozeBG code and un-indented the remaining code block.)