### PR TITLE
Autosens: don't detect resistance based on + deviations with BG < 80

### DIFF
--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -160,6 +160,10 @@ function detectSensitivity(inputs) {
         bgi = bgi.toFixed(2);
         //console.error(delta);
         deviation = delta-bgi;
+        // set positive deviations to zero if BG is below 80
+        if ( bg < 80 && deviation > 0 ) {
+            deviation = 0;
+        }
         deviation = deviation.toFixed(2);
 
         var glucoseDatum = bucketed_data[i];


### PR DESCRIPTION
We sometimes see BG running low overnight due to resistance detected during the previous day.  To prevent that, this PR forces autosens to reduce positive deviations to zero any time BG is less than 80 mg/dL, which quickly decays away any previously detected resistance, and prevents autosens from detecting further resistance as easily if BG has been < 80 for very long during the last 8h or 24h.  It will *not* cause autosens to detect sensitivity any more than it otherwise would.

Here's an example of autosens output from before this change:
```
Calculating sensitivity using 8h of non-exluded data
+60g(xxxxxxxx22h=xxxxxxxxxxxx23hxxxxxxxxxxxx0h=x)-++++++++++1h-+++--+++-++2h=-+-++++++++-3h-+-++---++++4h=++++----+-++5h+++--+++++++6h=+++-------+-+-7h+-------+-+-+-+-+-+-+-+-8h=+-------+---+-----+-+---9h------+-----+---+--++10h=++
Using most recent 128 deviations since 2018-01-12T05:06:15.000Z
42% of non-meal deviations positive (>50% = resistance)
56% of non-meal deviations negative (>50% = sensitivity)
RMS deviation: 5.82
Insulin sensitivity detected: ISF adjusted from 51.671 to 57
Calculating sensitivity using all non-exluded data (up to 24h)
+60g(xxxxxxxx22h=xxxxxxxxxxxx23hxxxxxxx)-++++0h=--++++++++++1h-+++---++-++2h=-+-++++++++-3h-+-++---++++4h=++++----+-++5h+++--+++++++6h=+++-------+-+-7h+-------+-+-+-+-+-+-+-+-8h=+-------+---+-----+-+---9h------+-----+---+--++10h=++
Using most recent 170 deviations since 2018-01-12T05:06:15.000Z
49% of non-meal deviations positive (>50% = resistance)
48% of non-meal deviations negative (>50% = sensitivity)
RMS deviation: 5.75
Sensitivity normal.
ISF adjusted from 51.671 to 52
Using 8h autosens ratio of 0.91 (ISF 57)
{"ratio":0.91}
```
And with this change:
```
Calculating sensitivity using 8h of non-exluded data
+60g(xxxxxxxx22h=xxxxxxxxxxxx23hxxxxxxxx)====0h=--===+++++++1h-+++--+++-++2h=-+-++++++++-3h-+-++---++++4h=++++----=-==5h===--=======6h==++-------=-=-7h=-------=-=-=-+-+-+-+-+-8h=+-------=---=-----=-=---9h------=-----=---=--++10h=++
Using most recent 131 deviations since 2018-01-12T05:06:15.000Z
23% of non-meal deviations positive (>50% = resistance)
54% of non-meal deviations negative (>50% = sensitivity)
RMS deviation: 5.28
Insulin sensitivity detected: ISF adjusted from 51.671 to 57
Calculating sensitivity using all non-exluded data (up to 24h)
+60g(xxxxxxxx22h=xxxxxxxxxxxx23hxxxxxxx)-====0h=--====++++++1h-+++---++-++2h=-+-++++++++-3h-+-++---++++4h=++++----=-==5h===--=======6h==++-------=-=-7h=-------=-=-=-+-+-+-+-+-8h=+-------=---=-----=-=---9h------=-----=---=--++10h=++
Using most recent 170 deviations since 2018-01-12T05:06:15.000Z
28% of non-meal deviations positive (>50% = resistance)
48% of non-meal deviations negative (>50% = sensitivity)
RMS deviation: 5.17
Sensitivity normal.
ISF adjusted from 51.671 to 52
Using 8h autosens ratio of 0.91 (ISF 57)
{"ratio":0.91}
```
In this case you can see that the end result was unchanged, because it was detecting sensitivity already, but you'll notice that the `% of non-meal deviations positive` dropped from 42% and 49% to 23% and 28%, which will likely prevent it from detecting resistance for 24h after the time spent < 80 mg/dL between 5am and 6am (where you see lots of `===` where there previously were `+++`.
