### PR TITLE
Generate settings/bg_targets.json for x12 models

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -657,7 +657,7 @@ function get_settings {
         retry_return check_model 2>&3 >&4 || return 1
         retry_return read_insulin_sensitivities 2>&3 >&4 || return 1
         retry_return read_carb_ratios 2>&3 >&4 || return 1
-        retry_return openaps report invoke settings/insulin_sensitivities.json 2>&3 >&4 || return 1
+        retry_return openaps report invoke settings/insulin_sensitivities.json settings/bg_targets.json 2>&3 >&4 || return 1
 	#NON_X12_ITEMS=""
     else
         # On all other supported pumps, we should be able to get all the data we need from the pump.


### PR DESCRIPTION
settings/bg_targets.json is generated from settings/bg_targets_raw.json, adding the user-preferred units, and pulls no data from the pump.