### PR TITLE
Consistent use of `$HOME` instead of `~`. Make it possible to install oref0 in another directory than `myopenaps`  and make it possible to start it from any directory

### DIFF
--- a/bin/oref0-log-shortcuts.sh
+++ b/bin/oref0-log-shortcuts.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
 
-myopenaps=${OPENAPS_DIR:-"~/myopenaps"}
+myopenaps=${OPENAPS_DIR:-"$HOME/myopenaps"}
 
 # add crontab entries
-grep -q networklog ~/.bash_profile 2>/dev/null || echo "alias networklog="'"tail -n 100 -F /var/log/openaps/network.log"' >> ~/.bash_profile
-grep -q xdrip-looplog ~/.bash_profile || echo "alias xdrip-looplog="'"tail -n 100 -F /var/log/openaps/xdrip-loop.log"' >> ~/.bash_profile
-grep -q cgm-looplog ~/.bash_profile || echo "alias cgm-looplog="'"tail -n 100 -F /var/log/openaps/cgm-loop.log"' >> ~/.bash_profile
-grep -q autosens-looplog ~/.bash_profile || echo "alias autosens-looplog="'"tail -n 100 -F /var/log/openaps/autosens-loop.log"' >> ~/.bash_profile
-grep -q autotunelog ~/.bash_profile || echo "alias autotunelog="'"tail -n 100 -F /var/log/openaps/autotune.log"' >> ~/.bash_profile
-grep -q pump-looplog ~/.bash_profile || echo "alias pump-looplog="'"tail -n 100 -F /var/log/openaps/pump-loop.log"' >> ~/.bash_profile
-grep -q urchin-looplog ~/.bash_profile || echo "alias urchin-looplog="'"tail -n 100 -F /var/log/openaps/urchin-loop.log"' >> ~/.bash_profile
-grep -q ns-looplog ~/.bash_profile || echo "alias ns-looplog="'"tail -n 100 -F /var/log/openaps/ns-loop.log"' >> ~/.bash_profile
-grep -q cat-pref ~/.bash_profile || echo "alias cat-pref=\"cd ${myopenaps} && cat preferences.json\"" >> ~/.bash_profile
-grep -q edit-pref ~/.bash_profile || echo "alias edit-pref=\"cd ${myopenaps} && nano preferences.json\"" >> ~/.bash_profile
-grep -q cat-wifi ~/.bash_profile || echo "alias cat-wifi="'"cat /etc/wpa_supplicant/wpa_supplicant.conf"' >> ~/.bash_profile
-grep -q edit-wifi ~/.bash_profile || echo "alias edit-wifi="'"nano /etc/wpa_supplicant/wpa_supplicant.conf"' >> ~/.bash_profile
-grep -q cat-runagain ~/.bash_profile || echo "alias cat-runagain=\"cd ${myopenaps} && cat oref0-runagain.sh\"" >> ~/.bash_profile
-grep -q edit-runagain ~/.bash_profile || echo "alias edit-runagain=\"cd ${myopenaps} && nano oref0-runagain.sh\"" >> ~/.bash_profile
-grep -q cat-autotune ~/.bash_profile || echo "alias cat-autotune=\"cd ${myopenaps}/autotune && cat autotune_recommendations.log\"" >> ~/.bash_profile
-grep -q git-branch ~/.bash_profile || echo "alias git-branch="'"cd ~/src/oref0 && git branch"' >> ~/.bash_profile
-grep -q runagain ~/.bash_profile || echo "alias runagain=\"bash ${myopenaps}/oref0-runagain.sh\"" >> ~/.bash_profile
-grep -q edison-battery ~/.bash_profile || echo "alias edison-battery=\"cd ${myopenaps}/monitor && cat edison-battery.json\"" >> ~/.bash_profile
-grep -q cat-reservoir ~/.bash_profile || echo "alias cat-reservoir=\"cd ${myopenaps}/monitor && cat reservoir.json\"" >> ~/.bash_profile
-grep -q stop-cron ~/.bash_profile || echo "alias stop-cron=\"cd ${myopenaps} && /etc/init.d/cron stop && killall -g oref0-pump-loop\"" >> ~/.bash_profile
-grep -q start-cron ~/.bash_profile || echo "alias start-cron="'"/etc/init.d/cron start"' >> ~/.bash_profile
+grep -q networklog $HOME/.bash_profile 2>/dev/null || echo "alias networklog="'"tail -n 100 -F /var/log/openaps/network.log"' >> $HOME/.bash_profile
+grep -q xdrip-looplog $HOME/.bash_profile || echo "alias xdrip-looplog="'"tail -n 100 -F /var/log/openaps/xdrip-loop.log"' >> $HOME/.bash_profile
+grep -q cgm-looplog $HOME/.bash_profile || echo "alias cgm-looplog="'"tail -n 100 -F /var/log/openaps/cgm-loop.log"' >> $HOME/.bash_profile
+grep -q autosens-looplog $HOME/.bash_profile || echo "alias autosens-looplog="'"tail -n 100 -F /var/log/openaps/autosens-loop.log"' >> $HOME/.bash_profile
+grep -q autotunelog $HOME/.bash_profile || echo "alias autotunelog="'"tail -n 100 -F /var/log/openaps/autotune.log"' >> $HOME/.bash_profile
+grep -q pump-looplog $HOME/.bash_profile || echo "alias pump-looplog="'"tail -n 100 -F /var/log/openaps/pump-loop.log"' >> $HOME/.bash_profile
+grep -q urchin-looplog $HOME/.bash_profile || echo "alias urchin-looplog="'"tail -n 100 -F /var/log/openaps/urchin-loop.log"' >> $HOME/.bash_profile
+grep -q ns-looplog $HOME/.bash_profile || echo "alias ns-looplog="'"tail -n 100 -F /var/log/openaps/ns-loop.log"' >> $HOME/.bash_profile
+grep -q cat-pref $HOME/.bash_profile || echo "alias cat-pref=\"cd ${myopenaps} && cat preferences.json\"" >> $HOME/.bash_profile
+grep -q edit-pref $HOME/.bash_profile || echo "alias edit-pref=\"cd ${myopenaps} && nano preferences.json\"" >> $HOME/.bash_profile
+grep -q cat-wifi $HOME/.bash_profile || echo "alias cat-wifi="'"cat /etc/wpa_supplicant/wpa_supplicant.conf"' >> $HOME/.bash_profile
+grep -q edit-wifi $HOME/.bash_profile || echo "alias edit-wifi="'"nano /etc/wpa_supplicant/wpa_supplicant.conf"' >> $HOME/.bash_profile
+grep -q cat-runagain $HOME/.bash_profile || echo "alias cat-runagain=\"cd ${myopenaps} && cat oref0-runagain.sh\"" >> $HOME/.bash_profile
+grep -q edit-runagain $HOME/.bash_profile || echo "alias edit-runagain=\"cd ${myopenaps} && nano oref0-runagain.sh\"" >> $HOME/.bash_profile
+grep -q cat-autotune $HOME/.bash_profile || echo "alias cat-autotune=\"cd ${myopenaps}/autotune && cat autotune_recommendations.log\"" >> $HOME/.bash_profile
+grep -q git-branch $HOME/.bash_profile || echo "alias git-branch="'"cd $HOME/src/oref0 && git branch"' >> $HOME/.bash_profile
+grep -q runagain $HOME/.bash_profile || echo "alias runagain=\"bash ${myopenaps}/oref0-runagain.sh\"" >> $HOME/.bash_profile
+grep -q edison-battery $HOME/.bash_profile || echo "alias edison-battery=\"cd ${myopenaps}/monitor && cat edison-battery.json\"" >> $HOME/.bash_profile
+grep -q cat-reservoir $HOME/.bash_profile || echo "alias cat-reservoir=\"cd ${myopenaps}/monitor && cat reservoir.json\"" >> $HOME/.bash_profile
+grep -q stop-cron $HOME/.bash_profile || echo "alias stop-cron=\"cd ${myopenaps} && /etc/init.d/cron stop && killall -g oref0-pump-loop\"" >> $HOME/.bash_profile
+grep -q start-cron $HOME/.bash_profile || echo "alias start-cron="'"/etc/init.d/cron start"' >> $HOME/.bash_profile
 
 # source default /etc/profile as well
