### PR TITLE
Fix Autotune TZ Issue

### DIFF
--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -107,11 +107,19 @@ function tuneAllTheThings (inputs) {
     for (var hour=0; hour < 24; hour++) {
         var deviations = 0;
         for (var i=0; i < basalGlucose.length; ++i) {
-            //console.error(basalGlucose[i].dateString);
-            var splitString = basalGlucose[i].dateString.split("T");
-            var timeString = splitString[1];
-            var splitTime = timeString.split(":");
-            var myHour = parseInt(splitTime[0]);
+            var BGTime;
+
+            if (basalGlucose[i].date) {
+                BGTime = new Date(basalGlucose[i].date);
+            } else if (basalGlucose[i].displayTime) {
+                BGTime = new Date(basalGlucose[i].displayTime.replace('T', ' '));
+            } else if (basalGuclose[i].dateString) {
+                BGTime = new Date(basalGlucose[i].dateString);
+            } else {
+                console.error("Could not determine last BG time");
+            }
+
+            var myHour = BGTime.getHours();
             if (hour == myHour) {
                 //console.error(basalGlucose[i].deviation);
                 deviations += parseFloat(basalGlucose[i].deviation);


### PR DESCRIPTION
When the database has mixed dateStrings containing zulu time lib/autotune/index.js would pick the wrong hour value when looking at the deviations per hour. This uses the Date object with the same methods as used in categorize arrive at the correct local time hour.