### PR TITLE
require boolean true on enableSMB preferences

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -343,12 +343,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var enableSMB=false;
     // disable SMB when a high temptarget is set
     if (! microBolusAllowed) {
-        console.error("SMB disabled")
+        console.error("SMB disabled (!microBolusAllowed)")
     } else if (! profile.allowSMB_with_high_temptarget && profile.temptargetSet && target_bg > 100) {
         console.error("SMB disabled due to high temptarget of",target_bg);
         enableSMB=false;
     // enable SMB/UAM (if enabled in preferences) while we have COB
-    } else if (profile.enableSMB_with_COB && meal_data.mealCOB) {
+    } else if (profile.enableSMB_with_COB === true && meal_data.mealCOB) {
         if (meal_data.bwCarbs) {
             if (profile.A52_risk_enable) {
                 console.error("Warning: SMB enabled with Bolus Wizard carbs: be sure to easy bolus 30s before using Bolus Wizard")
@@ -362,7 +362,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     // enable SMB/UAM (if enabled in preferences) for a full 6 hours after any carb entry
     // (6 hours is defined in carbWindow in lib/meal/total.js)
-    } else if (profile.enableSMB_after_carbs && meal_data.carbs ) {
+    } else if (profile.enableSMB_after_carbs === true && meal_data.carbs ) {
         if (meal_data.bwCarbs) {
             if (profile.A52_risk_enable) {
             console.error("Warning: SMB enabled with Bolus Wizard carbs: be sure to easy bolus 30s before using Bolus Wizard")
@@ -375,7 +375,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             enableSMB=true;
         }
     // enable SMB/UAM (if enabled in preferences) if a low temptarget is set
-    } else if (profile.enableSMB_with_temptarget && (profile.temptargetSet && target_bg < 100)) {
+    } else if (profile.enableSMB_with_temptarget === true && (profile.temptargetSet && target_bg < 100)) {
         if (meal_data.bwFound) {
             if (profile.A52_risk_enable) {
                 console.error("Warning: SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard")
@@ -388,9 +388,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             enableSMB=true;
         }
     // enable SMB/UAM if always-on (unless previously disabled for high temptarget)
-    } else if (profile.enableSMB_always) {
+    } else if (profile.enableSMB_always === true) {
         if (meal_data.bwFound) {
-            if (profile.A52_risk_enable) {
+            if (profile.A52_risk_enable === true) {
                 console.error("Warning: SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard")
                 enableSMB=true;
             } else {
@@ -401,7 +401,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             enableSMB=true;
         }
     } else {
-        console.error("SMB disabled");
+        console.error("SMB disabled (no enableSMB preferences active)");
     }
     // enable UAM (if enabled in preferences) if SMB is enabled
     var enableUAM=(profile.enableUAM && enableSMB);


### PR DESCRIPTION
Per https://gitter.im/nightscout/intend-to-bolus?at=5a15a1a2df09362e673ea448 @alimhassam discovered that setting a preference to the string `"false"` (instead of the boolean `false`) evaluates as `true`, which unexpectedly gave him enabledSMB_always behavior.  This PR looks for a boolean `true` (not just something that evaluates to true) for the enableSMB preferences to make things behave as you'd intuitively expect.

There may be other boolean preferences that need this treatment as well, but the enableSMB ones are the most important.