### PR TITLE
Bash refactoring: a file for common functions

### DIFF
--- a/bin/mm-format-ns-glucose.sh
+++ b/bin/mm-format-ns-glucose.sh
@@ -5,23 +5,15 @@
 
 # Written for decocare v0.0.17. Will need updating the the decocare json format changes.
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self [--oref0] <medtronic-glucose.json>
+Format Medtronic glucose data into something acceptable to Nightscout.
+EOT
+
 NSONLY=""
 test "$1" = "--oref0" && NSONLY="this.glucose = this.sgv" && shift
-
-self=$(basename $0)
-function usage ( ) {
-
-cat <<EOT
-$self [--oref0] <medtronic-glucose.json>
-$self - Format Medtronic glucose data into something acceptable to Nightscout.
-EOT
-}
-
-case "$1" in
-  --help|-h|help)
-    usage
-    exit 0
-esac
 
 HISTORY=${1-glucosehistory.json}
 OUTPUT=${2-/dev/fd/1}

--- a/bin/mm-format-ns-profile.sh
+++ b/bin/mm-format-ns-profile.sh
@@ -2,7 +2,8 @@
 
 # Author: Ben West
 
-self=$(basename $0)
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 SETTINGS=${1-monitor/settings.json}
 CARBS=${2-monitor/carb-ratios.json}
 BASALRATES=${3-monitor/active-basal-profile.json}
@@ -13,23 +14,20 @@ OUTPUT=${6-/dev/fd/1}
 # CARBRATIO
 #TZ=${3-$(date +%z)}
 
-function usage ( ) {
-cat <<EOF
-$self: Format known pump data into Nightscout "profile".
+usage "$@" <<EOT
+Usage: $self pump-settings carb-ratios active-basal-profile insulin-sensitivities bg-targets
+
+Format known pump data into Nightscout "profile".
 
 Profile documents allow Nightscout to establish a common set of settings for
 therapy, including the type of units used, the timezone, carb-ratios, active
 basal profiles, insulin sensitivities, and BG targets.  This compiles the
 separate pump reports into a single profile document for Nightscout.
 
-Usage:
-$self pump-settings carb-ratios active-basal-profile insulin-sensitivities bg-targets
-
 Examples:
-bewest@bewest-MacBookPro:~/Documents/openaps$ mm-format-ns-profile monitor/settings.json monitor/carb-ratios.json monitor/active-basal-profile.json monitor/insulin-sensitivities.json monitor/bg-targets.json  
+bewest@bewest-MacBookPro:~/Documents/openaps$ mm-format-ns-profile monitor/settings.json monitor/carb-ratios.json monitor/active-basal-profile.json monitor/insulin-sensitivities.json monitor/bg-targets.json
 
-EOF
-}
+EOT
 
 function dia ( ) {
   cat $1 | json insulin_action_curve
@@ -146,12 +144,7 @@ function stub ( ) {
   }
 EOF
 }
-case $1 in
-  --help|config|help|-h)
-    usage
-    exit 0
-    ;;
-esac
+
 stub $SETTINGS | fix-dates \
   | add-carbs $CARBS \
   | add-basals $BASALRATES \

--- a/bin/mm-format-ns-pump-history.sh
+++ b/bin/mm-format-ns-pump-history.sh
@@ -3,20 +3,12 @@
 # Author: Ben West
 # Maintainer: Scott Leibrand
 
-self=$(basename $0)
-function usage ( ) {
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 
-cat <<EOT
-$self <medtronic-pump-history.json>
-$self - Format Medtronic pump-history data into something acceptable to Nightscout.
+usage "$@" <<EOT
+Usage: $self <medtronic-pump-history.json>
+Format Medtronic pump-history data into something acceptable to Nightscout.
 EOT
-}
-
-case "$1" in
-  --help|-h|help)
-    usage
-    exit 0
-esac
 
 
 HISTORY=${1-pumphistory.json}

--- a/bin/mm-format-ns-treatments.sh
+++ b/bin/mm-format-ns-treatments.sh
@@ -2,24 +2,17 @@
 
 # Author: Ben West
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 HISTORY=${1-monitor/pump-history-zoned.json}
 MODEL=${2-model.json}
 OUTPUT=${3-/dev/fd/1}
 #TZ=${3-$(date +%z)}
-self=$(basename $0)
-function usage ( ) {
 
-cat <<EOT
-$self <pump-history-zoned.json> <model.json>
-$self - Format medtronic history data into Nightscout treatments data.
+usage "$@" <<EOT
+Usage: $self <pump-history-zoned.json> <model.json>
+Format medtronic history data into Nightscout treatments data.
 EOT
-}
-
-case "$1" in
-  --help|-h|help)
-    usage
-    exit 0
-esac
 
 
 # | json -e "this.type = 'mm://openaps/$self'" \

--- a/bin/mm-format-oref0-glucose.sh
+++ b/bin/mm-format-oref0-glucose.sh
@@ -4,23 +4,16 @@
 # Maintainer: @tghoward
 
 # Written for decocare v0.0.18. Will need updating the the decocare json format changes.
-self=$(basename $0)
+
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 HISTORY=${1-glucosehistory.json}
 OUTPUT=${2-/dev/fd/1}
 #TZ=${3-$(date +%z)}
-function usage ( ) {
-
-cat <<EOT
-$self <glucose-history.json>
-$self - Format medtronic glucose data into oref0 format. 
+usage "$@" <<EOT
+Usage: $self <glucose-history.json>
+Format medtronic glucose data into oref0 format.
 EOT
-}
-
-case "$1" in
-  --help|-h|help)
-    usage
-    exit 0
-esac
 
 cat $HISTORY | \
   json -e "this.medtronic = this._type;" | \

--- a/bin/mm-stick.sh
+++ b/bin/mm-stick.sh
@@ -3,18 +3,11 @@
 # Author: Ben West @bewest
 
 # Written for decocare v0.0.17.
-self=$(basename $0)
-OUTPUT=/dev/fd/1
-if [[ "${1-}" == "-f" ]] ; then
-shift
-OUTPUT=$1
-shift
-fi
-OPERATION=${1-help}
-export OPERATION
 
