### PR TITLE
Display RMS deviation in autosens

### DIFF
--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -343,8 +343,12 @@ function detectSensitivity(inputs) {
     pResistant = percentile(deviations, 0.50);
 
     average = deviationSum / deviations.length;
-
     //console.error("Mean deviation: "+average.toFixed(2));
+    
+    squareDeviations = deviations.reduce(function(acc, dev){dev_f = parseFloat(dev); return acc + dev_f * dev_f}, 0);
+    rmsDev = Math.sqrt(squareDeviations / deviations.length);
+    console.error("RMS deviation: "+rmsDev.toFixed(2)); 
+
     var basalOff = 0;
 
     if(pSensitive < 0) { // sensitive


### PR DESCRIPTION
It can be difficult to evaluate whether changes to less-intuitive settings changes like insulin peak time/DIA are likely to be helpful.  By calculating RMS deviation in autosens we have a metric measuring how well the current settings are predicting observed values.  

A change reducing RMS error will likely improve results and a change increasing RMS error will likely be unhelpful.