### PR TITLE
Delete non-OpenAPS log files earlier to save disk space

### DIFF
--- a/logrotate.rsyslog
+++ b/logrotate.rsyslog
@@ -14,9 +14,8 @@
 
 /var/log/syslog
 {
-	rotate 24
-	daily
-	size 10M
+	rotate 3
+	size 5M
 	missingok
 	notifempty
 	delaycompress
@@ -39,9 +38,8 @@
 /var/log/debug
 /var/log/messages
 {
-	rotate 24
-	daily
-	size 10M
+	rotate 3
+	size 5M
 	missingok
 	notifempty
 	compress


### PR DESCRIPTION
Recently, several users have reported problems due to missing disk space on their rigs.  With the current configuration, log files can easily consume several hundred megabytes.

This small change lets the rig delete non-OpenAPS logs (system, cron, etc.) much earlier. I have been using this configuration for a while and it has kept the size of my non-OpenAPS log files below 100MB.

This PR does not touch the treatment of OpenAPS log files.