-function print_help ( ) {
-  cat <<EOF
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+
+usage "$@" <<EOF
 Usage: $self [{scan,diagnose,help},...]
 
     scan      - Print the local location of a plugged in stick.
@@ -30,7 +23,15 @@ Usage: $self [{scan,diagnose,help},...]
     fail      - Always return a failing exit code.
     help      - This message.
 EOF
-}
+
+OUTPUT=/dev/fd/1
+if [[ "${1-}" == "-f" ]] ; then
+    shift
+    OUTPUT=$1
+    shift
+fi
+OPERATION=${1-help}
+export OPERATION
 
 function print_fail ( ) {
   cat <<EOF
@@ -108,9 +109,6 @@ case $OPERATION in
   fail)
     print_fail $*
     exit 1
-    ;;
-  *|help|--help|-h)
-    print_help
     ;;
   esac
 )

--- a/bin/monitor-xdrip.sh
+++ b/bin/monitor-xdrip.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self
+Normally runs from crontab.
+EOT
+
 date
 cp -rf xdrip/glucose.json xdrip/last-glucose.json
 curl --compressed -s http://localhost:5000/api/v1/entries?count=288 | json -e "this.glucose = this.sgv" > xdrip/glucose.json

--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 
-self=$(basename $0)
 NAME=${1-help}
 shift
 PROGRAM="ns-${NAME}"

--- a/bin/ns-dedupe-treatments.sh
+++ b/bin/ns-dedupe-treatments.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-self=$(basename $0)
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 
-function usage ( ) {
-cat <<EOF
+usage "$@" <<EOF
 Usage: $self --find <NIGHTSCOUT_HOST> - No-op version, find out what delete would do.
 $self --list <NIGHTSCOUT_HOST> - list duplicate count per created_at
 $self delete <NIGHTSCOUT_HOST> - Delete duplicate entries from ${NIGHTSCOUT_HOST-<NIGHTSCOUT_HOST>}
 EOF
-}
 
 function fetch ( ) {
   curl --compressed -s -g $ENDPOINT.json
@@ -38,7 +36,7 @@ curl -X DELETE -H "API-SECRET: $API_SECRET" ${ENDPOINT}/$tid
 
 function list ( ) {
 NIGHTSCOUT_HOST=$1
-  test -z "$NIGHTSCOUT_HOST" && echo NIGHTSCOUT_HOST undefined. && usage && exit 1
+  test -z "$NIGHTSCOUT_HOST" && echo NIGHTSCOUT_HOST undefined. && print_usage && exit 1
 ENDPOINT=${NIGHTSCOUT_HOST}/api/v1/treatments
 
 export NIGHTSCOUT_HOST ENDPOINT
@@ -58,7 +56,7 @@ ENDPOINT=${NIGHTSCOUT_HOST}/api/v1/treatments
 if [[ -z "$NIGHTSCOUT_HOST" || -z "$NIGHTSCOUT_HOST" ]] ; then
   test -z "$NIGHTSCOUT_HOST" && echo NIGHTSCOUT_HOST undefined.
   test -z "$API_SECRET" && echo API_SECRET undefined.
-  usage
+  print_usage
   exit 1;
 fi
 
@@ -88,7 +86,7 @@ case "$1" in
     main $2 delete_cmd
     ;;
   *|help|--help|-h)
-    usage
+    print_usage
     exit 1;
     ;;
 esac

--- a/bin/ns-get.sh
+++ b/bin/ns-get.sh
@@ -2,7 +2,8 @@
 
 # Author: Ben West
 
-self=$(basename $0)
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 REPORT=${1-entries.json}
 NIGHTSCOUT_HOST=${NIGHTSCOUT_HOST-${2-localhost:1337}}
 QUERY=${3}
@@ -13,15 +14,12 @@ NIGHTSCOUT_FORMAT=${NIGHTSCOUT_FORMAT-jq .}
 test "$NIGHTSCOUT_DEBUG" = "1" && CURL_FLAGS="${CURL_FLAGS} -iv"
 test "$NIGHTSCOUT_DEBUG" = "1" && set -x
 
-function usage ( ) {
-cat <<EOF
+usage "$@" <<EOF
 Usage: $self <entries.json> [NIGHTSCOUT_HOST|localhost:1337] [QUERY] [stdout|-]
 
 $self type <entries.json> <NIGHTSCOUT_HOST|localhost:1337] [QUERY] [stdout|-]
 $self host <NIGHTSCOUT_HOST|localhost:1337> <entries.json> [QUERY] [stdout|-]
-
 EOF
-}
 
 CURL_AUTH=""
 
@@ -55,7 +53,7 @@ case $1 in
     else
       REPORT_ENDPOINT=$NIGHTSCOUT_HOST/api/v1/${REPORT}'?'${QUERY}
     fi
-    test -z "$NIGHTSCOUT_HOST" && usage && exit 1;
+    test -z "$NIGHTSCOUT_HOST" && print_usage && exit 1;
 
     curl -m 30 ${CURL_AUTH} ${CURL_FLAGS} $REPORT_ENDPOINT | $NIGHTSCOUT_FORMAT
 
@@ -65,10 +63,10 @@ case $1 in
     exec $self $*
     ;;
   help|--help|-h)
-    usage
+    print_usage
     ;;
   *)
-    test -z "$NIGHTSCOUT_HOST" && usage && exit 1;
+    test -z "$NIGHTSCOUT_HOST" && print_usage && exit 1;
     curl -m 30 ${CURL_AUTH} ${CURL_FLAGS} $REPORT_ENDPOINT | $NIGHTSCOUT_FORMAT
     ;;
 esac

--- a/bin/ns-upload-entries.sh
+++ b/bin/ns-upload-entries.sh
@@ -3,24 +3,16 @@
 # Author: Ben West
 # Maintainer: @cjo20, @scottleibrand
 
-self=$(basename $0)
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 ENTRIES=${1-entries.json}
 NIGHTSCOUT_HOST=${NIGHTSCOUT_HOST-localhost:1337}
 OUTPUT=${2}
 
