### PR TITLE
Fix handling of dates so that we are not comparing the time the pump-…

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -156,12 +156,12 @@ function smb_reservoir_before {
     try_fail timerun openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
     echo -n "Checking pump clock: "
     (cat monitor/clock-zoned.json; echo) | tr -d '\n'
-    echo -n " is within 90s of current time: " && date
+    echo -n " is within 55s of current time: " && date
     let DTG_DIFFERENCE=$CURRENT_DTG-$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g'))
     DTG_DIFFERENCE=${DTG_DIFFERENCE/#-/}
-    if [ "$DTG_DIFFERENCE" -gt "90" ]
+    if [ "$DTG_DIFFERENCE" -gt "55" ]
     then
-	echo Pump clock is more than 90s off: attempting to reset it
+	echo Pump clock is more than 55s off: attempting to reset it
         timerun oref0-set-device-clocks
         # Refresh current-date, since we just reset device clock.
         $CURRENT_DTG=$(date +%s)
@@ -172,6 +172,8 @@ function smb_reservoir_before {
 	then
 		echo "Error: pump clock refresh error / mismatch"
 		fail "$@"
+	else
+		echo "Pump clock is now within 90s of current time. Proceeding."
 	fi
     fi
     find monitor/ -mmin -1 -size +5c | grep -q pumphistory || { echo "Error: pumphistory too old"; fail "$@"; }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -152,16 +152,28 @@ function smb_reservoir_before {
     # Refresh reservoir.json and pumphistory.json
     try_fail refresh_pumphistory_and_meal
     try_fail cp monitor/reservoir.json monitor/lastreservoir.json
+    CURRENT_DTG=$(date +%s)
     try_fail timerun openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
     echo -n "Checking pump clock: "
     (cat monitor/clock-zoned.json; echo) | tr -d '\n'
     echo -n " is within 90s of current time: " && date
-    if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -55 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 55 )); then
-        echo Pump clock is more than 55s off: attempting to reset it
+    let DTG_DIFFERENCE=$CURRENT_DTG-$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g'))
+    DTG_DIFFERENCE=${DTG_DIFFERENCE/#-/}
+    if [ "$DTG_DIFFERENCE" -gt "90" ]
+    then
+	echo Pump clock is more than 90s off: attempting to reset it
         timerun oref0-set-device-clocks
-       fi
-    (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > -90 )) \
-    && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < 90 )) || { echo "Error: pump clock refresh error / mismatch"; fail "$@"; }
+        # Refresh current-date, since we just reset device clock.
+	try_fail timerun openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
+        $CURRENT_DTG=$(date +%s)
+	let DTG_DIFFERENCE=$CURRENT_DTG-$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g"'))
+	DTG_DIFFERENCE=${DTG_DIFFERENCE/#-/}
+	if [ "$DTG_DIFFERENCE" -gt "90" ]
+	then
+		echo "Error: pump clock refresh error / mismatch"
+		fail "$@"
+	fi
+    fi
     find monitor/ -mmin -1 -size +5c | grep -q pumphistory || { echo "Error: pumphistory too old"; fail "$@"; }
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -164,8 +164,8 @@ function smb_reservoir_before {
 	echo Pump clock is more than 90s off: attempting to reset it
         timerun oref0-set-device-clocks
         # Refresh current-date, since we just reset device clock.
-	try_fail timerun openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
         $CURRENT_DTG=$(date +%s)
+	try_fail timerun openaps report invoke monitor/clock.json monitor/clock-zoned.json 2>&3 >&4 | tail -1
 	let DTG_DIFFERENCE=$CURRENT_DTG-$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g"'))
 	DTG_DIFFERENCE=${DTG_DIFFERENCE/#-/}
 	if [ "$DTG_DIFFERENCE" -gt "90" ]

--- a/bin/oref0-set-device-clocks.sh
+++ b/bin/oref0-set-device-clocks.sh
@@ -26,7 +26,10 @@ CGM=${4-cgm}
 die() { echo "$@" ; exit 1; }
 self=$(basename $0)
 function usage ( ) {
-
+echo $CLOCK
+echo $GLUCOSE
+echo $PUMP
+echo $CGM
 cat <<EOF
 $self
 $self - Set pump and CGM clocks based on NTP time if avaialble.
@@ -47,6 +50,10 @@ if checkNTP; then
     sudo ntpdate -s -b time.nist.gov
     echo Setting pump time to $(date)
     openaps use $PUMP set_clock --to now 2>&1 >/dev/null | tail -1
-    echo Setting CGM time to $(date)
-    openaps use $CGM UpdateTime --to now 2>&1 >/dev/null | tail -1
+    #xdrip CGM doesn't have a clock.
+    if [ ! -f "xdrip.ini" ]
+    then
+	   echo Setting CGM time to $(date)
+	   openaps use $CGM UpdateTime --to now 2>&1 >/dev/null | tail -1
+    fi
 fi


### PR DESCRIPTION
Fix date-comparison routine so that it captures the date to a variable immediately after pulling the device-clock date, rather than comparing what the clock *was* set to when the json file was written to disk, to the time it is when the test executes. 

This reduces the number of erroneous pump-set calls when CPU load is high. 

Also, fix set-device-clocks so that it doesn't try and set the 'clock' on xdrip CGM.
