### PR TITLE
Ignore records with 0 sgv

### DIFF
--- a/bin/oref0-mdt-trend.js
+++ b/bin/oref0-mdt-trend.js
@@ -56,11 +56,15 @@ if (!module.parent) {
 		continue;
 	}
 
+    if (record.sgv == 0)
+    {
+        continue;
+    }
 	var used_records = 0;
 	for (var j = 0; j < max_entries; j++)
 	{
 		var past_record = last_entries[j];
-		if (typeof past_record == "undefined")
+		if (typeof past_record == "undefined" || past_record.sgv == 0)
 		{
 			continue;
 		}


### PR DESCRIPTION
It seems that there are occasionally records from MDT cgm with a sgv of 0. This causes the trend arrows to think that BG is rising rapdily. 

Written without my rig nearby (oops), so needs to be tested by me or another MDT CGM user before merge.