-function usage ( ) {
-cat <<EOF
-$self <entries.json> <http://nightscout.host:1337>
-$self - Upload entries (glucose data) to NS.
+usage "$@" <<EOF
+Usage: $self <entries.json> <http://nightscout.host:1337>
+Upload entries (glucose data) to NS.
 EOF
-}
-
-case "$1" in
-  -h|--help|help)
-    usage
-    exit 0
-    ;;
-esac
 
 export ENTRIES API_SECRET NIGHTSCOUT_HOST
 

--- a/bin/ns-upload.sh
+++ b/bin/ns-upload.sh
@@ -2,7 +2,8 @@
 
 # Author: Ben West
 
-self=$(basename $0)
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 NIGHTSCOUT_HOST=${NIGHTSCOUT_HOST-${1-localhost:1337}}
 API_SECRET=${2-${API_SECRET}}
 TYPE=${3-entries.json}
@@ -11,31 +12,17 @@ OUTPUT=${5}
 
 REST_ENDPOINT="${NIGHTSCOUT_HOST}/api/v1/${TYPE}"
 
-function usage ( ) {
-cat <<EOF
+usage "$@" <<EOF
 Usage: $self <NIGHTSCOUT_HOST|localhost:1337> <API_SECRET> [API-TYPE|entries.json] <monitor/entries-to-upload.json> [stdout|-]
 
 $self help - This message.
 EOF
-}
-
-case $1 in
-  help)
-    usage
-    ;;
-  *)
-    # curl -s ${REPORT_ENDPOINT} | json
-    ;;
-esac
 
 export ENTRIES API_SECRET NIGHTSCOUT_HOST REST_ENDPOINT
 if [[ -z $API_SECRET ]] ; then
   echo "$self: missing API_SECRET"
   test -z "$NIGHTSCOUT_HOST" && echo "$self: also missing NIGHTSCOUT_HOST"
-  usage > /dev/fd/2
-  cat <<EOF > /dev/fd/2
-Usage: $self <NIGHTSCOUT_HOST-http://localhost:1337> <API_SECRET> [entries|treatments|profile/] <file-to-upload.json> 
-EOF
+  print_usage > /dev/fd/2
   exit 1;
 fi
 # requires API_SECRET and NIGHTSCOUT_HOST to be set in calling environment

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-die() {
-    echo "$@"
-    exit 1
-}
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self
+
+Downloads OpenAPS packages using pip, and dependencies using apt-get and npm.
+This is normally invoked from openaps-install.sh.
+EOT
 
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true install -y sudo

--- a/bin/openaps-src.sh
+++ b/bin/openaps-src.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self
+
+Install development tools and download source code to OpenAPS projects from
+GitHub to ~/src. This is not run as part of a normal end-user setup of OpenAPS,
+but may be useful for developers or for advanced troubleshooting.
+EOT
+
 apt-get install -y sudo
 sudo apt-get update
 sudo apt-get install -y git python python-dev python-software-properties python-numpy python-pip nodejs-legacy npm watchdog strace tcpdump screen acpid vim locate jq lm-sensors && \

--- a/bin/oref0-append-local-temptarget.sh
+++ b/bin/oref0-append-local-temptarget.sh
@@ -1,10 +1,30 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self -|<filename>|<target> <duration> [starttime]
+
+Set a temporary target, by formatting it as JSON and storing it in
+settings/local-temptargets.json where the pump loop will find it on its next
+iteration.
+
+If no arguments are given, expects JSON on stdin. If one argument is given,
+it's the name of a file containing JSON describing a temporary target. If two
+or more arguments, they are a target, duration, and optional start time (as
+with oref0-set-local-temptarget.js).
+EOT
+
+
 if [[ ! -z "$2" ]]; then
+    # If two or more arguments, runs oref0-set-local-temptarget.js forwarding
+    # all its arguments, and input is the output of that.
     input=$(oref0-set-local-temptarget $@)
 elif [[ ! -z "$1" ]]; then
+    # If exactly one argument, it's a filename
     input=$(cat $1)
 else
+    # If no arguments, act like a filter
     input=$(cat /dev/stdin)
 fi
 #cat "${1:-/dev/stdin}" \

