### PR TITLE
autosens-history

### DIFF
--- a/bin/oref0-autosens-history.js
+++ b/bin/oref0-autosens-history.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/*
+  Determine Basal
+
+  Released under MIT license. See the accompanying LICENSE.txt file for
+  full terms and conditions
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+var basal = require('oref0/lib/profile/basal');
+var get_iob = require('oref0/lib/iob');
+var detect = require('oref0/lib/determine-basal/autosens');
+
+if (!module.parent) {
+    var detectsensitivity = init();
+
+    var glucose_input = process.argv[2];
+    var pumphistory_input = process.argv[3];
+    var isf_input = process.argv[4];
+    var basalprofile_input = process.argv[5];
+    var profile_input = process.argv[6];
+
+    if (!glucose_input || !pumphistory_input || !profile_input) {
+        console.error('usage: ', process.argv.slice(0, 2), '<glucose.json> <pumphistory.json> <insulin_sensitivities.json> <basal_profile.json> <profile.json>');
+        process.exit(1);
+    }
+    
+    var fs = require('fs');
+    try {
+        var cwd = process.cwd();
+        var glucose_data = require(cwd + '/' + glucose_input);
+        // require 6 hours of data to run autosens
+        if (glucose_data.length < 72) {
+            console.error("Optional feature autosens disabled: not enough glucose data to calculate sensitivity");
+            return console.log('{ "ratio": 1, "reason": "not enough glucose data to calculate autosens" }');
+            //process.exit(2);
+        }
+
+        var pumphistory_data = require(cwd + '/' + pumphistory_input);
+        var profile = require(cwd + '/' + profile_input);
+
+        var isf_data = require(cwd + '/' + isf_input);
+        if (isf_data.units !== 'mg/dL') {
+            if (isf_data.units == 'mmol/L') {
+                for (var i = 0, len = isf_data.sensitivities.length; i < len; i++) {
+                    isf_data.sensitivities[i].sensitivity = isf_data.sensitivities[i].sensitivity * 18;
+                }
+               isf_data.units = 'mg/dL';
+            } else {
+                console.log('ISF is expected to be expressed in mg/dL or mmol/L.'
+                        , 'Found', isf_data.units, 'in', isf_input, '.');
+                process.exit(2);
+            }
+        }
+        var basalprofile = require(cwd + '/' + basalprofile_input);
+
+        var iob_inputs = {
+            history: pumphistory_data
+            , profile: profile
+        };
+    } catch (e) {
+        return console.error("Could not parse input data: ", e);
+    }
+
+    var detection_inputs = {
+        iob_inputs: iob_inputs
+        , carbs: {}
+        , glucose_data: glucose_data
+        , basalprofile: basalprofile
+        , temptargets: {}
+    };
+    var ratioArray = [];
+    do {
+        detection_inputs.deviations = 96;
+        detect(detection_inputs);
+        for(var i=0; i<10; i++) {
+            detection_inputs.glucose_data.shift();
+        }
+        console.error(ratio, newisf);
+        ratioArray.unshift(ratio);
+    }
+    while(detection_inputs.glucose_data.length > 96);
+    //var lowestRatio = Math.min(ratio8h, ratio24h);
+    //var sensAdj = {
+        //"ratio": lowestRatio
+    //}
+    return console.log(JSON.stringify(ratioArray));
+
+}
+
+function init() {
+
+    var detectsensitivity = {
+        name: 'detect-sensitivity'
+        , label: "OpenAPS Detect Sensitivity"
+    };
+
+    //detectsensitivity.getLastGlucose = require('../lib/glucose-get-last');
+    //detectsensitivity.detect_sensitivity = require('../lib/determine-basal/determine-basal');
+    return detectsensitivity;
+
+}
+module.exports = init;
+
+// From https://gist.github.com/IceCreamYou/6ffa1b18c4c8f6aeaad2
+// Returns the value at a given percentile in a sorted numeric array.
+// "Linear interpolation between closest ranks" method
+function percentile(arr, p) {
+    if (arr.length === 0) return 0;
+    if (typeof p !== 'number') throw new TypeError('p must be a number');
+    if (p <= 0) return arr[0];
+    if (p >= 1) return arr[arr.length - 1];
+
+    var index = arr.length * p,
+        lower = Math.floor(index),
+        upper = lower + 1,
+        weight = index % 1;
+
+    if (upper >= arr.length) return arr[lower];
+    return arr[lower] * (1 - weight) + arr[upper] * weight;
+}
+
+// Returns the percentile of the given value in a sorted numeric array.
+function percentRank(arr, v) {
+    if (typeof v !== 'number') throw new TypeError('v must be a number');
+    for (var i = 0, l = arr.length; i < l; i++) {
+        if (v <= arr[i]) {
+            while (i < l && v === arr[i]) i++;
+            if (i === 0) return 0;
+            if (v !== arr[i-1]) {
+                i += (v - arr[i-1]) / (arr[i] - arr[i-1]);
+            }
+            return i / l;
+        }
+    }
+    return 1;
+}
+

--- a/bin/oref0-autosens-history.js
+++ b/bin/oref0-autosens-history.js
@@ -24,12 +24,10 @@ if (!module.parent) {
 
     var glucose_input = process.argv[2];
     var pumphistory_input = process.argv[3];
-    var isf_input = process.argv[4];
-    var basalprofile_input = process.argv[5];
-    var profile_input = process.argv[6];
+    var profile_input = process.argv[4];
 
     if (!glucose_input || !pumphistory_input || !profile_input) {
-        console.error('usage: ', process.argv.slice(0, 2), '<glucose.json> <pumphistory.json> <insulin_sensitivities.json> <basal_profile.json> <profile.json>');
+        console.error('usage: ', process.argv.slice(0, 2), '<glucose.json> <pumphistory.json> <profile.json>');
         process.exit(1);
     }
     
@@ -47,7 +45,7 @@ if (!module.parent) {
         var pumphistory_data = require(cwd + '/' + pumphistory_input);
         var profile = require(cwd + '/' + profile_input);
 
-        var isf_data = require(cwd + '/' + isf_input);
+        var isf_data = profile.isfProfile;
         if (isf_data.units !== 'mg/dL') {
             if (isf_data.units == 'mmol/L') {
                 for (var i = 0, len = isf_data.sensitivities.length; i < len; i++) {
@@ -60,7 +58,7 @@ if (!module.parent) {
                 process.exit(2);
             }
         }
-        var basalprofile = require(cwd + '/' + basalprofile_input);
+        var basalprofile = profile.basalprofile;
 
         var iob_inputs = {
             history: pumphistory_data

--- a/bin/oref0-autosens-history.js
+++ b/bin/oref0-autosens-history.js
@@ -46,17 +46,25 @@ if (!module.parent) {
         var profile = require(cwd + '/' + profile_input);
 
         var isf_data = profile.isfProfile;
-        if (isf_data.units !== 'mg/dL') {
-            if (isf_data.units == 'mmol/L') {
-                for (var i = 0, len = isf_data.sensitivities.length; i < len; i++) {
-                    isf_data.sensitivities[i].sensitivity = isf_data.sensitivities[i].sensitivity * 18;
+        var units;
+        if (typeof(isf_data) != "undefined" && typeof(isf_data.units == "string")) {
+            units = isf_data.units;
+            if (isf_data.units !== 'mg/dL') {
+                if (isf_data.units == 'mmol/L') {
+                    for (var i = 0, len = isf_data.sensitivities.length; i < len; i++) {
+                        isf_data.sensitivities[i].sensitivity = isf_data.sensitivities[i].sensitivity * 18;
+                    }
+                    isf_data.units = 'mg/dL';
+                } else {
+                    console.log('ISF is expected to be expressed in mg/dL or mmol/L.'
+                            , 'Found', isf_data.units, 'in', isf_input, '.');
+                    process.exit(2);
                 }
-               isf_data.units = 'mg/dL';
-            } else {
-                console.log('ISF is expected to be expressed in mg/dL or mmol/L.'
-                        , 'Found', isf_data.units, 'in', isf_input, '.');
-                process.exit(2);
             }
+        } else if (typeof(profile[0].store.Default.units == "string")) {
+            units = profile[0].store.Default.units;
+        } else {
+            console.error("Unable to determine units.");
         }
         var basalprofile = profile.basalprofile;
 

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -20,7 +20,8 @@ function detectSensitivity(inputs) {
 
     // use last 24h worth of data by default
     if (inputs.retrospective) {
-        var lastSiteChange = new Date(0);
+        //console.error(glucose_data[0]);
+        var lastSiteChange = new Date(new Date(glucose_data[0].date).getTime() - (24 * 60 * 60 * 1000));
     } else {
         var lastSiteChange = new Date(new Date().getTime() - (24 * 60 * 60 * 1000));
     }

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -7,17 +7,23 @@ var tz = require('moment-timezone');
 
 function detectSensitivity(inputs) {
 
+    //console.error(inputs.glucose_data[0]);
     glucose_data = inputs.glucose_data.map(function prepGlucose (obj) {
         //Support the NS sgv field to avoid having to convert in a custom way
         obj.glucose = obj.glucose || obj.sgv;
         return obj;
     });
+    //console.error(glucose_data[0]);
     iob_inputs = inputs.iob_inputs;
     basalprofile = inputs.basalprofile;
     profile = inputs.iob_inputs.profile;
 
     // use last 24h worth of data by default
-    var lastSiteChange = new Date(new Date().getTime() - (24 * 60 * 60 * 1000));
+    if (inputs.retrospective) {
+        var lastSiteChange = new Date(0);
+    } else {
+        var lastSiteChange = new Date(new Date().getTime() - (24 * 60 * 60 * 1000));
+    }
     if (inputs.iob_inputs.profile.rewind_resets_autosens ) {
         // scan through pumphistory and set lastSiteChange to the time of the last pump rewind event
         // if not present, leave lastSiteChange unchanged at 24h ago.
@@ -61,6 +67,7 @@ function detectSensitivity(inputs) {
     var bucketed_data = [];
     glucose_data.reverse();
     bucketed_data[0] = glucose_data[0];
+    //console.error(bucketed_data[0]);
     j=0;
     // go through the meal treatments and remove any that are older than the oldest glucose value
     //console.error(meals);
@@ -103,6 +110,7 @@ function detectSensitivity(inputs) {
         }
     }
     bucketed_data.shift();
+    //console.error(bucketed_data[0]);
     for (var i=meals.length-1; i>0; --i) {
         var treatment = meals[i];
         //console.error(treatment);
@@ -111,6 +119,10 @@ function detectSensitivity(inputs) {
             var treatmentTime = treatmentDate.getTime();
             var glucoseDatum = bucketed_data[0];
             //console.error(glucoseDatum);
+            if (! glucoseDatum || ! glucoseDatum.date) {
+              //console.error("No date found on: ",glucoseDatum);
+              continue;
+            }
             var BGDate = new Date(glucoseDatum.date);
             var BGTime = BGDate.getTime();
             if ( treatmentTime < BGTime ) {


### PR DESCRIPTION
This is a tool for calculating autosens retrospectively, which will be useful in processing data uploaded to the OpenAPS Data Commons.  Merging it into go-explorer-hat for testing to make sure none of the changes to lib/determine-basal/autosens.js cause any issues.