### PR TITLE
Upgrade bluez to 5.48, start bluetoothd if it's not running, remove experimental

### DIFF
--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
+# start bluetoothd if bluetoothd is not running
+if ! ( ps -fC bluetoothd ) ; then
+   sudo /usr/local/bin/bluetoothd &
+fi
+
 if ! ( hciconfig -a | grep -q "PSCAN" ) ; then
    sudo killall bluetoothd
-   sudo /usr/local/bin/bluetoothd --experimental &
+   sudo /usr/local/bin/bluetoothd &
 fi
 
 if ( hciconfig -a | grep -q "DOWN" ) ; then
    sudo hciconfig hci0 up
-   sudo /usr/local/bin/bluetoothd --experimental &
+   sudo /usr/local/bin/bluetoothd &
 fi
 
 if !( hciconfig -a | grep -q $HOSTNAME ) ; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -697,7 +697,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             sed -i"" 's/^exit 0/\/usr\/local\/bin\/bluetoothd \&\n\nexit 0/' /etc/rc.local
         fi
         # starting with bluez 5.48 the --experimental command line option is not needed. remove the --experimental if it still exists in /etc/rc.local. this is for rigs with version 0.6.0 or earlier
-        if grep -q '/usr/local/bin/bluetoothd --experimental &' /etc/rc.local; then
+        if ! grep -q '/usr/local/bin/bluetoothd --experimental &' /etc/rc.local; then
             sed -i"" 's/^\/usr\/local\/bin\/bluetoothd --experimental \&/\/usr\/local\/bin\/bluetoothd \&/' /etc/rc.local
         fi
         if ! grep -q 'bluetooth_rfkill_event >/dev/null 2>&1 &' /etc/rc.local; then


### PR DESCRIPTION
- bugfix: also start bluetoothd in oref0-bluetoothup if it's not running
- upgrade bluez to 5.48, changelog http://www.bluez.org/release-of-bluez-5-48/
- remove `--experimental` (finally) on bluetoothd startup and change it in /etc/rc.local if it's still there

Tested with pebble and works. Will test bluetooth tethering later on.
