### PR TITLE
run autotune 4am-4am instead of midnight-midnight

### DIFF
--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -181,7 +181,8 @@ echo "Grabbing NIGHTSCOUT treatments.json and entries/sgv.json for date range...
 # Get Nightscout BG (sgv.json) Entries
 for i in "${date_list[@]}"
 do 
-    query="find%5Bdate%5D%5B%24gte%5D=`(date -d $i +%s | tr -d '\n'; echo 000)`&find%5Bdate%5D%5B%24lte%5D=`(date --date="$i +1 days" +%s | tr -d '\n'; echo 000)`&count=1000"
+    # pull CGM data from 4am-4am
+    query="find%5Bdate%5D%5B%24gte%5D=`(date -d "$i +4 hours " +%s | tr -d '\n'; echo 000)`&find%5Bdate%5D%5B%24lte%5D=`(date --date="$i +28 hours" +%s | tr -d '\n'; echo 000)`&count=1000"
     echo Query: $NIGHTSCOUT_HOST $query
     ns-get host $NIGHTSCOUT_HOST entries/sgv.json $query > ns-entries.$i.json || die "Couldn't download ns-entries.$i.json"
     ls -la ns-entries.$i.json || die "No ns-entries.$i.json downloaded"
@@ -190,8 +191,8 @@ do
     # echo $i $START_DATE;
     #query="find%5Bdate%5D%5B%24gte%5D=`(date -d $i +%s | tr -d'\n'; echo 000)`&find%5Bdate%5D%5B%24lte%5D=`(date --date="$i +1 days" +%s | tr -d '\n'; echo 000)`&count=1000"
     # to capture UTC-dated treatments, we need to capture an extra 12h on either side, plus the DIA lookback
-    # 18h = 12h for timezones + 6h for DIA; 36h = 24h for end-of-day + 12h for timezones
-    query="find%5Bcreated_at%5D%5B%24gte%5D=`date --date="$i -18 hours" -Iminutes`&find%5Bcreated_at%5D%5B%24lte%5D=`date --date="$i +36 hours" -Iminutes`"
+    # 18h = 12h for timezones + 6h for DIA; 40h = 28h for 4am + 12h for timezones
+    query="find%5Bcreated_at%5D%5B%24gte%5D=`date --date="$i -18 hours" -Iminutes`&find%5Bcreated_at%5D%5B%24lte%5D=`date --date="$i +42 hours" -Iminutes`"
     echo Query: $NIGHTSCOUT_HOST/$query
     ns-get host $NIGHTSCOUT_HOST treatments.json $query > ns-treatments.$i.json || die "Couldn't download ns-treatments.$i.json"
     ls -la ns-treatments.$i.json || die "No ns-treatments.$i.json downloaded"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1018,8 +1018,8 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'oref0-autosens-loop' || oref0-autosens-loop 2>&1" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'oref0-autosens-loop' || oref0-autosens-loop 2>&1 | tee -a /var/log/openaps/autosens-loop.log") | crontab -
         fi
         if [[ $ENABLE =~ autotune ]]; then
-            # autotune nightly at 12:05am using data from NS
-            (crontab -l; crontab -l | grep -q "oref0-autotune -d=$directory -n=$NIGHTSCOUT_HOST" || echo "5 0 * * * ( oref0-autotune -d=$directory -n=$NIGHTSCOUT_HOST && cat $directory/autotune/profile.json | json | grep -q start && cp $directory/autotune/profile.json $directory/settings/autotune.json) 2>&1 | tee -a /var/log/openaps/autotune.log") | crontab -
+            # autotune nightly at 4:05am using data from NS
+            (crontab -l; crontab -l | grep -q "oref0-autotune -d=$directory -n=$NIGHTSCOUT_HOST" || echo "5 4 * * * ( oref0-autotune -d=$directory -n=$NIGHTSCOUT_HOST && cat $directory/autotune/profile.json | json | grep -q start && cp $directory/autotune/profile.json $directory/settings/autotune.json) 2>&1 | tee -a /var/log/openaps/autotune.log") | crontab -
         fi
         if [[ "$ttyport" =~ "spi" ]]; then
             (crontab -l; crontab -l | grep -q "reset_spi_serial.py" || echo "@reboot reset_spi_serial.py") | crontab -


### PR DESCRIPTION
When COB > 0 at midnight, it messes up autotuning of CR and post-midnight basals.  Since most people's schedules mean COB=0 at 4am a lot more often than at midnight, this PR changes autotune to run 4am-4am instead of midnight-midnight to mostly avoid those issues.

Anyone installing this branch will need to re-run oref0-setup and answer Y to deleting their old cron (or manually update the autotune cron line from 12:05am to 4:05am) or their autotune will stop tuning midnight-4am basals until they do so.