### PR TITLE
gzip old autotune json and log files to save space

### DIFF
--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -178,7 +178,8 @@ done
 echo "Compressing old json and log files to save space..."
 gzip -f ns-*.json
 gzip -f autotune*.json
-gzip -f autotune.*.log
+# TODO: figure out how to do this without gzipping the log we're currently writing to
+# gzip -f autotune.*.log
 echo "Autotune disk usage:"
 du -h .
 echo "Overall disk used/avail:"

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -178,8 +178,8 @@ done
 echo "Compressing old json and log files to save space..."
 gzip -f ns-*.json
 gzip -f autotune*.json
-# TODO: figure out how to do this without gzipping the log we're currently writing to
-# gzip -f autotune.*.log
+# only gzip autotune log files more than 2 days old
+find autotune.*.log -mtime +2 | while read file; do gzip -f $file; done
 echo "Autotune disk usage:"
 du -h .
 echo "Overall disk used/avail:"

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -155,7 +155,6 @@ fi
 # If a previous valid settings/autotune.json exists, use that; otherwise start from settings/profile.json
 cp settings/autotune.json autotune/profile.json && cat autotune/profile.json | jq . | grep -q start || cp autotune/profile.pump.json autotune/profile.json
 cd autotune
-# TODO: Need to think through what to remove in the autotune folder...
 
 # Turn on stderr logging, if enabled (default to true)
 if [[ $TERMINAL_LOGGING = "true" ]]; then
@@ -175,6 +174,15 @@ do
     break
   fi
 done
+
+echo "Compressing old json and log files to save space..."
+gzip ns-*.json
+gzip autotune*.json
+gzip autotune.*.log
+echo "Autotune disk usage:"
+du -h .
+echo "Overall disk used/avail:"
+df -h .
 
 echo "Grabbing NIGHTSCOUT treatments.json and entries/sgv.json for date range..."
 

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -176,9 +176,9 @@ do
 done
 
 echo "Compressing old json and log files to save space..."
-gzip ns-*.json
-gzip autotune*.json
-gzip autotune.*.log
+gzip -f ns-*.json
+gzip -f autotune*.json
+gzip -f autotune.*.log
 echo "Autotune disk usage:"
 du -h .
 echo "Overall disk used/avail:"


### PR DESCRIPTION
Without intervention, the autotune/ directory can grow indefinitely, as it keeps all old entries, treatments, and autotune log files.  To reduce the disk space impact of doing so, this PR gzips all of those old files before each run.