### PR TITLE
add MDT to oref0-ns-loop

### DIFF
--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -6,7 +6,6 @@
 main() {
     echo
     echo Starting oref0-ns-loop at $(date):
-	#if [ mdt_check == 1 ]; then
 	if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
 		check_mdt_upload
 	else

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1023,7 +1023,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         elif ! [[ ${CGM,,} =~ "mdt" ]]; then # use nightscout for cgm
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps get-bg' || ( date; openaps get-bg ; cat cgm/glucose.json | json -a sgv dateString | head -1 ) | tee -a /var/log/openaps/cgm-loop.log") | crontab -
         fi
-        if [[ ${CGM,,} =~ "mdt" ]] || [[ ${CGM,,} =~ "xdrip" ]]; then # use old ns-loop for now
+        if [[ ${CGM,,} =~ "xdrip" ]]; then # use old ns-loop for now
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'openaps ns-loop' || openaps ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -
         else
             (crontab -l; crontab -l | grep -q "cd $directory && ps aux | grep -v grep | grep -q 'oref0-ns-loop'" || echo "* * * * * cd $directory && ps aux | grep -v grep | grep -q 'oref0-ns-loop' || oref0-ns-loop | tee -a /var/log/openaps/ns-loop.log") | crontab -


### PR DESCRIPTION
got rid of all MDT aliases and moved the uploading of the MDT CGM reading to oref0-ns-loop.

We waste less time on uploading the cgm data when there is nothing to upload yet, so since the upload loop runs faster you will have less time of a new cgm data that was received sitting around waiting to be uploaded. so it might be a bit faster on updating. 
note this does not fix the issue of collecting cgm data, just the uploading it to nightscout. 