### PR TITLE
only add extra negative deviations if exercise mode is set

### DIFF
--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -274,17 +274,19 @@ function detectSensitivity(inputs) {
         } else {
             process.stderr.write("x");
         }
-        // add an extra negative deviation if a high temptarget is running
-        tempTarget = tempTargetRunning(inputs.temptargets, bgTime)
-        if (tempTarget) {
-            //console.error(tempTarget)
-        }
-        if ( tempTarget > 100 ) {
-            // for a 110 temptarget, add a -0.5 deviation, for 160 add -3
-            tempDeviation=-(tempTarget-100)/20;
-            process.stderr.write("-");
-            //console.error(tempDeviation)
-            deviations.push(tempDeviation);
+        // add an extra negative deviation if a high temptarget is running and exercise mode is set
+        if (profile.high_temptarget_raises_sensitivity || profile.exercise_mode) {
+            tempTarget = tempTargetRunning(inputs.temptargets, bgTime)
+            if (tempTarget) {
+                //console.error(tempTarget)
+            }
+            if ( tempTarget > 100 ) {
+                // for a 110 temptarget, add a -0.5 deviation, for 160 add -3
+                tempDeviation=-(tempTarget-100)/20;
+                process.stderr.write("-");
+                //console.error(tempDeviation)
+                deviations.push(tempDeviation);
+            }
         }
 
         var minutes = bgTime.getMinutes();


### PR DESCRIPTION
Per https://gitter.im/nightscout/intend-to-bolus?at=5a08a2a471ad3f8736d66aa4 we should probably only be adding extra negative deviation if a high temptarget is running if exercise_mode or high_temptarget_raises_sensitivity is set.