### PR TITLE
Open lsgaps Entry Gap Window

### DIFF
--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -204,7 +204,7 @@ ns)
         | openaps use $ZONE  \
           rezone --astimezone --date dateString - \
         | openaps use $ZONE  \
-          lsgaps --minutes 5 --after now  --date dateString -
+          lsgaps --minutes 6 --after now  --date dateString -
 
 
     ;;


### PR DESCRIPTION
The G5 transmitter with xdrip-js can regularly have time gaps slightly greater than 5 minutes. Opening the window to identify gaps from 5 minutes to 6 minutes prevents generation of the false gaps.