### PR TITLE
Fix iob calculation error

### DIFF
--- a/lib/iob/calculate.js
+++ b/lib/iob/calculate.js
@@ -59,7 +59,7 @@ function iobCalcBiLinear(treatment, time, dia) {
 }
 
 
-function iobCalc(treatment, time, dia, peak, profile, curve) {
+function iobCalc(treatment, time, curve, dia, peak, profile) {
 
     if (!treatment.insulin) return {};
 

--- a/lib/iob/calculate.js
+++ b/lib/iob/calculate.js
@@ -59,53 +59,19 @@ function iobCalcBiLinear(treatment, time, dia) {
 }
 
 
-function iobCalc(treatment, time, dia, profile) {
+function iobCalc(treatment, time, dia, peak, profile, curve) {
 
     if (!treatment.insulin) return {};
-
-    var curve = 'bilinear';
-
-    if (profile.curve !== undefined) {
-        curve = profile.curve.toLowerCase();
-    }
-
-    var curveDefaults = {
-        'bilinear': {
-            requireLongDia: false
-        },
-        'rapid-acting': {
-            requireLongDia: true,
-            peak: 75,
-            tdMin: 300
-        },
-        'ultra-rapid': {
-            requireLongDia: true,
-            peak: 55,
-            tdMin: 300
-        },
-    };
-
-    if (!(curve in curveDefaults)) {
-        console.error('Unsupported curve function: "' + curve + '". Supported curves: "bilinear", "rapid-acting" (Novolog, Novorapid, Humalog, Apidra) and "ultra-rapid" (Fiasp). Defaulting to "rapid-acting".');
-        curve = 'bilinear';
-    }
 
     if (curve == 'bilinear') {
         return iobCalcBiLinear(treatment, time, dia);
     }
 
-    var defaults = curveDefaults[curve];
-
     var usePeakTime = false;
 
     var td = dia * 60;
 
-    if (defaults.requireLongDia && dia < 5) {
-        //console.error('Pump DIA must be set to 5 hours or more with the new curves, please adjust your pump. Defaulting to 5 hour DIA.');
-        td = 300;
-    }
-
-    var tp = defaults.peak;
+    var tp = peak;
 
     if (profile.useCustomPeakTime && profile.insulinPeakTime !== undefined) {
         if (profile.insulinPeakTime < 35 || profile.insulinPeakTime > 120) {

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -67,7 +67,7 @@ function iobTotal(opts, time) {
             var dia_ago = now - dia*60*60*1000;
             if( treatment.date > dia_ago ) {
                 // tIOB = total IOB
-                var tIOB = iobCalc(treatment, time, dia, peak, profile_data, curve);
+                var tIOB = iobCalc(treatment, time, curve, dia, peak, profile_data);
                 if (tIOB && tIOB.iobContrib) { iob += tIOB.iobContrib; }
                 if (tIOB && tIOB.activityContrib) { activity += tIOB.activityContrib; }
                 // basals look like either of these:

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -4,6 +4,8 @@ function iobTotal(opts, time) {
     var iobCalc = opts.calculate;
     var treatments = opts.treatments;
     var profile_data = opts.profile;
+    var dia = profile_data.dia;
+    var peak = 0;
     var iob = 0;
     var basaliob = 0;
     var bolusiob = 0;
@@ -16,18 +18,56 @@ function iobTotal(opts, time) {
         //var time = new Date();
     //}
 
+
+    // force minimum DIA of 3h
+    if (dia < 3) {
+        console.error("Warning; adjusting DIA from",dia,"to minimum of 3 hours");
+        dia = 3;
+    }
+
+    var curveDefaults = {
+        'bilinear': {
+            requireLongDia: false,
+            peak: 75 // not really used, but prevents having to check later
+        },
+        'rapid-acting': {
+            requireLongDia: true,
+            peak: 75,
+            tdMin: 300
+        },
+        'ultra-rapid': {
+            requireLongDia: true,
+            peak: 55,
+            tdMin: 300
+        },
+    };
+
+    var curve = 'bilinear';
+
+    if (profile_data.curve !== undefined) {
+        curve = profile_data.curve.toLowerCase();
+    }
+
+    if (!(curve in curveDefaults)) {
+        console.error('Unsupported curve function: "' + curve + '". Supported curves: "bilinear", "rapid-acting" (Novolog, Novorapid, Humalog, Apidra) and "ultra-rapid" (Fiasp). Defaulting to "rapid-acting".');
+        curve = 'bilinear';
+    }
+
+    var defaults = curveDefaults[curve];
+
+    if (defaults.requireLongDia && dia < 5) {
+        //console.error('Pump DIA must be set to 5 hours or more with the new curves, please adjust your pump. Defaulting to 5 hour DIA.');
+        dia = 5;
+    }
+
+    peak = defaults.peak;
+
     treatments.forEach(function(treatment) {
         if( treatment.date <= now ) {
-            var dia = profile_data.dia;
-            // force minimum DIA of 3h
-            if (dia < 3) {
-                console.error("Warning; adjusting DIA from",dia,"to minimum of 3 hours");
-                dia = 3;
-            }
             var dia_ago = now - profile_data.dia*60*60*1000;
             if( treatment.date > dia_ago ) {
                 // tIOB = total IOB
-                var tIOB = iobCalc(treatment, time, dia, profile_data);
+                var tIOB = iobCalc(treatment, time, dia, peak, profile_data, curve);
                 if (tIOB && tIOB.iobContrib) { iob += tIOB.iobContrib; }
                 if (tIOB && tIOB.activityContrib) { activity += tIOB.activityContrib; }
                 // basals look like either of these:

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -18,7 +18,6 @@ function iobTotal(opts, time) {
         //var time = new Date();
     //}
 
-
     // force minimum DIA of 3h
     if (dia < 3) {
         console.error("Warning; adjusting DIA from",dia,"to minimum of 3 hours");
@@ -55,6 +54,7 @@ function iobTotal(opts, time) {
 
     var defaults = curveDefaults[curve];
 
+    // Force minimum of 5 hour DIA when default requires a Long DIA.
     if (defaults.requireLongDia && dia < 5) {
         //console.error('Pump DIA must be set to 5 hours or more with the new curves, please adjust your pump. Defaulting to 5 hour DIA.');
         dia = 5;

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -64,7 +64,7 @@ function iobTotal(opts, time) {
 
     treatments.forEach(function(treatment) {
         if( treatment.date <= now ) {
-            var dia_ago = now - profile_data.dia*60*60*1000;
+            var dia_ago = now - dia*60*60*1000;
             if( treatment.date > dia_ago ) {
                 // tIOB = total IOB
                 var tIOB = iobCalc(treatment, time, dia, peak, profile_data, curve);

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -396,13 +396,17 @@ describe('IOB', function() {
             };
 
         var hourLaterInputs = inputs;
-        hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
+        hourLaterInputs.clock = new Date(now + (4 * 60 * 60 * 1000)).toISOString();
 
         var hourLaterWith5 = require('../lib/iob')(hourLaterInputs)[0];
 
-        hourLaterInputs.profile.dia = 4;
+        console.error(hourLaterWith5.iob);
+
+        hourLaterInputs.profile.dia = 3;
 
         var hourLaterWith4 = require('../lib/iob')(hourLaterInputs)[0];
+
+        console.error(hourLaterWith4.iob);
 
         hourLaterWith4.iob.should.equal(hourLaterWith5.iob);
     });

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -367,6 +367,45 @@ describe('IOB', function() {
         //afterDIA.bolussnooze.should.equal(0);
     });
 
+    it('should force minimum 5 hour DIA with Rapid-acting', function() {
+
+        var basalprofile = [{
+            'i': 0,
+            'start': '00:00:00',
+            'rate': 1,
+            'minutes': 0
+        }];
+
+        var now = Date.now(),
+            timestamp = new Date(now).toISOString(),
+            inputs = {
+                clock: timestamp,
+                history: [{
+                    _type: 'Bolus',
+                    amount: 1,
+                    timestamp: timestamp
+                }],
+                profile: {
+                    dia: 5,
+                    //bolussnooze_dia_divisor: 2,
+                    basalprofile: basalprofile,
+                    current_basal: 1,
+                    max_daily_basal: 1,
+                    curve: 'rapid-acting'
+                }
+            };
+
+        var hourLaterInputs = inputs;
+        hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
+
+        var hourLaterWith5 = require('../lib/iob')(hourLaterInputs)[0];
+
+        hourLaterInputs.profile.dia = 4;
+
+        var hourLaterWith4 = require('../lib/iob')(hourLaterInputs)[0];
+
+        hourLaterWith4.iob.should.equal(hourLaterWith5.iob);
+    });
 
     //it('should snooze fast if bolussnooze_dia_divisor is high', function() {
 


### PR DESCRIPTION
The IOB calculation was forcing a minimum of 5 hour DIA by calculate.js; however, the total.js script was only using the history up to the user's pump profile DIA setting, not the full 5 hours if their pump was set to less than 5 hour DIA.

This change makes total.js and calculate.js force a 5 hour minimum consistently.