### PR TITLE
openaps-menu status needs profile.json

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -118,7 +118,7 @@ main() {
 function update_display {
     # TODO: install this globally
     if [ -e /root/src/openaps-menu/scripts/status.js ]; then
-        node /root/src/openaps-menu/scripts/status.js
+        node /root/src/openaps-menu/scripts/status.js ~/myopenaps/settings/profile.json
     fi
 }
 


### PR DESCRIPTION
openaps-menu needs profile.json to be able to determine if
it needs to convert bgs to mmol, pass it as argument.

also see: https://github.com/openaps/openaps-menu/pull/9