### PR TITLE
Fix profile bootstrapping

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -581,9 +581,9 @@ function get_settings {
         NON_X12_ITEMS=""
     else
         # On all other supported pumps, these reports work. 
-        NON_X12_ITEMS="settings/bg_targets_raw.json settings/basal_profile.json settings/settings.json"
+        NON_X12_ITEMS="settings/bg_targets_raw.json settings/bg_targets.json settings/basal_profile.json settings/settings.json"
     fi
-    retry_return openaps report invoke settings/model.json settings/bg_targets.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/carb_ratios.json $NON_X12_ITEMS 2>&3 >&4 | tail -1 || return 1
+    retry_return openaps report invoke settings/model.json settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/carb_ratios.json $NON_X12_ITEMS 2>&3 >&4 | tail -1 || return 1
     # generate settings/pumpprofile.json without autotune
     oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json settings/autotune.json 2>&3 | jq . > settings/pumpprofile.json.new || { echo "Couldn't refresh pumpprofile"; fail "$@"; }
     if ls settings/pumpprofile.json.new >&4 && cat settings/pumpprofile.json.new | jq -e .current_basal >&4; then


### PR DESCRIPTION
When settings/bg_targets_raw.json got moved into NON_X12_ITEMS, it caused settings/bg_targets.json to be run before settings/bg_targets_raw.json, which caused it to fail on a new install unless the settings/bg_targets_raw.json was created manually.  This moves settings/bg_targets.json into NON_X12_ITEMS as well, so it gets run after settings/bg_targets_raw.json.

We'll need to make sure this still works will x12 pumps (that they don't need us to run the settings/bg_targets.json report).