### PR TITLE
Fast pump history

### DIFF
--- a/bin/oref0-autosens-loop.sh
+++ b/bin/oref0-autosens-loop.sh
@@ -33,11 +33,11 @@ function completed_recently {
 # openaps use detect-sensitivity shell monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json
 function autosens {
     # only run autosens if pumphistory-24h is newer than autosens
-    if find settings/ -newer settings/autosens.json | grep -q pumphistory-24h-zoned.json \
+    if find monitor/ -newer settings/autosens.json | grep -q pumphistory-24h-zoned.json \
         || find settings/ -size -5c | grep -q autosens.json \
         || ! find settings/ | grep -q autosens \
         || ! find settings/autosens.json >/dev/null; then
-        if oref0-detect-sensitivity monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
+        if oref0-detect-sensitivity monitor/glucose.json monitor/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
             mv settings/autosens.json.new settings/autosens.json
             echo -n "Autosens refreshed: "
         else

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -112,7 +112,7 @@ function ns_meal_carbs {
     #openaps report invoke monitor/carbhistory.json >/dev/null
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET carb_history > monitor/carbhistory.json.new
     cat monitor/carbhistory.json.new | jq .[0].carbs | egrep -q [0-9] && mv monitor/carbhistory.json.new monitor/carbhistory.json
-    oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
+    oref0-meal settings/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
     grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
     echo -n "Refreshed carbhistory; COB: "
     grep COB monitor/meal.json | jq .mealCOB
@@ -169,7 +169,7 @@ function upload_recent_treatments {
 
 #nightscout cull-latest-openaps-treatments monitor/pumphistory-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
 function format_latest_nightscout_treatments {
-    nightscout cull-latest-openaps-treatments monitor/pumphistory-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
+    nightscout cull-latest-openaps-treatments settings/pumphistory-24h-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
 }
 
 function check_mdt_upload {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -112,7 +112,7 @@ function ns_meal_carbs {
     #openaps report invoke monitor/carbhistory.json >/dev/null
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET carb_history > monitor/carbhistory.json.new
     cat monitor/carbhistory.json.new | jq .[0].carbs | egrep -q [0-9] && mv monitor/carbhistory.json.new monitor/carbhistory.json
-    oref0-meal settings/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
+    oref0-meal monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
     grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
     echo -n "Refreshed carbhistory; COB: "
     grep COB monitor/meal.json | jq .mealCOB
@@ -169,7 +169,7 @@ function upload_recent_treatments {
 
 #nightscout cull-latest-openaps-treatments monitor/pumphistory-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
 function format_latest_nightscout_treatments {
-    nightscout cull-latest-openaps-treatments settings/pumphistory-24h-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
+    nightscout cull-latest-openaps-treatments monitor/pumphistory-24h-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json
 }
 
 function check_mdt_upload {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -177,7 +177,7 @@ function smb_reservoir_before {
        fi
     (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > -90 )) \
     && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < 90 )) || { echo "Error: pump clock refresh error / mismatch"; fail "$@"; }
-    find monitor/ -mmin -2 -size +5c | grep -q pumphistory || { echo "Error: pumphistory >2m old (or empty)"; fail "$@"; }
+    find settings/ -mmin -2 -size +5c | grep -q pumphistory || { echo "Error: pumphistory-24h >2m old (or empty)"; fail "$@"; }
 }
 
 # check if the temp was read more than 5m ago, or has been running more than 10m

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -45,7 +45,6 @@ old_main() {
             && refresh_pumphistory_and_enact \
             && refresh_profile \
             && pumphistory_daily_refresh \
-            && touch /tmp/pump_loop_success \
             && echo Completed basal-only pump-loop at $(date) \
             && touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted \
             && echo); do
@@ -85,7 +84,6 @@ main() {
                     && refresh_pumphistory_and_enact \
                     && refresh_profile \
 		    && pumphistory_daily_refresh \
-                    && touch /tmp/pump_loop_success \
                     && echo Completed pump-loop at $(date) \
                     && echo \
                     )

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -171,8 +171,9 @@ function smb_reservoir_before {
     (cat monitor/clock-zoned.json; echo) | tr -d '\n'
     echo -n " is within 90s of current time: " && date
     if (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < -55 )) || (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > 55 )); then
-        echo Pump clock is more than 55s off: attempting to reset it
+        echo Pump clock is more than 55s off: attempting to reset it and reload pumphistory
         oref0-set-device-clocks
+	read_full_pumphistory
        fi
     (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") > -90 )) \
     && (( $(bc <<< "$(date +%s -d $(cat monitor/clock-zoned.json | sed 's/"//g')) - $(date +%s)") < 90 )) || { echo "Error: pump clock refresh error / mismatch"; fail "$@"; }


### PR DESCRIPTION
Quicker 24h history refresh.
 - This works by maintaining the settings/pumphistory-24h-zoned.json
   file and only adding new recrords since the last refresh every time.

 - For safety the file is reloaded every 6hours or if for any reason it's
   corrupted (jq can't parse it, or can't get a timestamp on the first array
   element).

 - Logging can still be improved, i tried but failed to make it nice but stil
   keep it detailed enough.

 - Another: improvement would be to move this file back to the monitor directory

 - Also as per the large FIXME comment in the code, there could be an issue when
   clock is modified on the pump.