### PR TITLE
only use splitHistory internally: return un-split tempHistory

### DIFF
--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -210,15 +210,15 @@ function calcTempTreatments (inputs, zeroTempDuration) {
     tempHistory = _.sortBy(tempHistory, function(o) { return o.date; });
     splitHistory = _.sortBy(splitHistory, function(o) { return o.date; });
 
-    tempHistory = splitHistory;
+    // tempHistory = splitHistory;
 
     // iterate through the temp basals and create bolus events from temps that affect IOB
 
     var tempBolusSize;
 
-    for (var i=0; i < tempHistory.length; i++) {
+    for (var i=0; i < splitHistory.length; i++) {
 
-        var currentItem = tempHistory[i];
+        var currentItem = splitHistory[i];
 
         if (currentItem.duration > 0) {
 


### PR DESCRIPTION
Due to the way temp basal splitting works, the temp basal verification safety checks sometimes erroneously determine that a running temp basal doesn't match what's in pumphistory.  This PR continues to make use of the splitHistory internally, but returns the un-split tempHistory records for use in verification checks.