### PR TITLE
Slightly refactor oref0 meal to read all the data before

### DIFF
--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -126,7 +126,7 @@ function findMealInputs (inputs) {
                 console.error("This is caused by a BolusWizard without carbs. If you specified insulin, it will be noted as a seperate Bolus");
               }
               if (current.timestamp) {
-                  console.error("Timestamp of bolus wizard: ", current.timestamp);
+                  console.error("Timestamp of bolus wizard:", current.timestamp);
               }
           }
       } else {

--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -22,6 +22,7 @@ function findMealInputs (inputs) {
     var carbHistory = inputs.carbs;
     var profile_data = inputs.profile;
     var mealInputs = [];
+    var bolusWizardInputs = [];
     var duplicates = 0;
 
     for (var i=0; i < carbHistory.length; i++) {
@@ -38,6 +39,7 @@ function findMealInputs (inputs) {
             }
         }
     }
+
     for (var i=0; i < pumpHistory.length; i++) {
         var current = pumpHistory[i];
         if (current._type == "Bolus" && current.timestamp) {
@@ -52,24 +54,10 @@ function findMealInputs (inputs) {
                 duplicates += 1;
             }
         } else if (current._type == "BolusWizard" && current.timestamp) {
-            //console.log(pumpHistory[i]);
-            var temp = {};
-            temp.timestamp = current.timestamp;
-            temp.carbs = current.carb_input;
-            temp.bwCarbs = current.carb_input;
+            // Delay process the BolusWizard entries to make sure we've seen all possible that correspond to the bolus wizard.
+            // More specifically, we need to make sure we process the corresponding bolus entry first.
+            bolusWizardInputs.push(current);
 
-            // don't enter the treatment if there's another treatment with the same exact timestamp
-            // to prevent duped carb entries from multiple sources
-            if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"carbs")) {
-                if (arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"bolus")) {
-                    mealInputs.push(temp);
-                    //bwCarbs += temp.carbs;
-                } else {
-                    console.error("skipping bolus wizard entry with",current.carb_input,"g carbs and no insulin");
-                }
-            } else {
-                duplicates += 1;
-            }
         } else if ((current._type == "Meal Bolus" || current._type == "Correction Bolus" || current._type == "Snack Bolus" || current._type == "Bolus Wizard" || current._type == "Carb Correction") && current.created_at) {
             //imports carbs entered through Nightscout Care Portal
             //"Bolus Wizard" refers to the Nightscout Bolus Wizard, not the Medtronic Bolus Wizard
@@ -118,6 +106,27 @@ function findMealInputs (inputs) {
         }
     }
 
+    for(var i=0; i < bolusWizardInputs.length; i++) {
+      var current = bolusWizardInputs[i];
+      //console.log(bolusWizardInputs[i]);
+      var temp = {};
+      temp.timestamp = current.timestamp;
+      temp.carbs = current.carb_input;
+      temp.bwCarbs = current.carb_input;
+
+      // don't enter the treatment if there's another treatment with the same exact timestamp
+      // to prevent duped carb entries from multiple sources
+      if (!arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"carbs")) {
+          if (arrayHasElementWithSameTimestampAndProperty(mealInputs,current.timestamp,"bolus")) {
+              mealInputs.push(temp);
+              //bwCarbs += temp.carbs;
+          } else {
+              console.error("skipping bolus wizard entry with",current.carb_input,"g carbs and no insulin");
+          }
+      } else {
+          duplicates += 1;
+      }
+    }
     //if (duplicates > 0) console.error("Removed duplicate bolus/carb entries:" + duplicates);
 
     return mealInputs;

--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -121,7 +121,13 @@ function findMealInputs (inputs) {
               mealInputs.push(temp);
               //bwCarbs += temp.carbs;
           } else {
-              console.error("skipping bolus wizard entry with",current.carb_input,"g carbs and no insulin");
+              console.error("Skipping bolus wizard entry ", i, " in the pump history with",current.carb_input,"g carbs and no insulin.");
+              if (current.carb_input == 0) {
+                console.error("This is caused by a BolusWizard without carbs. If you specified insulin, it will be noted as a seperate Bolus");
+              }
+              if (current.timestamp) {
+                  console.error("Timestamp of bolus wizard: ", current.timestamp);
+              }
           }
       } else {
           duplicates += 1;

--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -121,7 +121,7 @@ function findMealInputs (inputs) {
               mealInputs.push(temp);
               //bwCarbs += temp.carbs;
           } else {
-              console.error("Skipping bolus wizard entry ", i, " in the pump history with",current.carb_input,"g carbs and no insulin.");
+              console.error("Skipping bolus wizard entry", i, "in the pump history with",current.carb_input,"g carbs and no insulin.");
               if (current.carb_input == 0) {
                 console.error("This is caused by a BolusWizard without carbs. If you specified insulin, it will be noted as a seperate Bolus");
               }

--- a/tests/cobhistory.test.js
+++ b/tests/cobhistory.test.js
@@ -38,7 +38,7 @@ describe('cobhistory', function ( ) {
         console.log(output);
 
         // BolusWizard carb_input without a timestamp-matched Bolus will be ignored
-        output.length.should.equal(5);
+        output.length.should.equal(6);
     });
 
 });


### PR DESCRIPTION
trying to match bolus wizard entries to corresponding
bolus entries.

This allows out of order bolus and bolus wizard entries to
still work correctly.

Before this change, when the bolus entry was after the bolusWizard
entry, the carb was being skipped because no corresponding
bolus was seen.

I'm hoping this will help with the issue reported in #952 