### PR TITLE
Cancel temp on error and > 55m w/ skip_netural_temps

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -204,10 +204,10 @@ function determine_basal {
     oref0-determine-basal monitor/iob.json monitor/temp_basal.json monitor/glucose.json settings/profile.json settings/autosens.json monitor/meal.json --microbolus --reservoir monitor/reservoir.json > enact/smb-suggested.json
 }
 
-# enact the appropriate temp before SMB'ing, (only if smb_verify_enacted fails)
+# enact the appropriate temp before SMB'ing, (only if smb_verify_enacted fails or a 0 duration temp is requested)
 function smb_enact_temp {
     smb_suggest
-    if ( echo -n "enact/smb-suggested.json: " && cat enact/smb-suggested.json | jq -C -c . && grep -q duration enact/smb-suggested.json 2>&3 && ! smb_verify_enacted ); then (
+    if ( echo -n "enact/smb-suggested.json: " && cat enact/smb-suggested.json | jq -C -c . && grep -q duration enact/smb-suggested.json 2>&3 && ! smb_verify_enacted || jq --exit-status '.duration == 0' enact/smb-suggested.json >&4 ); then (
         rm enact/smb-enacted.json
         openaps report invoke enact/smb-enacted.json 2>&3 >&4 | tail -1
         grep -q duration enact/smb-enacted.json || openaps report invoke enact/smb-enacted.json 2>&3 >&4 | tail -1

--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -9,23 +9,22 @@ var tempBasalFunctions = {};
 
 tempBasalFunctions.getMaxSafeBasal = function getMaxSafeBasal(profile) {
 
-	var max_daily_safety_multiplier = (isNaN(profile.max_daily_safety_multiplier) || profile.max_daily_safety_multiplier == null) ? 3 : profile.max_daily_safety_multiplier;
-	var current_basal_safety_multiplier = (isNaN(profile.current_basal_safety_multiplier) || profile.current_basal_safety_multiplier == null) ? 4 : profile.current_basal_safety_multiplier;
-	
-	return Math.min(profile.max_basal, max_daily_safety_multiplier * profile.max_daily_basal, current_basal_safety_multiplier * profile.current_basal);
+    var max_daily_safety_multiplier = (isNaN(profile.max_daily_safety_multiplier) || profile.max_daily_safety_multiplier == null) ? 3 : profile.max_daily_safety_multiplier;
+    var current_basal_safety_multiplier = (isNaN(profile.current_basal_safety_multiplier) || profile.current_basal_safety_multiplier == null) ? 4 : profile.current_basal_safety_multiplier;
+
+    return Math.min(profile.max_basal, max_daily_safety_multiplier * profile.max_daily_basal, current_basal_safety_multiplier * profile.current_basal);
 };
 
 tempBasalFunctions.setTempBasal = function setTempBasal(rate, duration, profile, rT, currenttemp) {
     //var maxSafeBasal = Math.min(profile.max_basal, 3 * profile.max_daily_basal, 4 * profile.current_basal);
-    
+
     var maxSafeBasal = tempBasalFunctions.getMaxSafeBasal(profile);
-var round_basal = require('./round-basal');
-    
-    if (rate < 0) { 
-        rate = 0; 
-    } // if >30m @ 0 required, zero temp will be extended to 30m instead
-    else if (rate > maxSafeBasal) { 
-        rate = maxSafeBasal; 
+    var round_basal = require('./round-basal');
+
+    if (rate < 0) {
+        rate = 0;
+    } else if (rate > maxSafeBasal) {
+        rate = maxSafeBasal;
     }
 
     var suggestedRate = round_basal(rate, profile);

--- a/lib/basal-set-temp.js
+++ b/lib/basal-set-temp.js
@@ -28,7 +28,7 @@ tempBasalFunctions.setTempBasal = function setTempBasal(rate, duration, profile,
     }
 
     var suggestedRate = round_basal(rate, profile);
-    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && currenttemp.duration <= 120 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8) {
+    if (typeof(currenttemp) !== 'undefined' && typeof(currenttemp.duration) !== 'undefined' && typeof(currenttemp.rate) !== 'undefined' && currenttemp.duration > (duration-10) && currenttemp.duration <= 120 && suggestedRate <= currenttemp.rate * 1.2 && suggestedRate >= currenttemp.rate * 0.8 && duration > 0 ) {
         rT.reason += " "+currenttemp.duration+"m left and " + currenttemp.rate + " ~ req " + suggestedRate + "U/hr: no temp required";
         return rT;
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -219,7 +219,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m","tempModulus:",tempModulus,"m");
     rT.temp = 'absolute';
     rT.deliverAt = deliverAt;
-    if ( microBolusAllowed && currenttemp && iob_data.lastTemp && currenttemp.rate != iob_data.lastTemp.rate && lastTempAge > 10 ) {
+    if ( microBolusAllowed && currenttemp && iob_data.lastTemp && currenttemp.rate != iob_data.lastTemp.rate && lastTempAge > 10 && currenttemp.duration ) {
         rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; canceling temp";
         return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -219,7 +219,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     console.error("currenttemp:",currenttemp,"lastTempAge:",lastTempAge,"m","tempModulus:",tempModulus,"m");
     rT.temp = 'absolute';
     rT.deliverAt = deliverAt;
-    if ( microBolusAllowed && currenttemp && iob_data.lastTemp && currenttemp.rate != iob_data.lastTemp.rate ) {
+    if ( microBolusAllowed && currenttemp && iob_data.lastTemp && currenttemp.rate != iob_data.lastTemp.rate && lastTempAge > 10 ) {
         rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; canceling temp";
         return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
     }
@@ -231,7 +231,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //}
         //console.error(lastTempAge, round(iob_data.lastTemp.duration,1), round(lastTempAge - iob_data.lastTemp.duration,1));
         var lastTempEnded = lastTempAge - iob_data.lastTemp.duration
-        if ( lastTempEnded > 5 ) {
+        if ( lastTempEnded > 5 && lastTempAge > 10 ) {
             rT.reason = "Warning: currenttemp running but lastTemp from pumphistory ended "+lastTempEnded+"m ago; canceling temp";
             //console.error(currenttemp, round(iob_data.lastTemp,1), round(lastTempAge,1));
             return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -919,6 +919,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // rate required to deliver insulinReq less insulin over 30m:
         var rate = basal + (2 * insulinReq);
         rate = round_basal(rate, profile);
+
+        // unless we need a zero temp, cancel temps before the top of the hour to reduce beeping/vibration
+        if ( rate > 0 && profile.skip_neutral_temps && rT.deliverAt.getMinutes() >= 55 ) {
+            rT.reason += "; Requested rate " + rate + " > 0: canceling temp at " + rT.deliverAt.getMinutes() + "m past the hour. ";
+            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+        }
+
         // if required temp < existing temp basal
         var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;
         // if current temp would deliver a lot (30% of basal) less than the required insulin,

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -220,8 +220,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     rT.temp = 'absolute';
     rT.deliverAt = deliverAt;
     if ( microBolusAllowed && currenttemp && iob_data.lastTemp && currenttemp.rate != iob_data.lastTemp.rate ) {
-        rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; setting neutral temp of "+basal+".";
-        return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+        rT.reason = "Warning: currenttemp rate "+currenttemp.rate+" != lastTemp rate "+iob_data.lastTemp.rate+" from pumphistory; canceling temp";
+        return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
     }
     if ( currenttemp && iob_data.lastTemp && currenttemp.duration > 0 ) {
         // TODO: fix this (lastTemp.duration is how long it has run; currenttemp.duration is time left
@@ -232,9 +232,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //console.error(lastTempAge, round(iob_data.lastTemp.duration,1), round(lastTempAge - iob_data.lastTemp.duration,1));
         var lastTempEnded = lastTempAge - iob_data.lastTemp.duration
         if ( lastTempEnded > 5 ) {
-            rT.reason = "Warning: currenttemp running but lastTemp from pumphistory ended "+lastTempEnded+"m ago; setting neutral temp of "+basal+".";
+            rT.reason = "Warning: currenttemp running but lastTemp from pumphistory ended "+lastTempEnded+"m ago; canceling temp";
             //console.error(currenttemp, round(iob_data.lastTemp,1), round(lastTempAge,1));
-            return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
         }
         // TODO: figure out a way to do this check that doesn't fail across basal schedule boundaries
         //if ( tempModulus < 25 && tempModulus > 5 ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -877,6 +877,13 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         return tempBasalFunctions.setTempBasal(0, durationReq, profile, rT, currenttemp);
     }
 
+    // if not in LGS mode, cancel temps before the top of the hour to reduce beeping/vibration
+    console.error(profile.skip_neutral_temps, rT.deliverAt.getMinutes());
+    if ( profile.skip_neutral_temps && rT.deliverAt.getMinutes() >= 55 ) {
+        rT.reason += "; Canceling temp at " + rT.deliverAt.getMinutes() + "m past the hour. ";
+        return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+    }
+
     if (eventualBG < min_bg) { // if eventual BG is below target:
         rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " < " + convert_bg(min_bg, profile);
         // if 5m or 30m avg BG is rising faster than expected delta
@@ -919,12 +926,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // rate required to deliver insulinReq less insulin over 30m:
         var rate = basal + (2 * insulinReq);
         rate = round_basal(rate, profile);
-
-        // unless we need a zero temp, cancel temps before the top of the hour to reduce beeping/vibration
-        if ( rate > 0 && profile.skip_neutral_temps && rT.deliverAt.getMinutes() >= 55 ) {
-            rT.reason += "; Requested rate " + rate + " > 0: canceling temp at " + rT.deliverAt.getMinutes() + "m past the hour. ";
-            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
-        }
 
         // if required temp < existing temp basal
         var insulinScheduled = currenttemp.duration * (currenttemp.rate - basal) / 60;


### PR DESCRIPTION
Per #840, skip_netural_temps currently breaks the temp basal safety checks, because the neutral temp we attempt to set to fix the situation never gets set.

This PR fixes that by issuing a cancel temp when the safety checks fail, and making sure that such a cancel temp command actually gets passed through to the pump.

This also includes a new feature to cancel temp basals (unless they're low glucose suspend zero-temps) after 55 minutes past the hour if skip_neutral_temps is set, so that no temp basal will be running at the top of the hour and therefore the pump will not beep or vibrate.