### PR TITLE
comment out broken CURL_AUTH API_SECRET line

### DIFF
--- a/bin/ns-get.sh
+++ b/bin/ns-get.sh
@@ -34,7 +34,7 @@ if [[ "${API_SECRET}" =~ "token=" ]]; then
   fi
 else
   REPORT_ENDPOINT=$NIGHTSCOUT_HOST/api/v1/${REPORT}'?'${QUERY}
-  CURL_AUTH='-H "api-secret: ${API_SECRET}"'
+  #CURL_AUTH='-H "api-secret: ${API_SECRET}"'
 fi
 
 case $1 in


### PR DESCRIPTION
When tokenauth was added, an improperly escaped CURL_AUTH= line was also added.  It hasn't done much harm, since anyone not using tokenauth has their NS site world-readable, but in @kandhoff's case (running autotune on a Mac) it seems to be breaking something: https://gitter.im/openaps/autotune?at=5a1e307c540c78242d5f36c3

This PR simply comments out the non-functional line to see if that helps.