### PR TITLE
limit SMB zero temps to 60m

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1064,10 +1064,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             var smbLowTempReq = 0;
             if (durationReq <= 0) {
                 durationReq = 0;
-            // don't set a temp longer than 120 minutes
+            // don't set an SMB zero temp longer than 60 minutes
             } else if (durationReq >= 30) {
                 durationReq = round(durationReq/30)*30;
-                durationReq = Math.min(120,Math.max(0,durationReq));
+                durationReq = Math.min(60,Math.max(0,durationReq));
             } else {
                 // if SMB durationReq is less than 30m, set a nonzero low temp
                 smbLowTempReq = round( basal * durationReq/30 ,2);


### PR DESCRIPTION
Per https://github.com/openaps/oref0/issues/781 and other feedback, and my own experience, it seems that 120m SMB zero temps may be doing more harm than good.

This PR caps SMB zero temps to 60m, while allowing zero temps based on minGuardBG or eventualBG to still extend to 120 minutes.  This should minimize the situations in which really long zero temps are set where unneeded, while preserving the ability to set them when BG predictions actually justify.