### PR TITLE
print enact/smb-suggested.json if deliverAt check fails

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -254,12 +254,18 @@ function smb_verify_suggested {
         echo "Checking system clock against pump clock:"
         oref0-set-system-clock 2>&3 >&4
     fi
-    echo -n "Checking deliverAt: " && jq -r .deliverAt enact/smb-suggested.json | tr -d '\n' \
-    && echo -n " is within 1m of current time: " && date \
-    && (( $(bc <<< "$(date +%s -d $(jq -r .deliverAt enact/smb-suggested.json | tr -d '\n')) - $(date +%s)") > -60 )) \
-    && (( $(bc <<< "$(date +%s -d $(jq -r .deliverAt enact/smb-suggested.json | tr -d '\n')) - $(date +%s)") < 60 )) \
-    && echo "and that smb-suggested.json is less than 1m old" \
-    && (find enact/ -mmin -1 -size +5c | grep -q smb-suggested.json)
+    if jq -e -r .deliverAt enact/smb-suggested.json; then
+        echo -n "Checking deliverAt: " && jq -r .deliverAt enact/smb-suggested.json | tr -d '\n' \
+        && echo -n " is within 1m of current time: " && date \
+        && (( $(bc <<< "$(date +%s -d $(jq -r .deliverAt enact/smb-suggested.json | tr -d '\n')) - $(date +%s)") > -60 )) \
+        && (( $(bc <<< "$(date +%s -d $(jq -r .deliverAt enact/smb-suggested.json | tr -d '\n')) - $(date +%s)") < 60 )) \
+        && echo "and that smb-suggested.json is less than 1m old" \
+        && (find enact/ -mmin -1 -size +5c | grep -q smb-suggested.json)
+    else
+        echo No deliverAt found.
+        cat enact/smb-suggested.json
+        false
+    fi
 }
 
 function smb_verify_status {


### PR DESCRIPTION
When oref0-determine-basal generates an error and doesn't generate a full recommendation, oref0 0.6.0 currently doesn't display that.  This PR does an explicit check for the deliverAt field in the smb-suggested.json, and prints the contents before exiting if it's not found.