### PR TITLE
Make oref0-version more useful if you're not running on openaps/oref0 directly

### DIFF
--- a/bin/oref0-version.sh
+++ b/bin/oref0-version.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-
+source ~/.bash_profile
 # Simple script to check current version / branch of oref0 installed and check for updates
-
-branch=$(cd $HOME/src/oref0/ && git rev-parse --abbrev-ref HEAD)
-version=$(jq .version "$HOME/src/oref0/package.json" | sed 's/"//g')
+location=${OREF0_SRC:-${HOME}/src/oref0}
+branch=$(cd ${location} && git rev-parse --abbrev-ref HEAD)
+version=$(jq .version "${location}/package.json" | sed 's/"//g')
 
 if [[ $1 =~ "update" ]]; then
-    cd $HOME/src/oref0/ && timeout 30 git fetch 2>/dev/null || echo git fetch failed # pull latest remote info
-    behind=$(cd $HOME/src/oref0/ && git rev-list --count ${branch}...origin/${branch})
+    cd ${location} && timeout 30 git fetch 2>/dev/null || echo git fetch failed # pull latest remote info
+    behind=$(cd ${location}/ && git rev-list --count --right-only ${branch}...origin/${branch})
     if (("$behind" > "0")); then
         # we are out of date
         echo "Your instance of oref0 [${version}, ${branch}] is out-of-date by ${behind} commits: you may want to consider updating."
@@ -20,6 +20,27 @@ if [[ $1 =~ "update" ]]; then
     else
         echo "Your instance of oref0 [${version}, ${branch}] is up-to-date."
     fi
+
+
+    git remote -v | grep -q upstream
+    exit_status=$?
+    if [[ $exit_status -eq 0 ]]; then
+        behind=$(cd ${location}/ && git rev-list --count --right-only ${branch}...upstream/${branch})
+        if (("$behind" > "0")); then
+            # we are out of date
+            echo "Your instance of oref0 [${version}, ${branch}] is out-of-date by ${behind} commits upstream: you may want to consider updating."
+            if [ $branch != "master" ]; then
+                echo "You are currently running a development branch of oref0.  Such branches change frequently."
+                echo "Please read the latest PR notes and update with the latest commits to dev before reporting any issues."
+            else
+                echo "Please make sure to read any new documentation and release notes that accompany the update."
+            fi
+        else
+            echo "Your instance of oref0 [${version}, ${branch}] is up-to-date with upstream."
+        fi
+    fi
+
+
 else
     # simple version check and report.
     echo "${version} [${branch}]"


### PR DESCRIPTION
A few changes to make the message at the end of the loop more useful if you're not running on the main `openaps/oref0 repo`.
- Check OREF0_SRC env for source code location.
- Check for being behind upstream (if it exists).
- Only warn if repo is ahead of local (not local ahead of remote)