### PR TITLE
don't require enableSMB to enableUAM

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -403,8 +403,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     } else {
         console.error("SMB disabled (no enableSMB preferences active)");
     }
-    // enable UAM (if enabled in preferences) if SMB is enabled
-    var enableUAM=(profile.enableUAM && enableSMB);
+    // enable UAM (if enabled in preferences)
+    var enableUAM=(profile.enableUAM);
 
 
     //console.error(meal_data);


### PR DESCRIPTION
Now that enableUAM is on by default, we should probably make use of it in non-SMB contexts as well, to help AMA determine when high-temping is needed due to undercounted carbs, etc.