### PR TITLE
Improve the oref0-pump-loop debuging options by adding a debug flag.

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# OREF0_DEBUG make this script much more verbose
-# and allow it to print additional debug information.
+# OREF0_DEBUG makes this script much more verbose
+# and allows it to print additional debug information.
 # OREF0_DEBUG=1 generally means to print everything that usually
-# to stderr. (It will will include stack traces in case
+# goes to stderr. (It will will include stack traces in case
 # of errors or exceptions in sub commands)
 # OREF0_DEBUG=2 is for debugging only. It will print all commands
 # being executed as well as all their output, (use with care as it

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -1,5 +1,32 @@
 #!/bin/bash
 
+# OREF0_DEBUG make this script much more verbose
+# and allow it to print additional debug information.
+# OREF0_DEBUG=1 generally means to print everything that usually
+# to stderr. (It will will include stack traces in case
+# of errors or exceptions in sub commands)
+# OREF0_DEBUG=2 is for debugging only. It will print all commands
+# being executed as well as all their output, (use with care as it
+# might overflow your log files)
+# The default value is 0. A silent mode could also be implemented, but
+# it hasn't been done at this point.
+# Note: for future changes:
+# -  when subcommand outputs are not needed in the main log file:
+#    - redirect the output to either fd >&3 or fd >&4 based on
+#    - when you want the output visible.
+OREF0_DEBUG=${OREF0_DEBUG:-0}
+if [[ "$OREF0_DEBUG" -ge 1 ]] ; then
+  exec 3>&1
+else
+  exec 3>/dev/null
+fi
+if [[ "$OREF0_DEBUG" -ge 2 ]] ; then
+  exec 4>&1
+  set -x
+else
+  exec 4>/dev/null
+fi
+
 # old pump-loop
 old_main() {
     prep
@@ -45,7 +72,7 @@ main() {
         try_fail refresh_old_profile
         try_fail touch /tmp/pump_loop_enacted -r monitor/glucose.json
         if smb_check_everything; then
-            if ( grep -q '"units":' enact/smb-suggested.json 2>/dev/null); then
+            if ( grep -q '"units":' enact/smb-suggested.json 2>&3); then
                 if try_return smb_bolus; then
                     touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
                 else
@@ -70,7 +97,7 @@ main() {
                     fi
                 fi
             fi
-            cat /tmp/oref0-updates.txt 2>/dev/null
+            cat /tmp/oref0-updates.txt 2>&3
             echo Completed oref0-pump-loop at $(date)
             echo
         else
@@ -82,12 +109,12 @@ main() {
 
 function fail {
     echo -n "oref0-pump-loop failed. "
-    if find enact/ -mmin -5 | grep smb-suggested.json > /dev/null && grep "too old" enact/smb-suggested.json 3>/dev/null; then
+    if find enact/ -mmin -5 | grep smb-suggested.json >&4 && grep "too old" enact/smb-suggested.json >&4; then
         touch /tmp/pump_loop_completed
         wait_for_bg
         echo "Unsuccessful oref0-pump-loop (BG too old) at $(date)"
     # don't treat suspended pump as a complete failure
-    elif find monitor/ -mmin -5 | grep status.json > /dev/null && grep -q '"suspended": true' monitor/status.json; then
+    elif find monitor/ -mmin -5 | grep status.json >&4 && grep -q '"suspended": true' monitor/status.json; then
         refresh_profile 15; refresh_pumphistory_24h
         refresh_after_bolus_or_enact
         echo "Incomplete oref0-pump-loop (pump suspended) at $(date)"
@@ -98,7 +125,7 @@ function fail {
     if grep -q "percent" monitor/temp_basal.json; then
         echo "Error: pump is set to % basal type. The pump won’t accept temporary basal rates in this mode. Please change the pump to absolute u/hr so temporary basal rates will then be able to be set."
     fi
-    if ! cat preferences.json | jq . >/dev/null; then
+    if ! cat preferences.json | jq . >&4; then
         echo Error: syntax error in preferences.json: please go correct your typo.
     fi
     echo
@@ -108,7 +135,7 @@ function fail {
 
 function overtemp {
     # check for CPU temperature above 85°C
-    sensors -u 2>/dev/null | awk '$NF > 85' | grep input \
+    sensors -u 2>&3 | awk '$NF > 85' | grep input \
     && echo Rig is too hot: not running pump-loop at $(date)\
     && echo Please ensure rig is properly ventilated
 }
@@ -117,7 +144,7 @@ function smb_reservoir_before {
     # Refresh reservoir.json and pumphistory.json
     try_fail refresh_pumphistory_and_meal
     try_fail cp monitor/reservoir.json monitor/lastreservoir.json
-    try_fail openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1
+    try_fail openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
     echo -n "Checking pump clock: "
     (cat monitor/clock-zoned.json; echo) | tr -d '\n'
     echo -n " is within 1m of current time: " && date
@@ -133,7 +160,7 @@ function smb_reservoir_before {
 # check if the temp was read more than 5m ago, or has been running more than 10m
 function smb_old_temp {
     (find monitor/ -mmin +5 -size +5c | grep -q temp_basal && echo temp_basal.json more than 5m old) \
-    || ( jq --exit-status "(.duration-1) % 30 < 20" monitor/temp_basal.json > /dev/null \
+    || ( jq --exit-status "(.duration-1) % 30 < 20" monitor/temp_basal.json >&4 \
         && echo -n "Temp basal set more than 10m ago: " && jq .duration monitor/temp_basal.json
         )
 }
@@ -142,7 +169,7 @@ function smb_old_temp {
 function smb_check_everything {
     try_fail smb_reservoir_before
     try_fail smb_enact_temp
-    if (grep -q '"units":' enact/smb-suggested.json 2>/dev/null); then
+    if (grep -q '"units":' enact/smb-suggested.json 2>&3); then
         # wait_for_silence and retry if first attempt fails
         ( smb_verify_suggested || smb_suggest ) \
         && echo -n "Listening for $upto10s s silence: " && wait_for_silence $upto10s \
@@ -164,10 +191,10 @@ function smb_check_everything {
 
 function smb_suggest {
     rm -rf enact/smb-suggested.json
-    ls enact/smb-suggested.json 2>/dev/null >/dev/null && die "enact/suggested.json present"
+    ls enact/smb-suggested.json 2>&3 >&4 && die "enact/suggested.json present"
     # Run determine-basal
     echo -n Temp refresh
-    try_fail openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1
+    try_fail openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
     try_fail calculate_iob && echo ed
     try_fail determine_basal && cp -up enact/smb-suggested.json enact/suggested.json
     try_fail smb_verify_suggested
@@ -180,10 +207,10 @@ function determine_basal {
 # enact the appropriate temp before SMB'ing, (only if smb_verify_enacted fails)
 function smb_enact_temp {
     smb_suggest
-    if ( echo -n "enact/smb-suggested.json: " && cat enact/smb-suggested.json | jq -C -c . && grep -q duration enact/smb-suggested.json 2>/dev/null && ! smb_verify_enacted ); then (
+    if ( echo -n "enact/smb-suggested.json: " && cat enact/smb-suggested.json | jq -C -c . && grep -q duration enact/smb-suggested.json 2>&3 && ! smb_verify_enacted ); then (
         rm enact/smb-enacted.json
-        openaps report invoke enact/smb-enacted.json 2>&1 >/dev/null | tail -1
-        grep -q duration enact/smb-enacted.json || openaps report invoke enact/smb-enacted.json 2>&1 >/dev/null | tail -1
+        openaps report invoke enact/smb-enacted.json 2>&3 >&4 | tail -1
+        grep -q duration enact/smb-enacted.json || openaps report invoke enact/smb-enacted.json 2>&3 >&4 | tail -1
         cp -up enact/smb-enacted.json enact/enacted.json
         echo -n "enact/smb-enacted.json: " && cat enact/smb-enacted.json | jq -C -c '. | "Rate: \(.rate) Duration: \(.duration)"'
         ) 2>&1 | egrep -v "^  |subg_rfspy|handler"
@@ -199,16 +226,16 @@ function smb_verify_enacted {
     rm -rf monitor/temp_basal.json
     ( echo -n Temp refresh \
         && ( openaps report invoke monitor/temp_basal.json || openaps report invoke monitor/temp_basal.json ) \
-        2>&1 >/dev/null | tail -1 && echo -n "ed: " \
+        2>&3 >&4 | tail -1 && echo -n "ed: " \
     ) && echo -n "monitor/temp_basal.json: " && cat monitor/temp_basal.json | jq -C -c . \
-    && jq --slurp --exit-status 'if .[1].rate then (.[0].rate > .[1].rate - 0.03 and .[0].rate < .[1].rate + 0.03 and .[0].duration > .[1].duration - 5 and .[0].duration < .[1].duration + 20) else true end' monitor/temp_basal.json enact/smb-suggested.json > /dev/null
+    && jq --slurp --exit-status 'if .[1].rate then (.[0].rate > .[1].rate - 0.03 and .[0].rate < .[1].rate + 0.03 and .[0].duration > .[1].duration - 5 and .[0].duration < .[1].duration + 20) else true end' monitor/temp_basal.json enact/smb-suggested.json >&4
 }
 
 function smb_verify_reservoir {
     # Read the pump reservoir volume and verify it is within 0.1U of the expected volume
     rm -rf monitor/reservoir.json
     echo -n "Checking reservoir: " \
-    && (openaps report invoke monitor/reservoir.json || openaps report invoke monitor/reservoir.json) 2>&1 >/dev/null | tail -1 \
+    && (openaps report invoke monitor/reservoir.json || openaps report invoke monitor/reservoir.json) 2>&3 >&4 | tail -1 \
     && echo -n "reservoir level before: " \
     && cat monitor/lastreservoir.json \
     && echo -n ", suggested: " \
@@ -222,9 +249,9 @@ function smb_verify_reservoir {
 }
 
 function smb_verify_suggested {
-    if grep incorrectly enact/smb-suggested.json 2>/dev/null; then
+    if grep incorrectly enact/smb-suggested.json 2>&3; then
         echo "Checking system clock against pump clock:"
-        oref0-set-system-clock 2>&1 >/dev/null
+        oref0-set-system-clock 2>&3 >&4
     fi
     echo -n "Checking deliverAt: " && jq -r .deliverAt enact/smb-suggested.json | tr -d '\n' \
     && echo -n " is within 1m of current time: " && date \
@@ -238,7 +265,7 @@ function smb_verify_status {
     # Read the pump status and verify it is not bolusing
     rm -rf monitor/status.json
     echo -n "Checking pump status (suspended/bolusing): "
-    ( openaps report invoke monitor/status.json || openaps report invoke monitor/status.json ) 2>&1 >/dev/null | tail -1 \
+    ( openaps report invoke monitor/status.json || openaps report invoke monitor/status.json ) 2>&3 >&4 | tail -1 \
     && cat monitor/status.json | jq -C -c . \
     && grep -q '"status": "normal"' monitor/status.json \
     && grep -q '"bolusing": false' monitor/status.json \
@@ -253,12 +280,12 @@ function smb_verify_status {
 function smb_bolus {
     # Verify that the suggested.json is less than 5 minutes old
     # and administer the supermicrobolus
-    find enact/ -mmin -5 | grep smb-suggested.json > /dev/null \
-    && if (grep -q '"units":' enact/smb-suggested.json 2>/dev/null); then
+    find enact/ -mmin -5 | grep smb-suggested.json >&4 \
+    && if (grep -q '"units":' enact/smb-suggested.json 2>&3); then
         # press ESC three times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
         echo -n "Sending ESC ESC ESC to exit any open menus before SMBing: "
         try_return openaps use pump press_keys esc esc esc | jq .completed | grep true \
-        && try_return openaps report invoke enact/bolused.json 2>&1 >/dev/null | tail -1 \
+        && try_return openaps report invoke enact/bolused.json 2>&3 >&4 | tail -1 \
         && echo -n "enact/bolused.json: " && cat enact/bolused.json | jq -C -c . \
         && rm -rf enact/smb-suggested.json
     else
@@ -273,7 +300,7 @@ function refresh_after_bolus_or_enact {
         refresh_pumphistory_and_meal \
             || ( wait_for_silence 15 && refresh_pumphistory_and_meal ) \
             || ( wait_for_silence 30 && refresh_pumphistory_and_meal )
-        calculate_iob && determine_basal 2>/dev/null >/dev/null \
+        calculate_iob && determine_basal 2>&3 >&4 \
         && cp -up enact/smb-suggested.json enact/suggested.json \
         && echo -n "IOB: " && cat enact/smb-suggested.json | jq .IOB
         true
@@ -313,14 +340,14 @@ function prep {
 
 function if_mdt_get_bg {
     echo -n
-    if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
+    if grep "MDT cgm" openaps.ini 2>&3 >&4; then
         echo \
         && echo Attempting to retrieve MDT CGM data from pump
         #due to sometimes the pump is not in a state to give this command repeat until it completes
         #"decocare.errors.DataTransferCorruptionError: Page size too short"
         n=0
         until [ $n -ge 3 ]; do
-            openaps report invoke monitor/cgm-mm-glucosedirty.json 2>&1 >/dev/null && break
+            openaps report invoke monitor/cgm-mm-glucosedirty.json 2>&3 >&4 && break
             echo
             echo CGM data retrieval from pump disrupted, retrying in 5 seconds...
             n=$[$n+1]
@@ -356,7 +383,7 @@ function wait_for_mdt_get_bg {
         echo "Last CGM Time was $(date -d $(jq .[1].date monitor/cgm-mm-glucosedirty.json| tr -d '"') +"%r") wait untill $(date --date="@$(($(date #-d $(jq .[1].date monitor/cgm-mm-glucosedirty.json| tr -d '"') +%s) + 300))" +"%r")to continue"
         echo "waiting for $CGMDIFFTIME seconds before continuing"
         sleep $CGMDIFFTIME
-        until openaps report invoke monitor/cgm-mm-glucosedirty.json 2>&1 >/dev/null; do
+        until openaps report invoke monitor/cgm-mm-glucosedirty.json 2>&3 >&4; do
             echo cgm data from pump disrupted, retrying in 5 seconds...
             sleep 5;
             echo -n MDT cgm data retrieve
@@ -364,22 +391,22 @@ function wait_for_mdt_get_bg {
     done
 }
 function mdt_get_bg {
-    openaps report invoke monitor/cgm-mm-glucosetrend.json 2>&1 >/dev/null \
-    && openaps report invoke cgm/cgm-glucose.json 2>&1 >/dev/null \
+    openaps report invoke monitor/cgm-mm-glucosetrend.json 2>&3 >&4 \
+    && openaps report invoke cgm/cgm-glucose.json 2>&3 >&4 \
     && grep -q glucose cgm/cgm-glucose.json \
     && echo MDT CGM data retrieved \
     && cp -pu cgm/cgm-glucose.json cgm/glucose.json \
     && cp -pu cgm/glucose.json monitor/glucose-unzoned.json \
     && echo -n MDT New cgm data reformat \
-    && openaps report invoke monitor/glucose.json 2>&1 >/dev/null \
-    && openaps report invoke nightscout/glucose.json 2>&1 >/dev/null \
+    && openaps report invoke monitor/glucose.json 2>&3 >&4 \
+    && openaps report invoke nightscout/glucose.json 2>&3 >&4 \
     && echo ted
 }
 # make sure we can talk to the pump and get a valid model number
 function preflight {
     echo -n "Preflight "
     # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
-    ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&1 >/dev/null | tail -1 \
+    ( openaps report invoke settings/model.json || openaps report invoke settings/model.json ) 2>&3 >&4 | tail -1 \
     && ( egrep -q "[57](15|22|23|54)" settings/model.json || (grep 12 settings/model.json && die "error: x12 pumps do support SMB safety checks: quitting to restart with basal-only pump-loop") ) \
     && echo -n "OK. " \
     || ( echo -n "fail. "; false )
@@ -389,18 +416,18 @@ function preflight {
 function mmtune {
     # TODO: remove reset_spi_serial.py once oref0_init_pump_comms.py is fixed to do it correctly
     if [[ $port == "/dev/spidev5.1" ]]; then
-        reset_spi_serial.py 2>/dev/null
+        reset_spi_serial.py 2>&3
     fi
     oref0_init_pump_comms.py
     echo -n "Listening for 40s silence before mmtuning: "
     for i in $(seq 1 800); do
         echo -n .
-        any_pump_comms 40 2>/dev/null | egrep -v subg | egrep -q No \
+        any_pump_comms 40 2>&3 | egrep -v subg | egrep -q No \
         && echo "No interfering pump comms detected from other rigs (this is a good thing!)" \
         && break
     done
     echo {} > monitor/mmtune.json
-    echo -n "mmtune: " && openaps report invoke monitor/mmtune.json 2>&1 >/dev/null | tail -1
+    echo -n "mmtune: " && openaps report invoke monitor/mmtune.json 2>&3 >&4 | tail -1
     grep -v setFreq monitor/mmtune.json | grep -A2 $(json -a setFreq -f monitor/mmtune.json) | while read line
         do echo -n "$line "
     done
@@ -449,7 +476,7 @@ function wait_for_silence {
     echo -n "Listening: "
     for i in $(seq 1 800); do
         echo -n .
-        any_pump_comms $waitfor 2>/dev/null | egrep -v subg | egrep -q No \
+        any_pump_comms $waitfor 2>&3 | egrep -v subg | egrep -q No \
         && echo "No interfering pump comms detected from other rigs (this is a good thing!)" \
         && break
     done
@@ -457,7 +484,7 @@ function wait_for_silence {
 
 # Refresh pumphistory etc.
 function refresh_pumphistory_and_meal {
-    retry_return openaps report invoke monitor/status.json 2>&1 >/dev/null | tail -1 || return 1
+    retry_return openaps report invoke monitor/status.json 2>&3 >&4 | tail -1 || return 1
     echo -n Ref
     ( grep -q "model.*12" monitor/status.json || \
          test $(cat monitor/status.json | json suspended) == true || \
@@ -483,12 +510,12 @@ function calculate_iob {
 }
 
 function invoke_pumphistory_etc {
-    openaps report invoke monitor/clock.json monitor/temp_basal.json monitor/pumphistory.json monitor/pumphistory-zoned.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1
+    openaps report invoke monitor/clock.json monitor/temp_basal.json monitor/pumphistory.json monitor/pumphistory-zoned.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
     test ${PIPESTATUS[0]} -eq 0
 }
 
 function invoke_reservoir_etc {
-    openaps report invoke monitor/reservoir.json monitor/battery.json monitor/status.json 2>&1 >/dev/null | tail -1
+    openaps report invoke monitor/reservoir.json monitor/battery.json monitor/status.json 2>&3 >&4 | tail -1
     test ${PIPESTATUS[0]} -eq 0
 }
 
@@ -497,12 +524,12 @@ function calculate_iob {
 }
 
 function invoke_pumphistory_etc {
-    openaps report invoke monitor/clock.json monitor/temp_basal.json monitor/pumphistory.json monitor/pumphistory-zoned.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1
+    openaps report invoke monitor/clock.json monitor/temp_basal.json monitor/pumphistory.json monitor/pumphistory-zoned.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
     test ${PIPESTATUS[0]} -eq 0
 }
 
 function invoke_reservoir_etc {
-    openaps report invoke monitor/reservoir.json monitor/battery.json monitor/status.json 2>&1 >/dev/null | tail -1
+    openaps report invoke monitor/reservoir.json monitor/battery.json monitor/status.json 2>&3 >&4 | tail -1
     test ${PIPESTATUS[0]} -eq 0
 }
 
@@ -517,10 +544,10 @@ function enact {
     openaps report invoke enact/suggested.json \
     && if (cat enact/suggested.json && grep -q duration enact/suggested.json); then (
         rm enact/enacted.json
-        openaps report invoke enact/enacted.json 2>&1 >/dev/null | tail -1
+        openaps report invoke enact/enacted.json 2>&3 >&4 | tail -1
         grep -q duration enact/enacted.json || openaps report invoke enact/enacted.json ) 2>&1 | egrep -v "^  |subg_rfspy|handler"
     fi
-    grep incorrectly enact/suggested.json && oref0-set-system-clock 2>/dev/null
+    grep incorrectly enact/suggested.json && oref0-set-system-clock 2>&3
     echo -n "enact/enacted.json: " && cat enact/enacted.json | jq -C -c .
 }
 
@@ -542,14 +569,14 @@ function refresh_old_pumphistory_24h {
     find settings/ -mmin -120 -size +100c | grep -q pumphistory-24h-zoned \
     || ( echo -n "Old pumphistory-24h, waiting for $upto30s seconds of silence: " && wait_for_silence $upto30s \
         && echo -n Old pumphistory-24h refresh \
-        && openaps report invoke settings/pumphistory-24h.json settings/pumphistory-24h-zoned.json 2>&1 >/dev/null | tail -1 && echo ed )
+        && openaps report invoke settings/pumphistory-24h.json settings/pumphistory-24h-zoned.json 2>&3 >&4 | tail -1 && echo ed )
 }
 
 # refresh settings/profile if it's more than 1h old
 function refresh_old_profile {
     find settings/ -mmin -60 -size +5c | grep -q settings/profile.json && echo -n "Profile less than 60m old; " \
         || { echo -n "Old settings: " && get_settings; }
-    if ls settings/profile.json >/dev/null && cat settings/profile.json | jq -e .current_basal >/dev/null; then
+    if ls settings/profile.json >&4 && cat settings/profile.json | jq -e .current_basal >&3; then
         echo -n "Profile valid. "
     else
         echo -n "Profile invalid: "
@@ -560,10 +587,10 @@ function refresh_old_profile {
 
 # get-settings report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json settings/pumpprofile.json settings/profile.json
 function get_settings {
-    retry_return openaps report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json 2>&1 >/dev/null | tail -1 || return 1
+    retry_return openaps report invoke settings/model.json settings/bg_targets_raw.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/basal_profile.json settings/settings.json settings/carb_ratios.json 2>&3 >&4 | tail -1 || return 1
     # generate settings/pumpprofile.json without autotune
-    oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json settings/autotune.json 2>/dev/null | jq . > settings/pumpprofile.json.new || { echo "Couldn't refresh pumpprofile"; fail "$@"; }
-    if ls settings/pumpprofile.json.new >/dev/null && cat settings/pumpprofile.json.new | jq -e .current_basal >/dev/null; then
+    oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json settings/autotune.json 2>&3 | jq . > settings/pumpprofile.json.new || { echo "Couldn't refresh pumpprofile"; fail "$@"; }
+    if ls settings/pumpprofile.json.new >&4 && cat settings/pumpprofile.json.new | jq -e .current_basal >&4; then
         mv settings/pumpprofile.json.new settings/pumpprofile.json
         echo -n "Pump profile refreshed; "
     else
@@ -572,7 +599,7 @@ function get_settings {
     fi
     # generate settings/profile.json.new with autotune
     oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json | jq . > settings/profile.json.new || { echo "Couldn't refresh profile"; fail "$@"; }
-    if ls settings/profile.json.new >/dev/null && cat settings/profile.json.new | jq -e .current_basal >/dev/null; then
+    if ls settings/profile.json.new >&4 && cat settings/profile.json.new | jq -e .current_basal >&4; then
         mv settings/profile.json.new settings/profile.json
         echo -n "Settings refreshed; "
     else
@@ -615,7 +642,7 @@ function refresh_temp_and_enact {
 }
 
 function invoke_temp_etc {
-    openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json 2>&1 >/dev/null | tail -1
+    openaps report invoke monitor/temp_basal.json monitor/clock.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
     test ${PIPESTATUS[0]} -eq 0
     calculate_iob
 }
@@ -643,11 +670,11 @@ function refresh_profile {
 }
 
 function wait_for_bg {
-    if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
+    if grep "MDT cgm" openaps.ini 2>&3 >&4; then
         echo "MDT CGM configured; not waiting"
-    elif egrep -q "Warning:" enact/smb-suggested.json 2>/dev/null; then
+    elif egrep -q "Warning:" enact/smb-suggested.json 2>&3; then
         echo "Retrying without waiting for new BG"
-    elif egrep -q "Waiting [0].[0-9]m to microbolus again." enact/smb-suggested.json 2>/dev/null; then
+    elif egrep -q "Waiting [0].[0-9]m to microbolus again." enact/smb-suggested.json 2>&3; then
         echo "Retrying microbolus without waiting for new BG"
     else
         echo -n "Waiting up to 4 minutes for new BG: "
@@ -663,8 +690,8 @@ function wait_for_bg {
 
 function glucose-fresh {
     # set mtime of monitor/glucose.json to the time of its most recent glucose value
-    touch -d "$(date -R -d @$(jq .[0].date/1000 monitor/glucose.json))" monitor/glucose.json 2>/dev/null
-    if (! ls /tmp/pump_loop_completed >/dev/null ); then
+    touch -d "$(date -R -d @$(jq .[0].date/1000 monitor/glucose.json))" monitor/glucose.json 2>&3
+    if (! ls /tmp/pump_loop_completed >&4 ); then
         return 0;
     elif (find monitor/ -newer /tmp/pump_loop_completed | grep -q glucose.json); then
         echo glucose.json newer than pump_loop_completed
@@ -675,13 +702,13 @@ function glucose-fresh {
 }
 
 function refresh_pumphistory_24h {
-    if (! ls monitor/edison-battery.json 2>/dev/null >/dev/null); then
+    if (! ls monitor/edison-battery.json 2>&3 >&4); then
         echo -n "Edison battery level not found. "
         autosens_freq=15
-    elif (jq --exit-status ".battery >= 98 or (.battery <= 70 and .battery >= 60)" monitor/edison-battery.json > /dev/null); then
+    elif (jq --exit-status ".battery >= 98 or (.battery <= 70 and .battery >= 60)" monitor/edison-battery.json >&4); then
         echo -n "Edison battery at $(jq .battery monitor/edison-battery.json)% is charged (>= 98%) or likely charging (60-70%). "
         autosens_freq=15
-    elif (jq --exit-status ".battery < 98" monitor/edison-battery.json > /dev/null); then
+    elif (jq --exit-status ".battery < 98" monitor/edison-battery.json >&4); then
         echo -n "Edison on battery: $(jq .battery monitor/edison-battery.json)%. "
         autosens_freq=30
     else
@@ -690,11 +717,11 @@ function refresh_pumphistory_24h {
     fi
     find settings/ -mmin -$autosens_freq -size +100c | grep -q pumphistory-24h-zoned && echo "Pumphistory-24 < ${autosens_freq}m old" \
     || { echo -n pumphistory-24h refresh \
-        && openaps report invoke settings/pumphistory-24h.json settings/pumphistory-24h-zoned.json 2>&1 >/dev/null | tail -1 && echo ed; }
+        && openaps report invoke settings/pumphistory-24h.json settings/pumphistory-24h-zoned.json 2>&3 >&4 | tail -1 && echo ed; }
 }
 
 function setglucosetimestamp {
-    if grep "MDT cgm" openaps.ini 2>&1 >/dev/null; then
+    if grep "MDT cgm" openaps.ini 2>&3 >&4; then
       touch -d "$(date -R -d @$(jq .[0].date/1000 nightscout/glucose.json))" monitor/glucose.json
     else
       touch -d "$(date -R -d @$(jq .[0].date/1000 monitor/glucose.json))" monitor/glucose.json


### PR DESCRIPTION
I took another stab at adding a verbose logging or debug option to oref0-pump-loop.sh if the approach is acceptable it could be done to other scripts such as ns-loop, i got tired of changing some of these manually every time, I hope it's done in a useful way, in this case the existing behavior is not changed unless an environment variable is passed.