### PR TITLE
Make logrotate in cron run hourly instead of daily

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -616,6 +616,10 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     sudo cp $HOME/src/oref0/logrotate.rsyslog /etc/logrotate.d/rsyslog || die "Could not cp /etc/logrotate.d/rsyslog"
 
     test -d /var/log/openaps || sudo mkdir /var/log/openaps && sudo chown $USER /var/log/openaps || die "Could not create /var/log/openaps"
+    
+    if [[ -f /etc/cron.daily/logrotate ]]; then
+        mv -f /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
+    fi
 
     #TODO: remove this when IPv6 works reliably
     echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4


### PR DESCRIPTION
The frequency of log-file rotation is controlled by config files, but
also by when logrotate is run by cron. Log-rotation is important to
prevent running out of disk space; since the log files are extremely
compressible, but can grow quickly, a day or two's worth of logs can
potentially deplete the disk space on an Intel Edison, causing problems.
Past commits tried to address this by changing the log-rotation schedule
in logrotate's config files, but it didn't work because the process that
*reads* the config files still only ran once per day. This changes that
from daily to hourly.