### PR TITLE
Autotune: don't detect resistance based on + deviations with BG < 80

### DIFF
--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -214,6 +214,11 @@ function categorizeBGDatums(opts) {
         // calculating deviation
         deviation = avgDelta-BGI;
 
+        // set positive deviations to zero if BG is below 80
+        if ( BG < 80 && deviation > 0 ) {
+            deviation = 0;
+        }
+
         // rounding and storing deviation
         deviation = deviation.toFixed(2);
         glucoseDatum.deviation = deviation;


### PR DESCRIPTION
As with #902, we sometimes see autotune tuning/leaving basal too high at a time of day when BG is low.  To prevent that, this PR forces autotune to reduce positive deviations to zero any time BG is less than 80 mg/dL.  This in turn causes it to lower basals, raise ISF, or raise CR when BG is too low for too long.