### PR TITLE
only calculate UAM deviations for the last ~30m

### DIFF
--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -58,10 +58,10 @@ function detectCarbAbsorption(inputs) {
             foundPreMealBG = true;
         }
 //console.error(glucose_data[i].glucose, bgTime, Math.round(hoursAfterMeal*100)/100, bucketed_data[bucketed_data.length-1].display_time);
-        // only consider last hour of data in CI mode
-        // this allows us to calculate deviations for the last ~45m
+        // only consider last ~45m of data in CI mode
+        // this allows us to calculate deviations for the last ~30m
         if (typeof ciTime) {
-            hoursAgo = (ciTime-bgTime)/(60*60*1000);
+            hoursAgo = (ciTime-bgTime)/(45*60*1000);
             if (hoursAgo > 1 || hoursAgo < 0) {
                 continue;
             }


### PR DESCRIPTION
When BG is rising fast and then slows its rise, it currently takes ~45m for UAM to pick itself up off the floor and predict continued rise.  This shortens the UAM lookback to ~30m to make it more responsive.