### PR TITLE
Remove i, x, and start from isf guard check

### DIFF
--- a/lib/oref0-setup/bg_targets_raw.json
+++ b/lib/oref0-setup/bg_targets_raw.json
@@ -1,30 +1,24 @@
 {
-  "units": "mg/dL", 
+  "units": "mg/dL",
   "targets": [
     {
-      "high": 120, 
-      "start": "00:00:00", 
-      "low": 110, 
-      "offset": 0, 
-      "i": 0, 
-      "x": 0
-    }, 
+      "high": 120,
+      "start": "00:00:00",
+      "low": 110,
+      "offset": 0,
+    },
     {
-      "high": 110, 
-      "start": "06:00:00", 
-      "low": 110, 
-      "offset": 360, 
-      "i": 12, 
-      "x": 1
-    }, 
+      "high": 110,
+      "start": "06:00:00",
+      "low": 110,
+      "offset": 360,
+    },
     {
-      "high": 120, 
-      "start": "20:00:00", 
-      "low": 110, 
-      "offset": 1200, 
-      "i": 40, 
-      "x": 2
+      "high": 120,
+      "start": "20:00:00",
+      "low": 110,
+      "offset": 1200,
     }
-  ], 
+  ],
   "first": 1
 }

--- a/lib/profile/isf.js
+++ b/lib/profile/isf.js
@@ -8,24 +8,24 @@ function isfLookup(isf_data, timestamp) {
     var nowDate = timestamp;
 
     if (typeof(timestamp) === 'undefined') {
-      nowDate = new Date();
+        nowDate = new Date();
     }
 
     var nowMinutes = nowDate.getHours() * 60 + nowDate.getMinutes();
 
-	if (lastResult && nowMinutes >= lastResult.offset && nowMinutes < lastResult.endOffset) {
-	    return lastResult.sensitivity;
-	}
+    if (lastResult && nowMinutes >= lastResult.offset && nowMinutes < lastResult.endOffset) {
+        return lastResult.sensitivity;
+    }
 
     isf_data = _.sortBy(isf_data.sensitivities, function(o) { return o.offset; });
 
     var isfSchedule = isf_data[isf_data.length - 1];
 
-    if (isf_data[0].offset != 0 || isf_data[0].i != 0 || isf_data[0].x != 0 || isf_data[0].start != "00:00:00") {
+    if (isf_data[0].offset != 0) {
         return -1;
     }
 
-	var endMinutes = 1440;
+    var endMinutes = 1440;
 
     for (var i = 0; i < isf_data.length - 1; i++) {
         var currentISF = isf_data[i];
@@ -45,4 +45,3 @@ function isfLookup(isf_data, timestamp) {
 
 isfLookup.isfLookup = isfLookup;
 exports = module.exports = isfLookup;
-

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -21,7 +21,7 @@ describe('Profile', function ( ) {
         ]
         , isf: {
             sensitivities: [
-                { offset: 0, i: 0, x: 0, start: '00:00:00', sensitivity: 100 }
+                { offset: 0, sensitivity: 100 }
             ]
         }
         , carbratio: {


### PR DESCRIPTION
Since only `offset` is used in calculating which isf is effective for the given
`timestamp`, these other fields add unnecessary confusion to the profile data.

Removing them here allows future removal in decocare and other profile.json
sources. Cleaner (and less) code, cleaner data, easier mental model :)