### PR TITLE
Cancel high temps and shorten long zero temps when we lose CGM data

### DIFF
--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -191,26 +191,6 @@ if (!module.parent) {
       process.exit(1);
     }
 
-    //if old reading from Dexcom do nothing
-
-    var systemTime = new Date();
-    var bgTime;
-    if (glucose_data[0].display_time) {
-        bgTime = new Date(glucose_data[0].display_time.replace('T', ' '));
-    } else if (glucose_data[0].dateString) {
-        bgTime = new Date(glucose_data[0].dateString);
-    } else { console.error("Could not determine last BG time"); }
-    var minAgo = (systemTime - bgTime) / 60 / 1000;
-
-    if (minAgo > 10 || minAgo < -5) { // Dexcom data is too old, or way in the future
-        var reason = "BG data is too old (it's probably this), or clock set incorrectly.  The last BG data was read at "+bgTime+" but your system time currently is "+systemTime;
-        console.error(reason);
-        var msg = {reason: reason }
-        console.log(JSON.stringify(msg));
-        process.exit(1);
-    }
-
-
     if (typeof(iob_data.length) && iob_data.length > 1) {
         console.error(JSON.stringify(iob_data[0]));
     } else {

--- a/bin/oref0-determine-basal.js
+++ b/bin/oref0-determine-basal.js
@@ -182,6 +182,15 @@ if (!module.parent) {
         }
     }
 
+    if (warnings.length) {
+      console.error(JSON.stringify(warnings));
+    }
+
+    if (errors.length) {
+      console.log(JSON.stringify(errors));
+      process.exit(1);
+    }
+
     //if old reading from Dexcom do nothing
 
     var systemTime = new Date();
@@ -193,21 +202,11 @@ if (!module.parent) {
     } else { console.error("Could not determine last BG time"); }
     var minAgo = (systemTime - bgTime) / 60 / 1000;
 
-    if (warnings.length) {
-      console.error(JSON.stringify(warnings));
-    }
-
-    if (errors.length) {
-      console.log(JSON.stringify(errors));
-      process.exit(1);
-    }
-
     if (minAgo > 10 || minAgo < -5) { // Dexcom data is too old, or way in the future
         var reason = "BG data is too old (it's probably this), or clock set incorrectly.  The last BG data was read at "+bgTime+" but your system time currently is "+systemTime;
         console.error(reason);
         var msg = {reason: reason }
         console.log(JSON.stringify(msg));
-        // errors.push(msg);
         process.exit(1);
     }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -68,10 +68,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (bg < 39) {  //Dexcom is in ??? mode or calibrating
         rT.reason = "CGM is calibrating or in ??? state";
     }
-    if (minAgo > 10 || minAgo < -5) { // Dexcom data is too old, or way in the future
+    if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     }
-    if (bg < 39 || minAgo > 10 || minAgo < -5) {
+    if (bg < 39 || minAgo > 12 || minAgo < -5) {
         if (currenttemp.rate >= basal) { // high temp is running
             rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
             rT.deliverAt = deliverAt;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -60,16 +60,36 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var profile_current_basal = round_basal(profile.current_basal, profile);
     var basal = profile_current_basal;
 
+    var systemTime = new Date();
+    var bgTime = new Date(glucose_status.date);
+    var minAgo = round( (systemTime - bgTime) / 60 / 1000 ,1);
+
     var bg = glucose_status.glucose;
     if (bg < 39) {  //Dexcom is in ??? mode or calibrating
         rT.reason = "CGM is calibrating or in ??? state";
-        if (basal <= currenttemp.rate * 1.2) { // high temp is running
-            rT.reason += "; setting current basal of " + basal + " as temp. ";
+    }
+    if (minAgo > 10 || minAgo < -5) { // Dexcom data is too old, or way in the future
+        rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
+    }
+    if (bg < 39 || minAgo > 10 || minAgo < -5) {
+        if (currenttemp.rate >= basal) { // high temp is running
+            rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
             rT.deliverAt = deliverAt;
             rT.temp = 'absolute';
-            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+            rT.duration = 0;
+            rT.rate = 0;
+            return rT;
+            //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+        } else if ( currenttemp.rate == 0 && currenttemp.duration > 30 ) { //shorten long zero temps to 30m
+            rT.reason += ". Shortening " + currenttemp.duration + "m long zero temp to 30m. ";
+            rT.deliverAt = deliverAt;
+            rT.temp = 'absolute';
+            rT.duration = 30;
+            rT.rate = 0;
+            return rT;
+            //return tempBasalFunctions.setTempBasal(0, 30, profile, rT, currenttemp);
         } else { //do nothing.
-            rT.reason += ", temp " + currenttemp.rate + " <~ current basal " + basal + "U/hr. ";
+            rT.reason += ". Temp " + currenttemp.rate + " <= current basal " + basal + "U/hr; doing nothing. ";
             return rT;
         }
     }

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -67,6 +67,7 @@ var getLastGlucose = function (data) {
         , glucose: Math.round( now.glucose * 100 ) / 100
         , short_avgdelta: Math.round( short_avgdelta * 100 ) / 100
         , long_avgdelta: Math.round( long_avgdelta * 100 ) / 100
+        , date: now_date
     };
 };
 


### PR DESCRIPTION
Per https://github.com/openaps/oref0/issues/788 it would be better to cancel/shorten long zero temps when the rig stops receiving CGM data.  It would also make sense to do the same thing for CGM errors as for no data, as they're often the same condition, just with/without the CGM plugged in.  In the event of >10m old CGM data, or CGM errors, this PR will:

Cancel high temps:
{"rate":0,"duration":0,"temp":"absolute","deliverAt":"2017-11-14T01:11:00.349Z","reason":"If current system time Mon Nov 13 2017 17:11:00 GMT-0800 (PST) is correct, then BG data is too old. The last BG data was read 12m ago at Mon Nov 13 2017 16:59:00 GMT-0800 (PST). Canceling high temp basal of 3.3"}

Shorten long zero temps to 30m:
{"rate":0,"duration":30,"temp":"absolute","deliverAt":"2017-11-14T01:11:42.771Z","reason":"If current system time Mon Nov 13 2017 17:11:42 GMT-0800 (PST) is correct, then BG data is too old. The last BG data was read 12.7m ago at Mon Nov 13 2017 16:59:00 GMT-0800 (PST). Shortening 59m long zero temp to 30m. "}

and let low temps run:
{"reason":"If current system time Mon Nov 13 2017 17:09:46 GMT-0800 (PST) is correct, then BG data is too old. The last BG data was read 10.8m ago at Mon Nov 13 2017 16:59:00 GMT-0800 (PST). Temp 1.25 <= current basal 1.3U/hr; doing nothing. "}