### PR TITLE
Don't loop on "stuck" CGM data

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -74,7 +74,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     }
-    if (bg <= 10 || bg == 38 || noise >= 3 || minAgo > 12 || minAgo < -5) {
+    // if BG is too old/noisy, or is completely unchanging, cancel any high temps and shorten any long zero temps
+    if (bg <= 10 || bg == 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( short_avgdelta == 0 && long_avgdelta == 0 ) ) {
         if (currenttemp.rate >= basal) { // high temp is running
             rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
             rT.deliverAt = deliverAt;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -75,7 +75,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     }
     // if BG is too old/noisy, or is completely unchanging, cancel any high temps and shorten any long zero temps
-    if (bg <= 10 || bg == 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( short_avgdelta == 0 && long_avgdelta == 0 ) ) {
+    if ( glucose_status.short_avgdelta == 0 && glucose_status.long_avgdelta == 0 ) {
+        rT.reason = "Error: CGM data is unchanged for the past ~45m";
+    }
+    if (bg <= 10 || bg == 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta == 0 && glucose_status.long_avgdelta == 0 ) ) {
         if (currenttemp.rate >= basal) { // high temp is running
             rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
             rT.deliverAt = deliverAt;

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -78,7 +78,7 @@ describe('determine-basal', function ( ) {
    //function determine_basal(glucose_status, currenttemp, iob_data, profile)
 
     // standard initial conditions for all determine-basal test cases unless overridden
-    var glucose_status = {"delta":0,"glucose":115,"long_avgdelta":0,"short_avgdelta":0};
+    var glucose_status = {"delta":0,"glucose":115,"long_avgdelta":0.1,"short_avgdelta":0};
     var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
     var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
     var profile = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.9,"max_daily_basal":1.3,"max_basal":3.5,"max_bg":120,"min_bg":110,"sens":40,"carb_ratio":10};
@@ -246,7 +246,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when LOW w/ positive IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
@@ -255,7 +255,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should low temp when LOW w/ negative IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
         var iob_data = {"iob":-2.5,"activity":-0.03,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.below(0.8);
@@ -264,7 +264,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when LOW w/ no IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
         var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);


### PR DESCRIPTION
Per discussion starting at https://gitter.im/nightscout/intend-to-bolus?at=5a991c2ff3f6d24c6829961b, @jane49 had an issue where her xDrip+ app repeatedly and indefinitely reported the last meter BG as the SGV/glucose value until she calibrated again.  This is a serious safety issue, as a high calibration before bed could result in OpenAPS continuing to dose extra insulin all night without knowing that BG is actually dropping, potentially leading to severe hypoglycemia or worse.

This change prevents oref0 from looping on "stuck" CGM data by requiring that either short_avgdelta or long_avgdelta be non-zero.  This might also prevent it from looping on the first data point after a long CGM gap, which is probably also a good thing.

I've tested this against the problematic glucose.json downloaded from @jane49's Nightscout, and confirmed it refuses to loop on the completely-flat CGM data her xDrip is reporting.