### PR TITLE
Fix autotune ISF adjustment fraction

### DIFF
--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -353,11 +353,13 @@ function tuneAllTheThings (inputs) {
     fullNewISF = Math.round( fullNewISF * 1000 ) / 1000;
     // adjust the target ISF to be a weighted average of fullNewISF and pumpISF
     var adjustmentFraction;
-    if (pumpProfile.autotune_isf_adjustmentFraction) {
+
+    if (typeof(pumpProfile.autotune_isf_adjustmentFraction) !== 'undefined') {
         adjustmentFraction = pumpProfile.autotune_isf_adjustmentFraction;
     } else {
         adjustmentFraction = 1.0;
     }
+
     // low autosens ratio = high ISF
     var maxISF = pumpISF / autotuneMin;
     // high autosens ratio = low ISF


### PR DESCRIPTION
The test for autotune ISF adjustment fraction from the profile test to see if it is true. This has the unintended consequence of setting the adjustment fraction to 1 when the profile setting is 0.

This modification changes the test from a test of whether its value is true to whether it exists.