### PR TITLE
Autotune: avoid raising basals from UAM

### DIFF
--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -326,15 +326,6 @@ function categorizeBGDatums(opts) {
             // When BGI is negative and more than about 1/4 of basalBGI, we can use that data to tune ISF,
             // unless avgDelta is positive: then that's some sort of unexplained rise we don't want to use for ISF, so that means basals
             if (basalBGI > -4 * BGI) {
-                // attempting to prevent basal from being calculated as negative; should help prevent basals from going below 0
-                //var minPossibleDeviation = -( basalBGI + Math.max(0,BGI) );
-                //var minPossibleDeviation = -basalBGI;
-                //if ( deviation < minPossibleDeviation ) {
-                    //console.error("Adjusting deviation",deviation,"to",minPossibleDeviation.toFixed(2));
-                    //deviation = minPossibleDeviation;
-                    //deviation = deviation.toFixed(2);
-                    //glucoseDatum.deviation = deviation;
-                //}
                 type="basal";
                 basalGlucoseData.push(glucoseDatum);
             } else {

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -107,6 +107,7 @@ function categorizeBGDatums(opts) {
     var CRCarbs = 0;
     var type="";
     // main for loop
+    var fullHistory = IOBInputs.history;
     for (var i=bucketedData.length-5; i > 0; --i) {
         var glucoseDatum = bucketedData[i];
         //console.error(glucoseDatum);
@@ -152,6 +153,26 @@ function categorizeBGDatums(opts) {
         //sens = ISF
         var sens = ISF.isfLookup(IOBInputs.profile.isfProfile,BGDate);
         IOBInputs.clock=BGDate.toISOString();
+        // trim down IOBInputs.history to just the data for 6h prior to BGDate
+        //console.error(IOBInputs.history[0].created_at);
+        var newHistory = [];
+        for (h=0; h<fullHistory.length; h++) {
+            var hDate = new Date(fullHistory[h].created_at)
+            //console.error(fullHistory[i].created_at, hDate, BGDate, BGDate-hDate);
+            //if (h == 0 || h == fullHistory.length - 1) {
+                //console.error(hDate, BGDate, hDate-BGDate)
+            //}
+            if (BGDate-hDate < 6*60*60*1000 && BGDate-hDate > 0) {
+                //process.stderr.write("i");
+                //console.error(hDate);
+                newHistory.push(fullHistory[h]);
+            }
+        }
+        IOBInputs.history = newHistory;
+        process.stderr.write("" + newHistory.length + " ");
+        //console.error(newHistory[0].created_at,newHistory[newHistory.length-1].created_at,newHistory.length);
+
+
         // for IOB calculations, use the average of the last 4 hours' basals to help convergence;
         // this helps since the basal this hour could be different from previous, especially if with autotune they start to diverge.
         // use the pumpbasalprofile to properly calculate IOB during periods where no temp basal is set
@@ -361,13 +382,13 @@ function categorizeBGDatums(opts) {
         console.error("Warning: too many deviations categorized as UnAnnounced Meals");
         console.error("Adding",UAMLength,"UAM deviations to",basalLength,"basal ones");
         var basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
-        console.error(basalGlucoseData);
+        //console.error(basalGlucoseData);
         // if too much data is excluded as UAM, add in the UAM deviations, but then discard the highest 50%
         basalGlucoseData.sort(function (a, b) {
             return a.deviation - b.deviation;
         });
         var newBasalGlucose = basalGlucoseData.slice(0,basalGlucoseData.length/2);
-        console.error(newBasalGlucose);
+        //console.error(newBasalGlucose);
         basalGlucoseData = newBasalGlucose;
         console.error("and selecting the lowest 50%, leaving", basalGlucoseData.length, "basal+UAM ones");
 

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -281,7 +281,7 @@ function categorizeBGDatums(opts) {
             console.error(CSFGlucoseData[CSFGlucoseData.length-1].mealAbsorption,"carb absorption");
           }
 
-          if ((iob.iob > currentBasal || uam) ) {
+          if ((iob.iob > currentBasal || deviation > 6 || uam) ) {
             if (deviation > 0) {
                 uam = 1;
             } else {
@@ -361,6 +361,16 @@ function categorizeBGDatums(opts) {
         console.error("Warning: too many deviations categorized as UnAnnounced Meals");
         console.error("Adding",UAMLength,"UAM deviations to",basalLength,"basal ones");
         var basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
+        console.error(basalGlucoseData);
+        // if too much data is excluded as UAM, add in the UAM deviations, but then discard the highest 50%
+        basalGlucoseData.sort(function (a, b) {
+            return a.deviation - b.deviation;
+        });
+        var newBasalGlucose = basalGlucoseData.slice(0,basalGlucoseData.length/2);
+        console.error(newBasalGlucose);
+        basalGlucoseData = newBasalGlucose;
+        console.error("and selecting the lowest 50%, leaving", basalGlucoseData.length, "basal+UAM ones");
+
         console.error("Adding",UAMLength,"UAM deviations to",ISFLength,"ISF ones");
         var ISFGlucoseData = ISFGlucoseData.concat(UAMGlucoseData);
         //console.error(ISFGlucoseData.length, UAMLength);


### PR DESCRIPTION
The current UAM-exclusion algorithm in autotune is based solely on IOB being higher than 1h of basal.  This, however, tends to miss cases where BG starts rising rapidly (perhaps from rescue carbs) with no IOB covering it.  To avoid raising basals in such a situation (and requiring even more rescue carbs later), this adds a UAM exclusion for any deviations > 6 mg/dL/5m.

When too much data is excluded as UAM, autotune adds back in the UAM deviations to avoid getting stuck in a bad equilibrium of too-low basals that prevent it from ever tuning them higher.  However, as implemented in 0.6.0, this sometimes results in autotune raising basals too high, and the addition of the 6 mg/dL/5m exclusion would make that more common.  To avoid both problems, this PR also makes autotune only include the lowest 50% of UAM deviations as basal deviations when there aren't enough basal ones otherwise.  This will allow autotune to tune basal upwards when really needed, but will avoid any upward bias on well-tuned basals.