### PR TITLE
Autotune Command Line Option to Classify UAM as Basal

### DIFF
--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -46,9 +46,12 @@ if (!module.parent) {
         process.exit(1);
     }
 
-    if (carb_input === '--categorize_uam_as_basal' || categorize_uam_as_basal_arg === '--categorize_uam_as_basal') {
+    if (carb_input === '--categorize_uam_as_basal') {
         categorize_uam_as_basal = true;
-    } else if (categorize_uam_as_basal_arg !== undefined) {
+        carb_input = undefined;
+    } else if (categorize_uam_as_basal_arg === '--categorize_uam_as_basal') {
+        categorize_uam_as_basal = true;
+    } else if (typeof categorize_uam_as_basal_arg !== 'undefined') {
         usage( );
         process.exit(1);
     }
@@ -88,7 +91,7 @@ if (!module.parent) {
     }
 
     var carb_data = { };
-    if ((typeof carb_input != 'undefined') && (carb_input !== '--categorize_uam_as_basal')) {
+    if (typeof carb_input != 'undefined') {
         try {
             carb_data = JSON.parse(fs.readFileSync(carb_input, 'utf8'));
         } catch (e) {

--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -22,24 +22,34 @@
 
 var generate = require('oref0/lib/autotune-prep');
 function usage ( ) {
-        console.error('usage: ', process.argv.slice(0, 2), '<pumphistory.json> <profile.json> <glucose.json> [pumpprofile.json] [carbhistory.json] [autotune/glucose.json]');
+        console.error('usage: ', process.argv.slice(0, 2), '<pumphistory.json> <profile.json> <glucose.json> [pumpprofile.json] [carbhistory.json] [autotune/glucose.json] [--categorize_uam_as_basal]');
 }
 
 if (!module.parent) {
     var pumphistory_input = process.argv[2];
     if ([null, '--help', '-h', 'help'].indexOf(pumphistory_input) > 0) {
       usage( );
-      process.exit(0)
+      process.exit(0);
     }
     var profile_input = process.argv[3];
     var glucose_input = process.argv[4];
-    var pumpprofile_input = process.argv[5]
-    var carb_input = process.argv[6]
+    var pumpprofile_input = process.argv[5];
+    var carb_input = process.argv[6];
+    var categorize_uam_as_basal_arg = process.argv[7];
+
+    var categorize_uam_as_basal = false;
     //var prepped_glucose_input = process.argv[7]
 
     if ( !pumphistory_input || !profile_input || !glucose_input ) {
         usage( );
         console.log('{ "error": "Insufficient arguments" }');
+        process.exit(1);
+    }
+
+    if (carb_input === '--categorize_uam_as_basal' || categorize_uam_as_basal_arg === '--categorize_uam_as_basal') {
+        categorize_uam_as_basal = true;
+    } else if (categorize_uam_as_basal_arg !== undefined) {
+        usage( );
         process.exit(1);
     }
 
@@ -78,7 +88,7 @@ if (!module.parent) {
     }
 
     var carb_data = { };
-    if (typeof carb_input != 'undefined') {
+    if ((typeof carb_input != 'undefined') && (carb_input !== '--categorize_uam_as_basal')) {
         try {
             carb_data = JSON.parse(fs.readFileSync(carb_input, 'utf8'));
         } catch (e) {
@@ -100,6 +110,7 @@ if (!module.parent) {
     , pumpprofile: pumpprofile_data
     , carbs: carb_data
     , glucose: glucose_data
+    , categorize_uam_as_basal: categorize_uam_as_basal
     //, prepped_glucose: prepped_glucose_data
     };
 

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -382,7 +382,7 @@ function categorizeBGDatums(opts) {
         //console.error(basalGlucoseData, UAMGlucoseData);
         console.error("Warning: too many deviations categorized as UnAnnounced Meals");
         console.error("Adding",UAMLength,"UAM deviations to",basalLength,"basal ones");
-        var basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
+        basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
         //console.error(basalGlucoseData);
         // if too much data is excluded as UAM, add in the UAM deviations, but then discard the highest 50%
         basalGlucoseData.sort(function (a, b) {
@@ -394,8 +394,11 @@ function categorizeBGDatums(opts) {
         console.error("and selecting the lowest 50%, leaving", basalGlucoseData.length, "basal+UAM ones");
 
         console.error("Adding",UAMLength,"UAM deviations to",ISFLength,"ISF ones");
-        var ISFGlucoseData = ISFGlucoseData.concat(UAMGlucoseData);
+        ISFGlucoseData = ISFGlucoseData.concat(UAMGlucoseData);
         //console.error(ISFGlucoseData.length, UAMLength);
+    } else if (opts.categorize_uam_as_basal) {
+        console.error("Categorizing all UAM data as basal.");
+        basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
     }
     var basalLength = basalGlucoseData.length;
     var ISFLength = ISFGlucoseData.length;
@@ -404,7 +407,7 @@ function categorizeBGDatums(opts) {
         //console.error("Adding",CSFLength,"CSF deviations to",basalLength,"basal ones");
         //var basalGlucoseData = basalGlucoseData.concat(CSFGlucoseData);
         console.error("Adding",CSFLength,"CSF deviations to",ISFLength,"ISF ones");
-        var ISFGlucoseData = ISFGlucoseData.concat(CSFGlucoseData);
+        ISFGlucoseData = ISFGlucoseData.concat(CSFGlucoseData);
         CSFGlucoseData = [];
     }
 

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -378,7 +378,10 @@ function categorizeBGDatums(opts) {
     var UAMLength = UAMGlucoseData.length;
     var basalLength = basalGlucoseData.length;
 
-    if (2*basalLength < UAMLength) {
+    if (opts.categorize_uam_as_basal) {
+        console.error("Categorizing all UAM data as basal.");
+        basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
+    } else if (2*basalLength < UAMLength) {
         //console.error(basalGlucoseData, UAMGlucoseData);
         console.error("Warning: too many deviations categorized as UnAnnounced Meals");
         console.error("Adding",UAMLength,"UAM deviations to",basalLength,"basal ones");
@@ -396,9 +399,6 @@ function categorizeBGDatums(opts) {
         console.error("Adding",UAMLength,"UAM deviations to",ISFLength,"ISF ones");
         ISFGlucoseData = ISFGlucoseData.concat(UAMGlucoseData);
         //console.error(ISFGlucoseData.length, UAMLength);
-    } else if (opts.categorize_uam_as_basal) {
-        console.error("Categorizing all UAM data as basal.");
-        basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
     }
     var basalLength = basalGlucoseData.length;
     var ISFLength = ISFGlucoseData.length;

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -18,6 +18,7 @@ function generate (inputs) {
   //, prepped_glucose: inputs.prepped_glucose
   , basalprofile: inputs.profile.basalprofile
   , pumpbasalprofile: inputs.pumpprofile.basalprofile
+  , categorize_uam_as_basal: inputs.categorize_uam_as_basal
   };
 
   var autotune_prep_output = categorize(opts);


### PR DESCRIPTION
This adds an option to autotune for a user to manually add a --categorize-uam-as-basal option to the command line to add all UAM categorizes BG data to basal data. This is useful if the user is confident all carb intake events were logged and the user's basal rates are far enough from reality that time periods are being incorrectly categorized as UAM events instead of basal events.