### PR TITLE
Disable upload of BGCapture pump records to NS.

### DIFF
--- a/lib/pump.js
+++ b/lib/pump.js
@@ -14,6 +14,7 @@ function translate (treatments) {
       case 'BasalProfileStart':
       case 'ResultDailyTotal':
       case 'BGReceived':
+      case 'BGCapture':
       case 'Sara6E':
       case 'Model522ResultTotals':
       case 'Model722ResultTotals':


### PR DESCRIPTION
THis might not be needed and creates unnecessary noise when used with fakeMeter.