### PR TITLE
Don't reverse pump history

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -599,7 +599,7 @@ function invoke_reservoir_etc {
 
 #TODO: remove this
 function merge_pumphistory {
-    jq -s '.[0] + .[1]|unique|sort_by(.timestamp)|reverse' monitor/pumphistory-zoned.json settings/pumphistory-24h-zoned.json > monitor/pumphistory-merged.json
+    jq -s '.[0] + .[1]|unique|sort_by(.timestamp)' monitor/pumphistory-zoned.json settings/pumphistory-24h-zoned.json > monitor/pumphistory-merged.json
     calculate_iob
 }
 


### PR DESCRIPTION
Currently the carb history calculation doesn't
work when the pump history is in reverse order.
This should work but doesn't. Remove the reversing until
this is fixed correctly.

Note, i'm not sure if this could have other negative effects, but the bolus wizard carbs work for me with this change.