### PR TITLE
Fix clock sync so that it actually uses 90s

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -156,8 +156,8 @@ function smb_reservoir_before {
     echo -n "Checking pump clock: "
     (cat monitor/clock-zoned.json; echo) | tr -d '\n'
     echo -n " is within 90s of current time: " && date
-    if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -55 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 55 )); then
-        echo Pump clock is more than 55s off: attempting to reset it
+    if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -55 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 90 )); then
+        echo Pump clock is more than 90s off: attempting to reset it
         timerun oref0-set-device-clocks
        fi
     (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > -90 )) \


### PR DESCRIPTION
The clock sync 'says' it is checking to see if the pump is within 90s of the rig.

However it actually uses 55s, and the error if it is out-of-sync says 55s as well. 

This causes issues on slower rigs (Pi Zero W).

Fixed.