--- a/bin/oref0-autosens-loop.sh
+++ b/bin/oref0-autosens-loop.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 main() {
     echo
     echo Starting oref0-autosens-loop at $(date):
@@ -13,17 +16,14 @@ main() {
     echo Completed oref0-autons-loop at $(date)
 }
 
-function overtemp {
-    # check for CPU temperature above 85°C
-    sensors -u 2>/dev/null | awk '$NF > 85' | grep input \
-    && echo Edison is too hot: waiting for it to cool down at $(date)\
-    && echo Please ensure rig is properly ventilated
-}
+usage "$@" <<EOT
+Usage: $self
+Autosens loop. Checks (once) how long it's been since autosens has run, checks
+for various trouble conditions (high load, high CPU temperature), and if it's
+been 30 minutes since autosens has run and everything is okay, runs
+oref0-detect-sensitivity. Working directory should be myopenaps.
+EOT
 
-function highload {
-    # check whether system load average is high
-    uptime | awk '$NF > 2' | grep load
-}
 
 function completed_recently {
     find /tmp/ -mmin -30 | egrep -q "autosens-completed"
@@ -47,11 +47,6 @@ function autosens {
         echo -n "No need to refresh autosens yet: "
     fi
     cat settings/autosens.json | jq . -C -c
-}
-
-die() {
-    echo "$@"
-    exit 1
 }
 
 main "$@"

--- a/bin/oref0-autotune-dayofweek.sh
+++ b/bin/oref0-autotune-dayofweek.sh
@@ -2,13 +2,25 @@
 
 # This script allows you to run autotune separately for each day of the week
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOF
+Usage: $0 ~/myopenaps http://mynightscouthost.herokuapp.com
+If you have day-of-the-week autotune profiles named like
+"myopenaps/autotune/profile-day0.json", copies the profile for whichever day
+today is to myopenaps/autotune/profile.json and reruns autotune. Day 0 is
+Sunday, day 1 is Monday, etc.
+
+This script is not used up by a default install.
+EOF
+
 [ -z "$OPENAPS_DIR" ] && OPENAPS_DIR="$1"
 myopenaps="$OPENAPS_DIR"
 nsurl=$2
 DOW=$(date +%u)
 
 if [ -z $myopenaps ] || [ -z $nsurl ]; then
-  echo "Usage: $0 ~/myopenaps http://mynightscouthost.herokuapp.com"
+  print_usage
   exit
 fi
 

--- a/bin/oref0-autotune-recommends-report.sh
+++ b/bin/oref0-autotune-recommends-report.sh
@@ -18,13 +18,11 @@
 #
 # Example usage: ~/src/oref0/bin/oref0-autotune-recommends-report.sh <OpenAPS Loop Directory Path>
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+
 # fix problems with locales with printf output
 LC_NUMERIC=en_US.UTF-8
-
-die() {
-  echo "$@"
-  exit 1
-}
 
 # Use alternate date command if on OS X:
 shopt -s expand_aliases
@@ -33,8 +31,14 @@ if [[ `uname` == 'Darwin' ]] ; then
     alias date='gdate'
 fi
 
+usage "$@" <<EOT
+Usage: ./oref0-autotune-recommends-report.sh <OpenAPS Loop Directory Path>
+Create a summary report of Autotune recommendations, and store it in
+<loop directory>/autotune/autotune_recommendations.log
+EOT
+
 if [ $# -ne 1 ]; then
-    echo "Usage: ./oref0-autotune-recommends-report.sh <OpenAPS Loop Directory Path>"
+    print_usage
     exit 1
 fi
 

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -26,6 +26,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 die() {
     if [[ -z "$API_SECRET" ]]; then
         echo "Warning: API_SECRET is not set when calling oref0-autotune.sh"

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -1,0 +1,76 @@
+#!/bin/echo This file should be source'd from another script, not run directly:
+#
+# Common functions for shell script components of oref0.
+
+# Set $self to the name the currently-executing script was run as. This is usually
+# used in help messages.
+self=$(basename $0)
+
+PREFERENCES_FILE="preferences.json"
+
+
+function overtemp {
+    # check for CPU temperature above 85°C
+    if is_pi; then
+        TEMPERATURE=`cat /sys/class/thermal/thermal_zone0/temp`
+        TEMPERATURE=`echo -n ${TEMPERATURE:0:2}; echo -n .; echo -n ${TEMPERATURE:2}`
+        echo $TEMPERATURE | awk '$NF > 70' | grep input \
+        && echo Rig is too hot: not running pump-loop at $(date)\
+        && echo Please ensure rig is properly ventilated
+    else
+        sensors -u 2>/dev/null | awk '$NF > 85' | grep input \
+        && echo Edison is too hot: waiting for it to cool down at $(date)\
+        && echo Please ensure rig is properly ventilated
+    fi
+}
+
+function highload {
+    # check whether system load average is high
+    uptime | tr -d ',' | awk "\$(NF-2) > 4" | grep load
+}
+
+
+die() {
+    echo "$@"
+    exit 1
+}
+
+
+
+# Takes a copy of the overall-program's arguments as arguments, and usage text
+# as stdin. If the first argument is help, -h, or --help, print usage
+# information and exit with status 0 (success). Otherwise, save the usage
+# information in environment variable HELP_TEXT so it can be used by print_usage
+# later.
+#
+# Correct invocation would look like:
+#    usage "$@" <<EOT
+#    Usage: $(basename $0) [--some-argument] [--some-other-argument]
+#    Description of what this tool does. Information about what the arguments do.
+#    EOT
+usage () {
+    case "$1" in
+        help|-h|--help)
+            cat -
+            exit 0
+            ;;
+    esac
+    export HELP_TEXT=$(cat -)
+}
+
+# Print the program's help text, as previously set by usage(). This would
+# typically be used after detecting invalid arguments, and followed by "exit 1".
+print_usage () {
+    echo "$HELP_TEXT"
+}
+
+# Check that the current working directory is the myopenaps directory; if it
+# isn't, print a message to stderr and exit with status 1 (failure). We assume
+# we're in the right directory if there's a file named "openaps.ini" here.
+assert_pwd_is_myopenaps () {
+    if [[ ! -e "openaps.ini" ]]; then
+        echo "$self: This script should be run from the myopenaps directory, but was run from $PWD which does not contain openaps.ini." 1>&2
+        exit 1
+    fi
+}
+

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -74,3 +74,25 @@ assert_pwd_is_myopenaps () {
     fi
 }
 
+
+# Returns success (0) if running on an Intel Edison, fail (1) otherwise. Uses
+# the existence of an "edison" account in /etc/passwd to determine that.
+is_edison () {
+    #if egrep -i "edison" /etc/passwd 2>/dev/null; then
+    if getent passwd edison; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Returns success (0) if running on a Raspberry Pi, fail (1) otherwise. Uses
+# the existence of a "pi" account in /etc/passwd to determine that.
+is_pi () {
+    if getent passwd pi > /dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self
+Attempt to establish a Bluetooth tethering connection.
+EOT
+
 # start bluetoothd if bluetoothd is not running
 if ! ( ps -fC bluetoothd >/dev/null ) ; then
    sudo /usr/local/bin/bluetoothd &

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -12,7 +12,7 @@ if ! ( ps -fC bluetoothd >/dev/null ) ; then
    sudo /usr/local/bin/bluetoothd &
 fi
 
-if getent passwd edison && ! ( hciconfig -a | grep -q "PSCAN" ) ; then
+if is_edison && ! ( hciconfig -a | grep -q "PSCAN" ) ; then
    sudo killall bluetoothd
    sudo /usr/local/bin/bluetoothd &
 fi

--- a/bin/oref0-conditional-run.sh
+++ b/bin/oref0-conditional-run.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 export GENERATE=false
 export FILE=$1
 export FILE2=$2
 export COMMAND=$3
 
+usage "$@" <<EOT
+Usage: $self <target report> <age-check report>
+EOT
+
 if test ! -n "$FILE"; then
-  echo "Usage: oref0-crun <target report> <age-check report>"
-  exit
+  print_usage
+  exit 1
 fi
 
 if test ! -f $FILE; then

--- a/bin/oref0-copy-fresher
+++ b/bin/oref0-copy-fresher
@@ -1,21 +1,18 @@
 #!/bin/bash
-self=$(basename $0)
+
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 WITHIN=0
 
-function usage ( ) {
-cat <<EOF
-$self [--since <seconds|0>] <file> [<file>...]
+usage "$@" <<EOF
+Usage: $self [--since <seconds|0>] <file> [<file>...]
 cat files mentioned.
 If --since seconds is specified, the file will only be cat'd if the files last
 modification occurred within <seconds>.
 Default <seconds> is 0, it will cat all files.
 EOF
-}
+
 case $1 in
-  --help|-h|help)
-    usage
-    exit 0
-    ;;
   --since)
     shift
     WITHIN=$1

--- a/bin/oref0-delete-future-entries.sh
+++ b/bin/oref0-delete-future-entries.sh
@@ -8,6 +8,12 @@
 # This will delete all the data in the  
 # monitor directory. Allowing oref0 to gather all of the data again in pump-loop 
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self
+EOT
+
 NEWTIME=$(date -d `(jq .[1].display_time monitor/glucose.json; echo ) | sed 's/"//g'` +%s)
 TIME=$(date --date '5 minutes' +%s)  
 

--- a/bin/oref0-dex-is-fresh.sh
+++ b/bin/oref0-dex-is-fresh.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
-GLUCOSE=$1
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 
+usage "$@" <<EOT
+Usage: $self <glucose.json> <minutes>
+Given a glucose log file, check whether the most recent sample is newer than
+the given number of minutes (default 5). If it's fresh, exit with status 0;
+otherwise exit with status 1. Either way, output a text description of how
+recent the latest sample is.
+EOT
+
+
+GLUCOSE=$1
 OLD=${2-5}
+
 TIME_SINCE=$(oref0-dex-time-since $GLUCOSE)
 
 if (( $(bc <<< "$TIME_SINCE >= $OLD") )); then

--- a/bin/oref0-dex-time-since.sh
+++ b/bin/oref0-dex-time-since.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self <glucose.json>
+Given a glucose log file, output the number of minutes it's been since the
+latest sample.
+EOT
+
 GLUCOSE=$1
 
 cat $GLUCOSE | json -e "this.minAgo=Math.round(100*(new Date()-new Date(this.dateString))/60/1000)/100" | json -a minAgo | head -n 1

--- a/bin/oref0-dex-wait-until-expected.sh
+++ b/bin/oref0-dex-wait-until-expected.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self <glucose.json> <sample-interval> <max-wait>
+Sleep until a new glucose value is expected from the CGM. Takes a log of recent
+glucose samples, the sample interval, and the maximum amount of time to wait.
+EOT
+
+
 GLUCOSE=$1
 
 OLD=${2-5}

--- a/bin/oref0-fix-git-corruption.sh
+++ b/bin/oref0-fix-git-corruption.sh
@@ -3,8 +3,12 @@
 #
 # Author: Ben West
 #
-#
-<<EOT
+
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+
+usage "$@" <<EOT
+Usage: $self
 Sometimes openaps instances get corrupted and only produce error
 messages.
 Looking at recent usage in git's ref-log allows us to guess at the last known

--- a/bin/oref0-ifttt-notify
+++ b/bin/oref0-ifttt-notify
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-self=$(basename $0)
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 # Something like this:
 # https://maker.ifttt.com/trigger/{event}/with/key/MyKey
 IFTTT_TRIGGER=${IFTTT_TRIGGER-${1}}
 IFTTT_NOTIFY_USAGE="${2-pump model}"
 
-function help_message ( ) {
-cat <<EOF
-Usage:
-$self <IFTTT_TRIGGER> <NOTIFY_USAGE>
+usage "$@" <<EOF
+Usage: $self <IFTTT_TRIGGER> <NOTIFY_USAGE>
 
 ## Setup IFTTT Account
 
@@ -59,8 +58,6 @@ Crontab:
 Author: @audiefile
 EOF
 
-}
-
 
 
 case $1 in
@@ -68,10 +65,6 @@ env)
   echo PATH=$PATH
   env
   exit
-  ;;
-help|--help|-h)
-  help_message
-  exit 0
   ;;
 *)
   if [[ -z "$IFTTT_TRIGGER" || -z  "$IFTTT_NOTIFY_USAGE" ]] ; then

