### PR TITLE
Go-based replacement for openaps toolkit for use with Explorer HAT

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -447,7 +447,10 @@ function mmtune {
       do
        freq=$freq"0"
       done
-    MEDTRONIC_FREQUENCY=$freq && echo $freq > monitor/medtronic_frequency.ini
+    #Make sure we don't zero out the medtronic frequency. It will break everything.
+    if [ $freq != "000000000" ] ; then
+	 MEDTRONIC_FREQUENCY=$freq && echo $freq > monitor/medtronic_frequency.ini
+    fi
     #Determine how long to wait, based on the RSSI value of the best frequency
     grep -v setFreq monitor/mmtune.json | grep -A2 $(json -a setFreq -f monitor/mmtune.json) | while read line
         do echo -n "$line "
@@ -786,8 +789,11 @@ function check_status() {
   mdt status 2>&3 | tee monitor/status.json 2>&3 >&4
 }
 function mmtune_Go() {
-#needs a check for radio locale, setting it to ww because that is what I am currently testing it on
-  Go-mmtune -ww | tee monitor/mmtune.json
+  if ( grep "WW" pump.ini ); then
+  	Go-mmtune -ww | tee monitor/mmtune.json
+  else
+  	Go-mmtune | tee monitor/mmtune.json
+  fi
 }
 function check_clock() {
   mdt clock 2>&3 | tee monitor/clock-zoned.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -562,7 +562,7 @@ function merge_pumphistory {
 function enact {
     rm enact/suggested.json
     openaps report invoke enact/suggested.json \
-    && if (cat enact/suggested.json && grep -q duration enact/suggested.json) ; then (
+    && if (cat enact/suggested.json && grep -q duration enact/suggested.json); then (
         rm enact/enacted.json
         ( mdt settempbasal enact/suggested.json && jq '.  + {"received": true}' enact/suggested.json > enact/enacted.json ) 2>&3 >&4 | tail -1
 	#openaps report invoke enact/enacted.json 2>&3 >&4 | tail -1

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -786,7 +786,8 @@ function check_status() {
   mdt status 2>&3 | tee monitor/status.json 2>&3 >&4
 }
 function mmtune_Go() {
-  Go-mmtune | tee monitor/mmtune.json
+#needs a check for radio locale, setting it to ww because that is what I am currently testing it on
+  Go-mmtune -ww | tee monitor/mmtune.json
 }
 function check_clock() {
   mdt clock 2>&3 | tee monitor/clock-zoned.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -562,11 +562,11 @@ function merge_pumphistory {
 function enact {
     rm enact/suggested.json
     openaps report invoke enact/suggested.json \
-    && if (cat enact/suggested.json && grep -q duration enact/suggested.json) ; then
+    && if (cat enact/suggested.json && grep -q duration enact/suggested.json) ; then (
         rm enact/enacted.json
         ( mdt settempbasal enact/suggested.json && jq '.  + {"received": true}' enact/suggested.json > enact/enacted.json ) 2>&3 >&4 | tail -1
 	#openaps report invoke enact/enacted.json 2>&3 >&4 | tail -1
-        grep -q duration enact/enacted.json || ( mdt settempbasal enact/suggested.json && jq '.  + {"received": true}' enact/suggested.json > enact/enacted.json ) 2>&1 | egrep -v "^  |subg_rfspy|handler"
+        grep -q duration enact/enacted.json || ( mdt settempbasal enact/suggested.json && jq '.  + {"received": true}' enact/suggested.json > enact/enacted.json ) ) 2>&1 | egrep -v "^  |subg_rfspy|handler"
     fi
     grep incorrectly enact/suggested.json && oref0-set-system-clock 2>&3
     echo -n "enact/enacted.json: " && cat enact/enacted.json | jq -C -c .

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -251,7 +251,7 @@ function smb_verify_reservoir {
     # Read the pump reservoir volume and verify it is within 0.1U of the expected volume
     rm -rf monitor/reservoir.json
     echo -n "Checking reservoir: " \
-    && ( check_reservoir || check_reservoir )2>&3 >&4 \
+    && ( check_reservoir || check_reservoir ) 2>&3 >&4 | tail -1 \
     && echo -n "reservoir level before: " \
     && cat monitor/lastreservoir.json \
     && echo -n ", suggested: " \
@@ -423,7 +423,7 @@ function mdt_get_bg {
 function preflight {
     echo -n "Preflight "
     # only 515, 522, 523, 715, 722, 723, 554, and 754 pump models have been tested with SMB
-    retry_fail check_model 2>&3 >&4 | tail -1 \
+    ( check_model || check_model ) 2>&3 >&4 | tail -1 \
     && ( egrep -q "[57](15|22|23|54)" settings/model.json || (grep 12 settings/model.json && die "error: x12 pumps do support SMB safety checks: quitting to restart with basal-only pump-loop") ) \
     && echo -n "OK. " \
     || ( echo -n "fail. "; false )
@@ -627,7 +627,7 @@ function get_settings {
 #    retry_return openaps report invoke settings/insulin_sensitivities_raw.json settings/insulin_sensitivities.json settings/carb_ratios.json $NON_X12_ITEMS 2>&3 >&4 | tail -1 || return 1
 
     # generate settings/pumpprofile.json without autotune
-    oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json 2>&3 | jq . > settings/pumpprofile.json.new || { echo "Couldn't refresh pumpprofile"; fail "$@"; }
+    oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json settings/autotune.json 2>&3 | jq . > settings/pumpprofile.json.new || { echo "Couldn't refresh pumpprofile"; fail "$@"; }
     if ls settings/pumpprofile.json.new >&4 && cat settings/pumpprofile.json.new | jq -e .current_basal >&4; then
         mv settings/pumpprofile.json.new settings/pumpprofile.json
         echo -n "Pump profile refreshed; "

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -17,7 +17,6 @@
 export MEDTRONIC_PUMP_ID=`grep serial pump.ini | tr -cd 0-9`
 export MEDTRONIC_FREQUENCY=`cat monitor/medtronic_frequency.ini`
 OREF0_DEBUG=${OREF0_DEBUG:-0}
-#OREF0_DEBUG=1
 if [[ "$OREF0_DEBUG" -ge 1 ]] ; then
   exec 3>&1
 else

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -227,7 +227,7 @@ function smb_enact_temp {
         #( mdt settempbasal enact/smb-suggested.json && ( cp enact/smb-suggested.json enact/smb-enacted.json ) ) 2>&3 >&4 | tail -1
 	#openaps report invoke enact/smb-enacted.json 2>&3 >&4 | tail -1
         #grep -q duration enact/smb-enacted.json || openaps report invoke enact/smb-enacted.json 2>&3 >&4 | tail -1
-        grep -q duration enact/smb-enacted.json || ( mdt settempbasal enact/smb-suggested.json && ( cp enact/smb-suggested.json enact/smb-enacted.json ) ) 2>&3 >&4 | tail -1
+        grep -q duration enact/smb-enacted.json || ( mdt settempbasal enact/smb-suggested.json && jq '.  + {"received": true}' enact/smb-suggested.json > enact/smb-enacted.json ) 2>&3 >&4 | tail -1
 	cp -up enact/smb-enacted.json enact/enacted.json
         echo -n "enact/smb-enacted.json: " && cat enact/smb-enacted.json | jq -C -c '. | "Rate: \(.rate) Duration: \(.duration)"'
         ) 2>&1 | egrep -v "^  |subg_rfspy|handler"
@@ -562,7 +562,7 @@ function enact {
         rm enact/enacted.json
         ( mdt settempbasal enact/suggested.json && jq '.  + {"received": true}' enact/suggested.json > enact/enacted.json ) 2>&3 >&4 | tail -1
 	#openaps report invoke enact/enacted.json 2>&3 >&4 | tail -1
-        grep -q duration enact/enacted.json || ( mdt settempbasal enact/smb-suggested.json && jq '.  + {"received": true}' enact/smb-suggested.json > enact/smb-enacted.json ) 2>&1 | egrep -v "^  |subg_rfspy|handler"
+        grep -q duration enact/enacted.json || ( mdt settempbasal enact/suggested.json && jq '.  + {"received": true}' enact/suggested.json > enact/enacted.json ) 2>&1 | egrep -v "^  |subg_rfspy|handler"
     fi
     grep incorrectly enact/suggested.json && oref0-set-system-clock 2>&3
     echo -n "enact/enacted.json: " && cat enact/enacted.json | jq -C -c .

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -282,7 +282,7 @@ function smb_verify_status {
     echo -n "Checking pump status (suspended/bolusing): "
     ( check_status || check_status ) 2>&3 >&4 | tail -1 \
     && cat monitor/status.json | jq -C -c . \
-    && grep -q '"string": "normal"' monitor/status.json \
+    && grep -q '"status": "normal"' monitor/status.json \
     && grep -q '"bolusing": false' monitor/status.json \
     && if grep -q '"suspended": true' monitor/status.json; then
         echo -n "Pump suspended; "

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1072,10 +1072,6 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             # autotune nightly at 4:05am using data from NS
             (crontab -l; crontab -l | grep -q "oref0-autotune -d=$directory -n=$NIGHTSCOUT_HOST" || echo "5 4 * * * ( oref0-autotune -d=$directory -n=$NIGHTSCOUT_HOST && cat $directory/autotune/profile.json | json | grep -q start && cp $directory/autotune/profile.json $directory/settings/autotune.json) 2>&1 | tee -a /var/log/openaps/autotune.log") | crontab -
         fi
-        if [[ "$ttyport" =~ "spi" ]]; then
-            (crontab -l; crontab -l | grep -q "reset_spi_serial.py" || echo "@reboot reset_spi_serial.py") | crontab -
-            (crontab -l; crontab -l | grep -q "oref0-radio-reboot" || echo "* * * * * oref0-radio-reboot") | crontab -
-        fi
         (crontab -l; crontab -l | grep -q "cd $directory && ( ps aux | grep -v grep | grep bash | grep -q 'bin/oref0-pump-loop'" || echo "* * * * * cd $directory && ( ps aux | grep -v grep | grep bash | grep -q 'bin/oref0-pump-loop' || oref0-pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -
         # try to start oref0-pump-loop every 30s
         (crontab -l; crontab -l | grep -q "cd $directory && sleep 30 && ( ps aux | grep -v grep | grep bash | grep -q 'bin/oref0-pump-loop'" || echo "* * * * * cd $directory && sleep 30 && ( ps aux | grep -v grep | grep bash | grep -q 'bin/oref0-pump-loop' || oref0-pump-loop ) 2>&1 | tee -a /var/log/openaps/pump-loop.log") | crontab -

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1033,7 +1033,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         cd ../pumphistory && go install -tags cc111x
         cd ../listen && go install -tags cc111x
         cd $HOME/go/bin && cp * /usr/local/bin
-        cp $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq #HOME/myopenaps/
+        cp $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq $HOME/myopenaps/
         #Necessary to "bootstrap" Go commands...
         if [[ $radio_locale =~ ^WW$ ]]; then
           cat 868400000 > $HOME/myopenaps/monitor/medtronic_frequency.ini

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -195,34 +195,35 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
         echo
     fi
 
-
-    read -p "Are you using an Explorer Board / HAT? [Y]/n " -r
-    if [[ $REPLY =~ ^[Nn]$ ]]; then
-        echo 'Are you using mmeowlink (i.e. with a TI stick)? If not, press enter. If so, paste your full port address: it looks like "/dev/ttySOMETHING" without the quotes.'
-        read -p "What is your TTY port? " -r
-        ttyport=$REPLY
-        echocolor-n "Ok, "
-        if [[ -z "$ttyport" ]]; then
-            echo -n Carelink
-        else
-            echo -n TTY $ttyport
-        fi
-        echocolor " it is. "
-        echo
+    if grep -a "Explorer HAT" /proc/device-tree/hat/product ; then
+        echocolor "Explorer Board HAT detected. "
+        ttyport=/dev/spidev0.0
     else
-        if  getent passwd edison > /dev/null; then
-            echocolor "Yay! Configuring for Edison with Explorer Board. "
-            ttyport=/dev/spidev5.1
-        elif getent passwd pi > /dev/null; then
-            echocolor "Yay! Configuring for Pi with Explorer Board HAT. "
-            ttyport=/dev/spidev0.0
-        else
-            echo "Hmm, you don't seem to be using an Edison or Pi."
-            read -p "What is your TTY port? (/dev/ttySOMETHING) " -r
+        read -p "Are you using an Explorer Board? [Y]/n " -r
+        if [[ $REPLY =~ ^[Nn]$ ]]; then
+            echo 'Are you using mmeowlink (i.e. with a TI stick)? If not, press enter. If so, paste your full port address: it looks like "/dev/ttySOMETHING" without the quotes.'
+            read -p "What is your TTY port? " -r
             ttyport=$REPLY
-            echocolor "Ok, we'll try TTY $ttyport then."
+            echocolor-n "Ok, "
+            if [[ -z "$ttyport" ]]; then
+                echo -n Carelink
+            else
+                echo -n TTY $ttyport
+            fi
+            echocolor " it is. "
+            echo
+        else
+            if  getent passwd edison > /dev/null; then
+                echocolor "Yay! Configuring for Edison with Explorer Board. "
+                ttyport=/dev/spidev5.1
+            else
+                echo "Hmm, you don't seem to be using an Edison."
+                read -p "What is your TTY port? (/dev/ttySOMETHING) " -r
+                ttyport=$REPLY
+                echocolor "Ok, we'll try TTY $ttyport then."
+            fi
+            echo
         fi
-        echo
     fi
 
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1033,6 +1033,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         cd ../pumphistory && go install -tags cc111x
         cd ../listen && go install -tags cc111x
         cd $HOME/go/bin && cp * /usr/local/bin
+        mv /usr/local/bin/mmtune /usr/local/bin/Go-mmtune
         cp $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq $HOME/myopenaps/
         #Necessary to "bootstrap" Go commands...
         if [[ $radio_locale =~ ^WW$ ]]; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1037,9 +1037,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         cp $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq $HOME/myopenaps/
         #Necessary to "bootstrap" Go commands...
         if [[ $radio_locale =~ ^WW$ ]]; then
-          cat 868400000 > $HOME/myopenaps/monitor/medtronic_frequency.ini
+          echo 868400000 > $HOME/myopenaps/monitor/medtronic_frequency.ini
         else
-          cat 916550000 > $HOME/myopenaps/monitor/medtronic_frequency.ini
+          echo 916550000 > $HOME/myopenaps/monitor/medtronic_frequency.ini
         fi
     fi
     

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1014,7 +1014,32 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         cd $HOME/src && git clone git://github.com/openaps/openaps-menu.git || (cd openaps-menu && git checkout master && git pull)
         cd $HOME/src/openaps-menu && sudo npm install
         cp $HOME/src/openaps-menu/openaps-menu.service /etc/systemd/system/ && systemctl enable openaps-menu
-        cd $HOME/myopenaps && openaps alias remove battery-status && openaps alias add battery-status '! bash -c "sudo ~/src/openaps-menu/scripts/getvoltage.sh > monitor/edison-battery.json"'
+     #This part works, but really needs a more concise rewrite.
+        echo "Installing Golang..."
+        cd /tmp && wget https://storage.googleapis.com/golang/go1.9.2.linux-armv6l.tar.gz && tar -C /usr/local -xzvf /tmp/go1.9.2.linux-armv6l.tar.gz
+        echo 'GOROOT=/usr/local/go' >> $HOME/.bash_profile
+        echo 'export GOROOT' >> $HOME/.bash_profile
+        echo 'GOPATH=$HOME/go' >> $HOME/.bash_profile
+        echo 'export GOPATH' >> $HOME/.bash_profile
+        echo 'PATH=$PATH:/usr/local/go/bin:$GOROOT/bin:$GOPATH/bin' >> $HOME/.bash_profile
+        echo 'export PATH' >> $HOME/.bash_profile
+        mkdir $HOME/go
+        source /root/.bash_profile
+        go get -v github.com/ecc1/cc111x
+        go get -v github.com/ecc1/medtronic
+        cd $HOME/go/src/github.com/ecc1/medtronic/cmd
+        cd mdt && go install -tags cc111x
+        cd ../mmtune && go install -tags cc111x
+        cd ../pumphistory && go install -tags cc111x
+        cd ../listen && go install -tags cc111x
+        cd $HOME/go/bin && cp * /usr/local/bin
+        cp $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq #HOME/myopenaps/
+        #Necessary to "bootstrap" Go commands...
+        if [[ $radio_locale =~ ^WW$ ]]; then
+          cat 868400000 > $HOME/myopenaps/monitor/medtronic_frequency.ini
+        else
+          cat 916550000 > $HOME/myopenaps/monitor/medtronic_frequency.ini
+        fi
     fi
     
     if [[ "$ttyport" =~ "spi" ]]; then


### PR DESCRIPTION
This work in progress branch replaces the use of the `openaps` toolkit and `mmeowlink` with @ecc1's Go-based tool for talking to `medtronic` pumps (https://github.com/ecc1/medtronic).  It promises to work much faster than `openaps`, allowing better battery life on Raspberry Pi based rigs, but still requires extensive testing.