### PR TITLE
Try three times to get a Bluetooth IP address

### DIFF
--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -118,7 +118,10 @@ function bt_connect {
             echo; echo "No Internet access detected, attempting to connect BT to $MAC"
             oref0-bluetoothup
             sudo bt-pan client $MAC -d
-            sudo bt-pan client $MAC && sudo dhclient bnep0
+	    for i in {1..3}
+	    do
+                sudo bt-pan client $MAC && sudo dhclient bnep0
+	    done
             if ifconfig | egrep -q "bnep0" >/dev/null; then
                 echo -n "Connected to Bluetooth with IP: "
                 print_local_ip bnep0

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -118,10 +118,10 @@ function bt_connect {
             echo; echo "No Internet access detected, attempting to connect BT to $MAC"
             oref0-bluetoothup
             sudo bt-pan client $MAC -d
-	    for i in {1..3}
-	    do
+            for i in {1..3}
+            do
                 sudo bt-pan client $MAC && sudo dhclient bnep0
-	    done
+            done
             if ifconfig | egrep -q "bnep0" >/dev/null; then
                 echo -n "Connected to Bluetooth with IP: "
                 print_local_ip bnep0


### PR DESCRIPTION
When my phone is in and out of service several times in as many minutes (between subway stations, for example) it doesn't assign an IP address to the device when it tries to connect via Bluetooth. Once back in a more stable environment it takes a while before it tries to get on the Internet via Bluetooth again. This change, tested over several weeks, significantly reduces the time offline during and after using the subway.