--- a/bin/oref0-log-shortcuts.sh
+++ b/bin/oref0-log-shortcuts.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 myopenaps=${OPENAPS_DIR:-"$HOME/myopenaps"}
+
+usage "$@" <<EOT
+Usage: $self
+Add aliases to various OpenAPS utilities, config files to edit, etc to your
+~/.bash_profile, if those shortcuts aren't already there.
+EOT
 
 # add crontab entries
 grep -q networklog $HOME/.bash_profile 2>/dev/null || echo "alias networklog="'"tail -n 100 -F /var/log/openaps/network.log"' >> $HOME/.bash_profile

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 # echo Starting ns-loop at $(date): && openaps get-ns-bg; sensors -u 2>/dev/null | awk '$NF > 85' | grep input || ( openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps upload )
 # echo Starting ns-loop at $(date): && openaps get-ns-bg; openaps ns-temptargets && echo -n Refreshed temptargets && openaps ns-meal-carbs && echo \\\" and meal-carbs\\\" && openaps battery-status; cat monitor/edison-battery.json; echo; openaps upload
 
@@ -31,6 +34,11 @@ main() {
     echo Completed oref0-ns-loop at $(date)
 }
 
+usage "$@" <<EOT
+Usage: $self
+Sync data with Nightscout. Typically runs from crontabb.
+EOT
+
 function pushover_snooze {
     URL=$NIGHTSCOUT_HOST/api/v1/devicestatus.json?count=100
     if snooze=$(curl -s $URL | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | tr -d '"'); then
@@ -39,18 +47,6 @@ function pushover_snooze {
         touch -d $(date -Is -d @$snooze) monitor/pushover-sent
         ls -la monitor/pushover-sent
     fi
-}
-
-function overtemp {
-    # check for CPU temperature above 85°C
-    sensors -u 2>/dev/null | awk '$NF > 85' | grep input \
-    && echo Edison is too hot: waiting for it to cool down at $(date)\
-    && echo Please ensure rig is properly ventilated
-}
-
-function highload {
-    # check whether system load average is high
-    uptime | tr -d ',' | awk "\$(NF-2) > 4" | grep load
 }
 
 
@@ -225,10 +221,5 @@ function mdt_upload_bg {
 
 
 
-
-die() {
-    echo "$@"
-    exit 1
-}
 
 main "$@"

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self
+Attempt to get a working internet connection via wifi or bluetooth. Typically
+run from crontab.
+EOT
+
+
 main() {
     MACs=$@
     HostAPDIP='10.29.29.1'

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -739,7 +739,7 @@ function refresh_profile {
 
 function onbattery {
     # check whether battery level is < 98%
-    if getent passwd edison > /dev/null; then
+    if is_edison; then
         jq --exit-status ".battery < 98 and (.battery > 70 or .battery < 60)" monitor/edison-battery.json >&4
     else
         jq --exit-status ".battery < 98" monitor/edison-battery.json >&4

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 # OREF0_DEBUG makes this script much more verbose
 # and allows it to print additional debug information.
 # OREF0_DEBUG=1 generally means to print everything that usually
@@ -28,6 +30,12 @@ if [[ "$OREF0_DEBUG" -ge 2 ]] ; then
 else
   exec 4>/dev/null
 fi
+
+usage "$@" <<EOT
+Usage: $self
+The main pump loop. Syncs with an insulin pump, enacts temporary basals and
+SMB boluses. Normally runs from crontab.
+EOT
 
 # main pump-loop
 main() {
@@ -124,22 +132,6 @@ function fail {
     update_display
     echo
     exit 1
-}
-
-function overtemp {
-    # check for CPU temperature above 85°C
-    # special temperature check for raspberry pi
-    if getent passwd pi > /dev/null; then
-        TEMPERATURE=`cat /sys/class/thermal/thermal_zone0/temp`
-        TEMPERATURE=`echo -n ${TEMPERATURE:0:2}; echo -n .; echo -n ${TEMPERATURE:2}`
-        echo $TEMPERATURE | awk '$NF > 70' | grep input \
-        && echo Rig is too hot: not running pump-loop at $(date)\
-        && echo Please ensure rig is properly ventilated
-    else
-        sensors -u 2>&3 | awk '$NF > 85' | grep input \
-        && echo Rig is too hot: not running pump-loop at $(date)\
-        && echo Please ensure rig is properly ventilated
-    fi
 }
 
 function smb_reservoir_before {
@@ -916,10 +908,6 @@ try_fail() {
 }
 try_return() {
     "$@" || { echo "Couldn't $*" - continuing; return 1; }
-}
-die() {
-    echo "$@"
-    exit 1
 }
 
 main "$@"

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self <TOKEN> <USER> [enact/suggested.json] [none] [15] [carbs|insulin]
+EOT
+
 TOKEN=$1
 USER=$2
 FILE=${3-enact/suggested.json}
@@ -15,8 +21,8 @@ PREF_FILE=preferences.json
 #echo "Running: $0 $TOKEN $USER $FILE $SOUND $SNOOZE"
 
 if [ -z $TOKEN ] || [ -z $USER ]; then
-    echo "Usage: $0 <TOKEN> <USER> [enact/suggested.json] [none] [15] [carbs|insulin]"
-    exit
+    print_usage
+    exit 1
 fi
 
 PREF_VALUE=$(cat $PREF_FILE | jq --raw-output -r .pushover_sound 2>/dev/null)

--- a/bin/oref0-radio-reboot.sh
+++ b/bin/oref0-radio-reboot.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOF
+Usage: $self
+Check the pump-loop logfile for certain types of radio errors. If any are
+found, schedule a reboot to fix them. Otherwise cancel a pending reboot.
+EOF
+
 # There are 2 known conditions in which communication between rig and pump is not working and a reboot is required.
 # 1) spidev5.1 already in use, see https://github.com/openaps/oref0/pull/411 (all pumps)
 # 2) continuous 'retry 0' or hanging reset.py, see https://github.com/oskarpearson/mmeowlink/issues/60 (WW-pump users only)

--- a/bin/oref0-reset-git.sh
+++ b/bin/oref0-reset-git.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Delete git lock / history if necessary to recover from corrupted .git objects
 #
 # Released under MIT license. See the accompanying LICENSE.txt file for
@@ -13,23 +12,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 # must be run from within a git repo to do anything useful
-self=$(basename $0)
 BACKUP_AREA=${1-${BACKUP_AREA-/var/cache/openaps-ruination}}
-function usage ( ) {
 
-cat <<EOF
-$self
-$self - Wipe out all history, forcibly re-initialzize openaps from scratch.
+usage "$@" <<EOF
+Usage: $self
+Wipe out all history, forcibly re-initialzize openaps from scratch.
 EOF
-}
 
-case "$1" in
-  --help|help|-h)
-    usage
-    exit 0
-    ;;
-esac
 test ! -d $BACKUP_AREA && BACKUP_AREA=/tmp
 BACKUP="$BACKUP_AREA/git-$(date +%s)"
 

--- a/bin/oref0-reset-usb.sh
+++ b/bin/oref0-reset-usb.sh
@@ -13,21 +13,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-self=$(basename $0)
-function usage ( ) {
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 
-cat <<EOF
-$self
-$self - Drop USB stack, rebind the usb kernel modules.
+usage "$@" <<EOF
+Usage: $self
+Drop USB stack, rebind the usb kernel modules.
 EOF
-}
-
-case "$1" in
-  --help|help|-h)
-    usage
-    exit 0
-    ;;
-esac
 
 # Raspberry Pi 1 running Raspbian Wheezy
 FILE=/sys/devices/platform/bcm2708_usb/buspower

--- a/bin/oref0-set-device-clocks.sh
+++ b/bin/oref0-set-device-clocks.sh
@@ -16,6 +16,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 CLOCK=${1-monitor/clock-zoned.json}
@@ -23,22 +26,10 @@ GLUCOSE=${2-monitor/glucose.json}
 PUMP=${3-pump}
 CGM=${4-cgm}
 
-die() { echo "$@" ; exit 1; }
-self=$(basename $0)
-function usage ( ) {
-
-cat <<EOF
-$self
-$self - Set pump and CGM clocks based on NTP time if avaialble.
+usage "$@" <<EOF
+Usage: $self
+Set pump and CGM clocks based on NTP time if avaialble.
 EOF
-}
-
-case "$1" in
-  --help|help|-h)
-    usage
-    exit 0
-    ;;
-esac
 
 
 checkNTP() { ntp-wait -n 1 -v || ( sudo /etc/init.d/ntp restart && ntp-wait -n 1 -v ) }

--- a/bin/oref0-set-system-clock.sh
+++ b/bin/oref0-set-system-clock.sh
@@ -16,6 +16,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 CLOCK=${1-monitor/clock-zoned.json}
@@ -23,22 +25,10 @@ GLUCOSE=${2-monitor/glucose.json}
 PUMP=${3-pump}
 CGM=${4-cgm}
 
-die() { echo "$@" ; exit 1; }
-self=$(basename $0)
-function usage ( ) {
-
-cat <<EOF
-$self
-$self - If NTP is unavailable, set system time to match pump time if it's later
+usage "$@" <<EOF
+Usage: $self
+If NTP is unavailable, set system time to match pump time if it's later
 EOF
-}
-
-case "$1" in
-  --help|help|-h)
-    usage
-    exit 0
-    ;;
-esac
 
 
 checkNTP() { ntp-wait -n 1 -v || ( sudo /etc/init.d/ntp restart && ntp-wait -n 1 -v ) }

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -14,10 +14,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-die() {
-  echo "$@"
-  exit 1
-}
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0-setup.sh in the right directory?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self <--dir=directory> <--serial=pump_serial_#> [--tty=/dev/ttySOMETHING] [--max_iob=0] [--ns-host=https://mynightscout.herokuapp.com] [--api-secret=[myplaintextapisecret|token=subjectname-plaintexthashsecret] [--cgm=(G4-upload|G4-local-only|G4-go|G5|MDT|xdrip)] [--bleserial=SM123456] [--blemac=FE:DC:BA:98:76:54] [--btmac=AB:CD:EF:01:23:45] [--enable='autotune'] [--radio_locale=(WW|US)] [--ww_ti_usb_reset=(yes|no)]
+EOT
 
 # defaults
 max_iob=0 # max_IOB will default to zero if not set in setup script
@@ -144,8 +145,7 @@ if ! [[ ${CGM,,} =~ "g4-upload" || ${CGM,,} =~ "g5" || ${CGM,,} =~ "g5-upload" |
     DIR="" # to force a Usage prompt
 fi
 if [[ -z "$DIR" || -z "$serial" ]]; then
-    echo "Usage: oref0-setup.sh <--dir=directory> <--serial=pump_serial_#> [--tty=/dev/ttySOMETHING] [--max_iob=0] [--ns-host=https://mynightscout.herokuapp.com] [--api-secret=[myplaintextapisecret|token=subjectname-plaintexthashsecret] [--cgm=(G4-upload|G4-local-only|shareble|G5|MDT|xdrip)] [--bleserial=SM123456] [--blemac=FE:DC:BA:98:76:54] [--btmac=AB:CD:EF:01:23:45] [--enable='autotune'] [--radio_locale=(WW|US)] [--ww_ti_usb_reset=(yes|no)]"
-    echo
+    print_usage
     read -p "Start interactive setup? [Y]/n " -r
     if [[ $REPLY =~ ^[Nn]$ ]]; then
         exit

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -221,7 +221,7 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
                 ttyport=/dev/spidev0.0
             fi
         else
-            if  getent passwd edison > /dev/null; then
+            if is_edison; then
                 echocolor "Yay! Configuring for Edison with Explorer Board. "
                 ttyport=/dev/spidev5.1
             else
@@ -667,7 +667,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         echo Checking bluez installation
         bluetoothdversion=$(bluetoothd --version || 0)
         # use packaged bluez with Rapsbian
-        if getent passwd pi > /dev/null; then
+        if is_pi; then
             bluetoothdminversion=5.43
         else
             bluetoothdminversion=5.48
@@ -947,7 +947,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     sudo sysctl -p
 
     # Install EdisonVoltage
-    if egrep -i "edison" /etc/passwd 2>/dev/null; then
+    if is_edison; then
         echo "Checking if EdisonVoltage is already installed"
         if [ -d "$HOME/src/EdisonVoltage/" ]; then
             echo "EdisonVoltage already installed"
@@ -984,7 +984,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     echo Running: openaps report add enact/suggested.json text determine-basal shell monitor/iob.json monitor/temp_basal.json monitor/glucose.json settings/profile.json settings/autosens.json monitor/meal.json
     openaps report add enact/suggested.json text determine-basal shell monitor/iob.json monitor/temp_basal.json monitor/glucose.json settings/profile.json settings/autosens.json monitor/meal.json
 
-    if egrep -qi "edison" /etc/passwd 2>/dev/null; then
+    if is_edison; then
         sudo apt-get -y -t jessie-backports install jq
     else
         sudo apt-get -y install jq
@@ -1118,7 +1118,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
           cp $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq $HOME/myopenaps/ || die "Couldn't cp openaps.jq"
         else
           arch=arm-spi
-          if egrep -i "edison" /etc/passwd 2>/dev/null; then
+          if is_edison; then
             arch=386-spi
           fi
           mkdir -p $HOME/go/bin && \
@@ -1133,7 +1133,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         fi
     fi
     if [[ ${CGM,,} =~ "g4-go" ]]; then
-        if egrep -i "edison" /etc/passwd 2>/dev/null; then
+        if is_edison; then
             go get -u -v -tags nofilter github.com/ecc1/dexcom/...
         else
             go get -u -v github.com/ecc1/dexcom/...
@@ -1205,7 +1205,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         (crontab -l; crontab -l | grep -q "oref0-bluetoothup" || echo '* * * * * ps aux | grep -v grep | grep -q "oref0-bluetoothup" || oref0-bluetoothup >> /var/log/openaps/network.log' ) | crontab -
         fi
         # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
-        if egrep -i "edison" /etc/passwd 2>/dev/null; then
+        if is_edison; then
            (crontab -l; crontab -l | grep -q "cd $directory && sudo ~/src/EdisonVoltage/voltage" || echo "*/15 * * * * cd $directory && sudo ~/src/EdisonVoltage/voltage json batteryVoltage battery | jq .batteryVoltage | awk '{if (\$1<=3050)system(\"sudo shutdown -h now\")}'") | crontab -
         fi
         (crontab -l; crontab -l | grep -q "cd $directory && oref0-delete-future-entries" || echo "@reboot cd $directory && oref0-delete-future-entries") | crontab -

--- a/bin/oref0-subg-ww-radio-parameters.sh
+++ b/bin/oref0-subg-ww-radio-parameters.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOF
+Usage: $self
+Set radio parameters for talking to a Medtronic pump. This script is normally
+invoked via Python wrapper oref0_subg_ww_radio_parameters.py.
+EOF
+
 # set SERIAL_PORT from environment variable, or first argument, or default to /dev/mmeowlink
 SERIAL_PORT=${SERIAL_PORT-${1-/dev/mmeowlink}}
 

--- a/bin/oref0-tail-log.sh
+++ b/bin/oref0-tail-log.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOF
+Usage: $self
+Monitors /var/log/openaps/pump-loop.log
+EOF
+
+
 tail -n 100 -F /var/log/openaps/pump-loop.log

--- a/bin/oref0-tail-wifi.sh
+++ b/bin/oref0-tail-wifi.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOF
+Usage: $self
+Monitors /var/log/openaps/network.log
+EOF
+
+
 tail -n 100 -F /var/log/openaps/network.log

--- a/bin/oref0-truncate-git-history.sh
+++ b/bin/oref0-truncate-git-history.sh
@@ -13,23 +13,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
 # must be run from within a git repo to do anything useful
-self=$(basename $0)
 BACKUP_AREA=${1-${BACKUP_AREA-/var/cache/openaps-ruination}}
-function usage ( ) {
 
-cat <<EOF
-$self
-$self - Check if git commit history is longer than 5000 commits, and re-initialize .git if so.
+usage "$@" <<EOF
+Usage: $self
+Check if git commit history is longer than 5000 commits, and re-initialize .git if so.
 EOF
-}
 
-case "$1" in
-  --help|help|-h)
-    usage
-    exit 0
-    ;;
-esac
 test ! -d $BACKUP_AREA && BACKUP_AREA=/tmp
 BACKUP="$BACKUP_AREA/git-$(date +%s)"
 

--- a/bin/oref0-upload-entries.sh
+++ b/bin/oref0-upload-entries.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOF
+Usage: $self
+Upload data to Nightscout. Normally runs from crontab.
+EOF
+
+
 echo "Checking entries-last-date.json..."
 if [ -e upload/entries-last-date.json ]; then
     LAST_TIME=$(jq -s ".[0].date" upload/entries-last-date.json)

--- a/bin/oref0.sh
+++ b/bin/oref0.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 
-self=$(basename $0)
-NAME=${1-help}
-shift
-PROGRAM="oref0-${NAME}"
-COMMAND=$(which $PROGRAM | head -n 1)
 
-function help_message ( ) {
-  cat <<EOF
+usage "$@" <<EOF
   Usage:
 $self <cmd>
 
@@ -33,7 +28,11 @@ Valid commands:
                                          saved in the file instead.
   oref0 help - this message
 EOF
-}
+
+NAME=${1-help}
+shift
+PROGRAM="oref0-${NAME}"
+COMMAND=$(which $PROGRAM | head -n 1)
 
 case $NAME in
 device-helper)
@@ -61,9 +60,6 @@ export-loop)
   openaps import -l | while read type ; do openaps $type show --json ; done | json -g > $out
 
   exit
-  ;;
-help|--help|-h)
-  help_message
   ;;
 *)
   test -n "$COMMAND" && exec $COMMAND $*