-grep -q /etc/skel/.profile ~/.bash_profile || echo ". /etc/skel/.profile" >> ~/.bash_profile
+grep -q /etc/skel/.profile $HOME/.bash_profile || echo ". /etc/skel/.profile" >> $HOME/.bash_profile
 
-# to enable shortcut aliases in ~/.bash_profile
-source ~/.bash_profile
+# to enable shortcut aliases in $HOME/.bash_profile
+source $HOME/.bash_profile

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -151,7 +151,7 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
     fi
     echo
     if [[ -z $DIR ]]; then
-        DIR="myopenaps"
+        DIR="$HOME/myopenaps"
     fi
     directory="$(readlink -m $DIR)"
     echo
@@ -480,8 +480,8 @@ read -r
 if [[ $REPLY =~ ^[Yy]$ ]]; then
 
     # Attempting to remove git to make install --nogit by default for existing users
-    echo Removing any existing git
-    rm -rf ~/myopenaps/.git
+    echo Removing any existing git in $directory/.git
+    rm -rf $directory/.git
     echo Removed any existing git
 
     # TODO: delete this after openaps 0.2.1 release


### PR DESCRIPTION
Fixes:
- stop installing openaps in the current directory, use $HOME/myopenaps by default
- replace ~ for $HOME because that's our standard way of writing it and it's better,
"The tilde is part of a shell expansion (like in bash, csh, zsh, etc). The $HOME variable is exportable and can be used independent of a specific shell." (source: https://stackoverflow.com/questions/11587343/difference-between-home-and-tilde ) 

Tested on Explorer HAT with PI and it fixes the problem. 
@scottleibrand : can you please review and merge.
I think failed test is caused by Travis and not by this PR.
  