### PR TITLE
Ignore time travel

### DIFF
--- a/bin/oref0-calculate-iob.js
+++ b/bin/oref0-calculate-iob.js
@@ -20,7 +20,7 @@
 
 var generate = require('oref0/lib/iob');
 function usage ( ) {
-    console.log('usage: ', process.argv.slice(0, 2), '<pumphistory-zoned.json> <profile.json> <clock-zoned.json> [autosens.json]');
+    console.log('usage: ', process.argv.slice(0, 2), '<pumphistory-zoned.json> <profile.json> <clock-zoned.json> [autosens.json] [pumphistory-24h-zoned.json]');
 
 }
 
@@ -33,6 +33,7 @@ if (!module.parent) {
   var profile_input = process.argv[3];
   var clock_input = process.argv[4];
   var autosens_input = process.argv[5];
+  var pumphistory_24_input = process.argv[6];
 
   if (!pumphistory_input || !profile_input) {
     usage( );
@@ -40,7 +41,7 @@ if (!module.parent) {
   }
 
   var cwd = process.cwd();
-  var all_data = require(cwd + '/' + pumphistory_input);
+  var pumphistory_data = require(cwd + '/' + pumphistory_input);
   var profile_data = require(cwd + '/' + profile_input);
   var clock_data = require(cwd + '/' + clock_input);
 
@@ -51,11 +52,18 @@ if (!module.parent) {
     } catch (e) {}
     //console.error(autosens_input, JSON.stringify(autosens_data));
   }
+  var pumphistory_24_data = null;
+  if (pumphistory_24_input) {
+    try {
+        var pumphistory_24_data = require(cwd + '/' + pumphistory_24_input);
+    } catch (e) {}
+  }
 
-  // all_data.sort(function (a, b) { return a.date > b.date });
+  // pumphistory_data.sort(function (a, b) { return a.date > b.date });
 
   var inputs = {
-    history: all_data
+    history: pumphistory_data
+  , history24: pumphistory_24_data
   , profile: profile_data
   , clock: clock_data
   };

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -501,8 +501,10 @@ function refresh_pumphistory_and_meal {
     echo -n resh
     retry_return monitor_pump || return 1
     echo -n ed
+    # TODO: remove
     retry_return merge_pumphistory || return 1
     echo -n " pumphistory"
+    # TODO: replace pumphistory-merged with pumphistory-zoned + pumphistory-24h-zoned as in calculate_iob
     retry_return timerun oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json || return 1
     echo " and meal.json"
 }
@@ -514,7 +516,7 @@ function monitor_pump {
 }
 
 function calculate_iob {
-    timerun oref0-calculate-iob monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json settings/autosens.json > monitor/iob.json || { echo; echo "Couldn't calculate IOB"; fail "$@"; }
+    timerun oref0-calculate-iob monitor/pumphistory-zoned.json settings/profile.json monitor/clock-zoned.json settings/autosens.json settings/pumphistory-24h-zoned.json > monitor/iob.json || { echo; echo "Couldn't calculate IOB"; fail "$@"; }
 }
 
 function invoke_pumphistory_etc {
@@ -527,6 +529,7 @@ function invoke_reservoir_etc {
     test ${PIPESTATUS[0]} -eq 0
 }
 
+#TODO: remove this
 function merge_pumphistory {
     jq -s '.[0] + .[1]|unique|sort_by(.timestamp)|reverse' monitor/pumphistory-zoned.json settings/pumphistory-24h-zoned.json > monitor/pumphistory-merged.json
     calculate_iob
@@ -635,7 +638,7 @@ function refresh_temp_and_enact {
             echo -n Temp refresh
             retry_fail invoke_temp_etc
             echo ed
-            timerun oref0-calculate-iob monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json settings/autosens.json || { echo "Couldn't calculate IOB"; fail "$@"; }
+            timerun oref0-calculate-iob monitor/pumphistory-zoned.json settings/profile.json monitor/clock-zoned.json settings/autosens.json settings/pumphistory-24h-zoned.json || { echo "Couldn't calculate IOB"; fail "$@"; }
             if (cat monitor/temp_basal.json | json -c "this.duration < 27" | grep -q duration); then
                 enact; else echo Temp duration 27m or more
             fi

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -614,7 +614,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // set eventualBG to include effect of carbs
         //console.error("PredBGs:",JSON.stringify(predBGs));
     } catch (e) {
-        console.error("Problem with iobArray.  Optional feature Advanced Meal Assist disabled:",e);
+        console.error("Problem with iobArray.  Optional feature Advanced Meal Assist disabled");
     }
     if (meal_data.mealCOB) {
         console.error("predCIs (mg/dL/5m):",predCIs.join(" "));

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -99,9 +99,13 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             var temp = {};
             temp.timestamp = current.timestamp;
             temp.started_at = new Date(tz(current.timestamp));
-            temp.date = temp.started_at.getTime();
-            temp.insulin = current.amount;
-            tempBoluses.push(temp);
+            if (temp.started_at > now) {
+                console.error("Warning: ignoring",current.amount,"U bolus in the future at",temp.started_at);
+            } else {
+                temp.date = temp.started_at.getTime();
+                temp.insulin = current.amount;
+                tempBoluses.push(temp);
+            }
         } else if (current.eventType == "Meal Bolus" || current.eventType == "Correction Bolus" || current.eventType == "Snack Bolus" || current.eventType == "Bolus Wizard") {
             //imports treatments entered through Nightscout Care Portal
             //"Bolus Wizard" refers to the Nightscout Bolus Wizard, not the Medtronic Bolus Wizard

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -80,12 +80,19 @@ function splitTimespan(event, splitterMoments) {
 
 function calcTempTreatments (inputs, zeroTempDuration) {
     var pumpHistory = inputs.history;
+    var pumpHistory24 = inputs.history24;
     var profile_data = inputs.profile;
     var autosens_data = inputs.autosens;
     var tempHistory = [];
     var tempBoluses = [];
     var now = new Date();
     var timeZone = now.toString().match(/([-\+][0-9]+)\s/)[1];
+
+    if(inputs.history24) {
+        var pumpHistory =  [ ].concat(inputs.history).concat(inputs.history24);
+    }
+
+    var lastRecordTime = now;
 
     // Pick relevant events for processing and clean the data
 
@@ -95,12 +102,23 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             var temp = current;
             current = temp.bolus;
         }
+        var currentRecordTime = new Date(tz(current.timestamp));
+        //console.error(currentRecordTime,lastRecordTime);
+        // ignore duplicate or out-of-order records (due to 1h and 24h overlap, or timezone changes)
+        if (currentRecordTime > lastRecordTime) {
+            //console.error("",currentRecordTime," > ",lastRecordTime);
+            //process.stderr.write(".");
+            continue;
+        } else {
+            lastRecordTime = currentRecordTime;
+        }
         if (current._type == "Bolus") {
             var temp = {};
             temp.timestamp = current.timestamp;
             temp.started_at = new Date(tz(current.timestamp));
             if (temp.started_at > now) {
-                console.error("Warning: ignoring",current.amount,"U bolus in the future at",temp.started_at);
+                //console.error("Warning: ignoring",current.amount,"U bolus in the future at",temp.started_at);
+                process.stderr.write(" "+current.amount+"U @ "+temp.started_at);
             } else {
                 temp.date = temp.started_at.getTime();
                 temp.insulin = current.amount;

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -342,7 +342,7 @@ describe('determine-basal', function ( ) {
         var glucose_status = {"delta":3,"glucose":85,"long_avgdelta":3,"short_avgdelta":3};
         var iob_data = {"iob":-0.7,"activity":-0.01,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
-        console.log(output);
+        //console.log(output);
         output.rate.should.be.above(0.8);
         output.duration.should.equal(30);
     });
@@ -354,7 +354,7 @@ describe('determine-basal', function ( ) {
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         //(typeof output.rate).should.equal('undefined');
         //(typeof output.duration).should.equal('undefined');
-        console.log(profile, output);
+        //console.log(profile, output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         output.reason.should.match(/in range.*setting current basal/);

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -406,16 +406,6 @@ describe('IOB', function() {
             inputs = {
                 clock: timestamp,
                 history: [{
-                    _type: 'TempBasalDuration',
-                    'duration (min)': 30,
-                    date: timestamp60mAgo,
-                    timestamp: timestamp60mAgo
-                }, {
-                    _type: 'TempBasal',
-                    rate: 2,
-                    date: timestamp60mAgo,
-                    timestamp: timestamp60mAgo
-                }, {
                     _type: 'TempBasal',
                     rate: 2,
                     date: timestamp30mAgo,
@@ -425,6 +415,16 @@ describe('IOB', function() {
                     'duration (min)': 30,
                     date: timestamp30mAgo,
                     timestamp: timestamp30mAgo
+                }, {
+                    _type: 'TempBasalDuration',
+                    'duration (min)': 30,
+                    date: timestamp60mAgo,
+                    timestamp: timestamp60mAgo
+                }, {
+                    _type: 'TempBasal',
+                    rate: 2,
+                    date: timestamp60mAgo,
+                    timestamp: timestamp60mAgo
                 }],
                 profile: {
                     dia: 3,
@@ -466,16 +466,6 @@ describe('IOB', function() {
         var inputs = {
             clock: timestamp,
             history: [{
-                _type: 'TempBasalDuration',
-                'duration (min)': 30,
-                date: timestampEarly,
-                timestamp: timestampEarly,
-            }, {
-                _type: 'TempBasal',
-                rate: 2,
-                date: timestampEarly,
-                timestamp: timestampEarly
-            }, {
                 _type: 'TempBasal',
                 rate: 2,
                 date: timestamp,
@@ -485,6 +475,16 @@ describe('IOB', function() {
                 'duration (min)': 30,
                 date: timestamp,
                 timestamp: timestamp,
+            }, {
+                _type: 'TempBasalDuration',
+                'duration (min)': 30,
+                date: timestampEarly,
+                timestamp: timestampEarly,
+            }, {
+                _type: 'TempBasal',
+                rate: 2,
+                date: timestampEarly,
+                timestamp: timestampEarly
             }],
             profile: {
                 dia: 3,
@@ -528,16 +528,6 @@ describe('IOB', function() {
             inputs = {
                 clock: timestamp,
                 history: [{
-                    _type: 'TempBasalDuration',
-                    'duration (min)': 30,
-                    date: timestampEarly,
-                    timestamp: timestampEarly
-                }, {
-                    _type: 'TempBasal',
-                    rate: 2,
-                    date: timestampEarly,
-                    timestamp: timestampEarly
-                }, {
                     _type: 'TempBasal',
                     rate: 2,
                     date: timestamp,
@@ -547,6 +537,16 @@ describe('IOB', function() {
                     'duration (min)': 30,
                     date: timestamp,
                     timestamp: timestamp
+                }, {
+                    _type: 'TempBasalDuration',
+                    'duration (min)': 30,
+                    date: timestampEarly,
+                    timestamp: timestampEarly
+                }, {
+                    _type: 'TempBasal',
+                    rate: 2,
+                    date: timestampEarly,
+                    timestamp: timestampEarly
                 }],
                 profile: {
                     dia: 3,

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -770,16 +770,6 @@ describe('IOB', function() {
                 history: [{
                     _type: 'TempBasalDuration',
                     'duration (min)': 15,
-                    date: timestamp60mAgo,
-                    timestamp: timestamp60mAgo
-                }, {
-                    _type: 'TempBasal',
-                    rate: 2,
-                    date: timestamp60mAgo,
-                    timestamp: timestamp60mAgo
-                }, {
-                    _type: 'TempBasalDuration',
-                    'duration (min)': 15,
                     date: timestamp45mAgo,
                     timestamp: timestamp45mAgo
                 }, {
@@ -787,6 +777,16 @@ describe('IOB', function() {
                     rate: 0,
                     date: timestamp45mAgo,
                     timestamp: timestamp45mAgo
+                }, {
+                    _type: 'TempBasalDuration',
+                    'duration (min)': 15,
+                    date: timestamp60mAgo,
+                    timestamp: timestamp60mAgo
+                }, {
+                    _type: 'TempBasal',
+                    rate: 2,
+                    date: timestamp60mAgo,
+                    timestamp: timestamp60mAgo
                 }],
                 profile: {
                     dia: 3,
@@ -862,13 +862,13 @@ describe('IOB', function() {
                 history: [{
                     _type: 'TempBasalDuration',
                     'duration (min)': 15,
-                    date: timestamp60mAgo,
-                    timestamp: timestamp60mAgo
+                    date: timestamp30mAgo,
+                    timestamp: timestamp30mAgo
                 }, {
                     _type: 'TempBasal',
                     rate: 2,
-                    date: timestamp60mAgo,
-                    timestamp: timestamp60mAgo
+                    date: timestamp30mAgo,
+                    timestamp: timestamp30mAgo
                 }, {
                     _type: 'TempBasalDuration',
                     'duration (min)': 15,
@@ -882,13 +882,13 @@ describe('IOB', function() {
                 }, {
                     _type: 'TempBasalDuration',
                     'duration (min)': 15,
-                    date: timestamp30mAgo,
-                    timestamp: timestamp30mAgo
+                    date: timestamp60mAgo,
+                    timestamp: timestamp60mAgo
                 }, {
                     _type: 'TempBasal',
                     rate: 2,
-                    date: timestamp30mAgo,
-                    timestamp: timestamp30mAgo
+                    date: timestamp60mAgo,
+                    timestamp: timestamp60mAgo
                 }],
                 profile: {
                     dia: 3,
@@ -965,13 +965,13 @@ describe('IOB', function() {
                 history: [{
                     _type: 'TempBasalDuration',
                     'duration (min)': 15,
-                    date: timestamp90mAgo,
-                    timestamp: timestamp90mAgo
+                    date: timestamp30mAgo,
+                    timestamp: timestamp30mAgo
                 }, {
                     _type: 'TempBasal',
                     rate: 2,
-                    date: timestamp90mAgo,
-                    timestamp: timestamp90mAgo
+                    date: timestamp30mAgo,
+                    timestamp: timestamp30mAgo
                 }, {
                     _type: 'TempBasalDuration',
                     'duration (min)': 45,
@@ -985,13 +985,13 @@ describe('IOB', function() {
                 }, {
                     _type: 'TempBasalDuration',
                     'duration (min)': 15,
-                    date: timestamp30mAgo,
-                    timestamp: timestamp30mAgo
+                    date: timestamp90mAgo,
+                    timestamp: timestamp90mAgo
                 }, {
                     _type: 'TempBasal',
                     rate: 2,
-                    date: timestamp30mAgo,
-                    timestamp: timestamp30mAgo
+                    date: timestamp90mAgo,
+                    timestamp: timestamp90mAgo
                 }],
                 profile: {
                     dia: 3,
@@ -1010,19 +1010,19 @@ describe('IOB', function() {
         inputs = {
             clock: timestamp,
             history: [{
+                _type: 'PumpResume',
+                date: timestamp30mAgo,
+                timestamp: timestamp30mAgo
+            }, {
                 _type: 'TempBasalDuration',
                 'duration (min)': 30,
-                date: timestamp90mAgo,
-                timestamp: timestamp90mAgo
+                date: timestamp45mAgo,
+                timestamp: timestamp45mAgo
             }, {
                 _type: 'TempBasal',
                 rate: 2,
-                date: timestamp90mAgo,
-                timestamp: timestamp90mAgo
-            }, {
-                _type: 'PumpSuspend',
-                date: timestamp75mAgo,
-                timestamp: timestamp75mAgo
+                date: timestamp45mAgo,
+                timestamp: timestamp45mAgo
             }, {
                 _type: 'TempBasalDuration',
                 'duration (min)': 15,
@@ -1034,19 +1034,19 @@ describe('IOB', function() {
                 date: timestamp60mAgo,
                 timestamp: timestamp60mAgo
             }, {
+                _type: 'PumpSuspend',
+                date: timestamp75mAgo,
+                timestamp: timestamp75mAgo
+            }, {
                 _type: 'TempBasalDuration',
                 'duration (min)': 30,
-                date: timestamp45mAgo,
-                timestamp: timestamp45mAgo
+                date: timestamp90mAgo,
+                timestamp: timestamp90mAgo
             }, {
                 _type: 'TempBasal',
                 rate: 2,
-                date: timestamp45mAgo,
-                timestamp: timestamp45mAgo
-            }, {
-                _type: 'PumpResume',
-                date: timestamp30mAgo,
-                timestamp: timestamp30mAgo
+                date: timestamp90mAgo,
+                timestamp: timestamp90mAgo
             }],
             profile: {
                 dia: 3,
@@ -1086,16 +1086,6 @@ describe('IOB', function() {
                 history: [{
                     _type: 'TempBasalDuration',
                     'duration (min)': 15,
-                    date: timestamp45mAgo,
-                    timestamp: timestamp45mAgo
-                }, {
-                    _type: 'TempBasal',
-                    rate: 0,
-                    date: timestamp45mAgo,
-                    timestamp: timestamp45mAgo
-                }, {
-                    _type: 'TempBasalDuration',
-                    'duration (min)': 15,
                     date: timestamp30mAgo,
                     timestamp: timestamp30mAgo
                 }, {
@@ -1103,6 +1093,16 @@ describe('IOB', function() {
                     rate: 2,
                     date: timestamp30mAgo,
                     timestamp: timestamp30mAgo
+                }, {
+                    _type: 'TempBasalDuration',
+                    'duration (min)': 15,
+                    date: timestamp45mAgo,
+                    timestamp: timestamp45mAgo
+                }, {
+                    _type: 'TempBasal',
+                    rate: 0,
+                    date: timestamp45mAgo,
+                    timestamp: timestamp45mAgo
                 }],
                 profile: {
                     dia: 3,
@@ -1176,16 +1176,6 @@ describe('IOB', function() {
                 clock: timestamp,
                 history: [{
                     _type: 'TempBasalDuration',
-                    'duration (min)': 435,
-                    date: timestamp480mAgo,
-                    timestamp: timestamp480mAgo
-                }, {
-                    _type: 'TempBasal',
-                    rate: 0,
-                    date: timestamp480mAgo,
-                    timestamp: timestamp480mAgo
-                }, {
-                    _type: 'TempBasalDuration',
                     'duration (min)': 15,
                     date: timestamp45mAgo,
                     timestamp: timestamp45mAgo
@@ -1194,6 +1184,16 @@ describe('IOB', function() {
                     rate: 2,
                     date: timestamp45mAgo,
                     timestamp: timestamp45mAgo
+                }, {
+                    _type: 'TempBasalDuration',
+                    'duration (min)': 435,
+                    date: timestamp480mAgo,
+                    timestamp: timestamp480mAgo
+                }, {
+                    _type: 'TempBasal',
+                    rate: 0,
+                    date: timestamp480mAgo,
+                    timestamp: timestamp480mAgo
                 }],
                 profile: {
                     dia: 3,

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -423,8 +423,8 @@ describe('IOB', function() {
                 }, {
                     _type: 'TempBasalDuration',
                     'duration (min)': 30,
-                    date: timestamp,
-                    timestamp: timestamp
+                    date: timestamp30mAgo,
+                    timestamp: timestamp30mAgo
                 }],
                 profile: {
                     dia: 3,
@@ -436,7 +436,6 @@ describe('IOB', function() {
             };
 
         var iobInputs = inputs;
-        iobInputs.clock = timestamp
         var iobNow = require('../lib/iob')(iobInputs)[0];
 
         //console.log(iobNow);
@@ -733,7 +732,8 @@ describe('IOB', function() {
             history: [{
                 _type: 'TempBasalDuration',
                 'duration (min)': 30,
-                date: startingPoint
+                date: startingPoint,
+                timestamp: startingPoint
             }, {
                 _type: 'TempBasal',
                 rate: 0.1,
@@ -747,7 +747,8 @@ describe('IOB', function() {
             }, {
                 _type: 'TempBasalDuration',
                 'duration (min)': 30,
-                date: startingPoint2
+                date: startingPoint2,
+                timestamp: startingPoint2
             }],
             profile: {
                 dia: 3,
@@ -876,6 +877,7 @@ describe('IOB', function() {
             inputs = {
                 clock: timestamp,
                 history: [{
+                    debug: "should show 0 IOB with Temp Basals if duration is not found",
                     _type: 'TempBasal',
                     rate: 2,
                     date: timestamp,
@@ -913,7 +915,8 @@ describe('IOB', function() {
                     {
                         _type: 'TempBasalDuration',
                         'duration (min)': 30,
-                        date: timestamp
+                        date: timestamp,
+                        timestamp: timestamp
                     }
                 ],
                 profile: {


### PR DESCRIPTION
When traveling westward and moving pump clock back in time, the pumphistory-merge method causes oref0 to use "future" boluses in calculating predBGs, which can result in persistent misdosing of insulin.  To prevent that, this PR changes oref0-calculate-iob to parse the pumphistory-zoned and pumphistory-24h-zoned records directly, and ignore out-of-order records. As a result, a timezone change can still cause dosing history to be ignored, (which oref0 fairly quickly adjusts to based on deviations), but prevents any persistent misdosing beyond that.

There are some TODOs in this code for further work here.  Eventually it'd be best if we actually parse pump time change records to understand the actual time of all events in the history, but this should prevent any serious issues from timezone changes until someone takes the time to do so.