### PR TITLE
use pumpbasalprofile for autotune IOB calculations

### DIFF
--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -97,6 +97,7 @@ if (!module.parent) {
     var inputs = {
         history: pumphistory_data
     , profile: profile_data
+    , pumpprofile: pumpprofile_data
     , carbs: carb_data
     , glucose: glucose_data
     , prepped_glucose: prepped_glucose_data

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -152,17 +152,21 @@ function categorizeBGDatums(opts) {
         //sens = ISF
         var sens = ISF.isfLookup(IOBInputs.profile.isfProfile,BGDate);
         IOBInputs.clock=BGDate.toISOString();
-        // use the average of the last 4 hours' basals to help convergence;
+        // for IOB calculations, use the average of the last 4 hours' basals to help convergence;
         // this helps since the basal this hour could be different from previous, especially if with autotune they start to diverge.
-        currentBasal = basal.basalLookup(opts.basalprofile, BGDate);
+        // use the pumpbasalprofile to properly calculate IOB during periods where no temp basal is set
+        currentPumpBasal = basal.basalLookup(opts.pumpbasalprofile, BGDate);
         BGDate1hAgo = new Date(BGTime-1*60*60*1000);
         BGDate2hAgo = new Date(BGTime-2*60*60*1000);
         BGDate3hAgo = new Date(BGTime-3*60*60*1000);
-        basal1hAgo = basal.basalLookup(opts.basalprofile, BGDate1hAgo);
-        basal2hAgo = basal.basalLookup(opts.basalprofile, BGDate2hAgo);
-        basal3hAgo = basal.basalLookup(opts.basalprofile, BGDate3hAgo);
-        var sum = [currentBasal,basal1hAgo,basal2hAgo,basal3hAgo].reduce(function(a, b) { return a + b; });
+        basal1hAgo = basal.basalLookup(opts.pumpbasalprofile, BGDate1hAgo);
+        basal2hAgo = basal.basalLookup(opts.pumpbasalprofile, BGDate2hAgo);
+        basal3hAgo = basal.basalLookup(opts.pumpbasalprofile, BGDate3hAgo);
+        var sum = [currentPumpBasal,basal1hAgo,basal2hAgo,basal3hAgo].reduce(function(a, b) { return a + b; });
         IOBInputs.profile.currentBasal = Math.round((sum/4)*1000)/1000;
+
+        // this is the current autotuned basal, used for everything else besides IOB calculations
+        currentBasal = basal.basalLookup(opts.basalprofile, BGDate);
 
         //console.error(currentBasal,basal1hAgo,basal2hAgo,basal3hAgo,IOBInputs.profile.currentBasal);
         // basalBGI is BGI of basal insulin activity.

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -17,6 +17,7 @@ function generate (inputs) {
   , glucose: inputs.glucose
   , prepped_glucose: inputs.prepped_glucose
   , basalprofile: inputs.profile.basalprofile
+  , pumpbasalprofile: inputs.pumpprofile.basalprofile
   };
 
   var autotune_prep_output = categorize(opts);

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -118,7 +118,7 @@ function tuneAllTheThings (inputs) {
             }
         }
         deviations = Math.round( deviations * 1000 ) / 1000
-        //console.error("Hour",hour.toString(),"total deviations:",deviations,"mg/dL");
+        console.error("Hour",hour.toString(),"total deviations:",deviations,"mg/dL");
         // calculate how much less or additional basal insulin would have been required to eliminate the deviations
         // only apply 20% of the needed adjustment to keep things relatively stable
         basalNeeded = 0.2 * deviations / ISF;


### PR DESCRIPTION
When running autotune retrospectively against NS data containing many/long periods without temp basals (i.e. data from AndroidAPS, OpenAPS with profile.skip_neutral_temps = true, Loop with wide BG target ranges, or long periods without any closed looping), autotune would assume that the autotuned basals were in effect any time there was no temp basal.  That could result in a feedback loop where autotune continued trying to raise or lower basals indefinitely until it hit the autosens_max or autosens_min, rather than converging on a sensible basal schedule.  This PR changes autotune to assume that the basal schedule from pumpprofile.json was in effect instead.  That should ensure that autotune converges, and as long as the pumpprofile.json basal schedule matches what was actually in effect during the time period being analyzed, should result in much better basal recommendations for time periods without neutral temps.