--- a/bin/peb-urchin-status.sh
+++ b/bin/peb-urchin-status.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+usage "$@" <<EOT
+Usage: $self <MAC>
+Collect status information to display on a Pebble SmarthWatch. Runs from
+crontab, if you indicated you have a Pebble during oref0-setup.
+EOT
+
 MAC=$1
 
 if ! ( rfcomm show hci0 | grep -q $MAC ) ; then

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "oref0-autotune-export-to-xlsx": "./bin/oref0-autotune-export-to-xlsx.py",
     "oref0-autotune-prep": "./bin/oref0-autotune-prep.js",
     "oref0-autotune-recommends-report": "./bin/oref0-autotune-recommends-report.sh",
+    "oref0-bash-common-functions.sh": "./bin/oref0-bash-common-functions.sh",
     "oref0-bluetoothup": "./bin/oref0-bluetoothup.sh",
     "oref0-calculate-iob": "./bin/oref0-calculate-iob.js",
     "oref0-copy-fresher": "./bin/oref0-copy-fresher",


### PR DESCRIPTION
Currently there is a fair amount of redundancy between the shell scripts in oref0, because if a function could be shared between scripts but isn't part of the public interface and isn't worth the overhead of its
own separate script, there wasn't anywhere to put it. This introduces a file oref0-bash-common-functions.sh, for stuff that's shared between scripts. This commit a couple existing functions there, "die", "highload" and "overtemp", which were previously copy-pasted into multiple places. ("Overtemp" had gotten out of sync, with some of the places updates for Pi and others not.)

This also introduces "usage" and "print_usage", which handle detecting the --help flag, and rewrites the help-text handling of most of the scripts to use them; and introduces functions is_edison and is_pi, which handle the idiom of checking /etc/passwd for "edison" and "pi" accounts to find out what type of rig we're running on.
