### PR TITLE
 Unit test to syntax-check script and source files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
+  - "8.11.1"
 script: make travis
 after_script: make report

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -11,7 +11,7 @@ sudo apt-get -o Acquire::ForceIPv4=true update && sudo apt-get -o Acquire::Force
 sudo apt-get -o Acquire::ForceIPv4=true install -y git python python-dev software-properties-common python-numpy python-pip nodejs-legacy watchdog strace tcpdump screen acpid vim locate jq lm-sensors || die "Couldn't install packages"
 if ! sudo apt-get -o Acquire::ForceIPv4=true install -y install npm; then
     sudo bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -" || die "Couldn't setup node 8"
-    sudo -o Acquire::ForceIPv4=true install -y apt-get install nodejs || die "Couldn't install nodejs"
+    sudo apt-get -o Acquire::ForceIPv4=true install -y nodejs || die "Couldn't install nodejs"
 fi
 sudo pip install -U openaps || die "Couldn't install openaps toolkit"
 sudo pip install -U openaps-contrib || die "Couldn't install openaps-contrib"

--- a/bin/oref0-autotune-export-to-xlsx.py
+++ b/bin/oref0-autotune-export-to-xlsx.py
@@ -20,7 +20,7 @@ import glob, os, sys
 try:
     import xlsxwriter
 except:
-    print "This software requires XlsxWriter package. Install it with 'sudo pip install XlsxWriter', see http://xlsxwriter.readthedocs.io/"
+    print("This software requires XlsxWriter package. Install it with 'sudo pip install XlsxWriter', see http://xlsxwriter.readthedocs.io/")
     sys.exit(1)
 
 import datetime
@@ -49,7 +49,7 @@ def expandProfile(l, valueField, offsetField):
         minutes1=calc_minutes(start1)
         offset1=l[i][offsetField]
         if minutes1!=offset1:
-            print "Error in JSON offSetField %s contains %s does not match start time %s (%d minutes). Please report this as a bug" % (offsetField, offset1, start1, minutes1) 
+            print("Error in JSON offSetField %s contains %s does not match start time %s (%d minutes). Please report this as a bug" % (offsetField, offset1, start1, minutes1))
             sys.exit(1)
         while (minutes<minutes1):
             r.append(value)
@@ -163,14 +163,14 @@ if __name__ == '__main__':
     # change to openaps directory
     os.chdir(args.dir)
 
-    print "Writing headers to Microsoft Excel file %s" % args.output
+    print("Writing headers to Microsoft Excel file %s" % args.output)
     workbook = xlsxwriter.Workbook(args.output)
     (worksheetProfile,worksheetBasal, worksheetIsf,excel_2decimals_format,excel_integer_format)=excel_init_workbook(workbook)
     row=1 # start on second row, row=0 is for headers
     filenamelist=sortedFilenames()
     for filename in filenamelist:
         f=open(filename, 'r')
-        print "Adding %s to Excel" % filename
+        print("Adding %s to Excel" % filename)
         j=json.load(f)
         try:
             basalProfile=j['basalprofile']
@@ -183,9 +183,9 @@ if __name__ == '__main__':
             row=row+1
         except Exception as e:
             if j.has_key('error'):
-               print "Skipping file. Error: %s " % j['error']
+               print("Skipping file. Error: %s " % j['error'])
             else:
-               print "Skipping file. Exception: %s" % e
+               print("Skipping file. Exception: %s" % e)
                 
     workbook.close()  
-    print "Written %d lines to Excel" % row
+    print("Written %d lines to Excel" % row)

--- a/bin/oref0-autotune.py
+++ b/bin/oref0-autotune.py
@@ -214,15 +214,15 @@ def export_to_excel(output_directory, output_excel_filename):
     call(autotune_export_to_xlsx, shell=True)
 
 def create_summary_report_and_display_results(output_directory):
-    print 
-    print "Autotune pump profile recommendations:"
-    print "---------------------------------------------------------"
+    print()
+    print("Autotune pump profile recommendations:")
+    print("---------------------------------------------------------")
     
     report_file = os.path.join(output_directory, 'autotune', 'autotune_recommendations.log')
     autotune_recommends_report = 'oref0-autotune-recommends-report {0}'.format(output_directory)
     
     call(autotune_recommends_report, shell=True)
-    print "Recommendations Log File: {0}".format(report_file)
+    print("Recommendations Log File: {0}".format(report_file))
     
     # Go ahead and echo autotune_recommendations.log to the terminal, minus blank lines
     # cat $report_file | egrep -v "\| *\| *$"

--- a/bin/oref0-dexusb-cgm-loop.py
+++ b/bin/oref0-dexusb-cgm-loop.py
@@ -49,30 +49,30 @@ CGMPER24H=288*2 # 24 hours = 288 * 5 minutes. For raw values multiply by 2
 
 # limit the list to maxlen items
 def limitlist(l,maxlen):
-	if len(l)<maxlen:
-		return l
-	else:
-		return l[:maxlen]
+    if len(l)<maxlen:
+        return l
+    else:
+        return l[:maxlen]
 
 # execute a command, print
 
 def gettimestatusoutput(command):
-	print( "Executing command %s" % command, end="")
-	t1=datetime.datetime.now()
-        try:
-                data = subprocess.check_output(command, shell=True, universal_newlines=True, stderr=subprocess.STDOUT)
-                status = 0
-        except subprocess.CalledProcessError as ex:
-                data = ex.output
-                status = ex.returncode
-        if data[-1:] == '\n':
-                data = data[:-1]
-	t2=datetime.datetime.now()
-	deltat=(t2-t1).microseconds/1e6
-	print(" in %.2f seconds (exitcode=%d)" % (deltat,status))
-	if status!=0:
-		print("Error: %s" % data)
-	return (deltat, status, data)
+    print( "Executing command %s" % command, end="")
+    t1=datetime.datetime.now()
+    try:
+        data = subprocess.check_output(command, shell=True, universal_newlines=True, stderr=subprocess.STDOUT)
+        status = 0
+    except subprocess.CalledProcessError as ex:
+        data = ex.output
+        status = ex.returncode
+    if data[-1:] == '\n':
+        data = data[:-1]
+    t2=datetime.datetime.now()
+    deltat=(t2-t1).microseconds/1e6
+    print(" in %.2f seconds (exitcode=%d)" % (deltat,status))
+    if status!=0:
+        print("Error: %s" % data)
+    return (deltat, status, data)
 
 def hours_since(dt):
     if dt==-1:
@@ -103,12 +103,12 @@ most_recent_cgm_system_time=datetime.datetime.now()
 
 print("Starting loop")
 while (status!=0):
-	(t, status, output) = gettimestatusoutput(CMD_GET_GLUCOSE % hours)
-	if status==0:
-		break
-	iteration=iteration+1
-	print("Iteration: %d. Sleeping %d seconds" % (iteration, WAIT))
-	time.sleep(WAIT)
+    (t, status, output) = gettimestatusoutput(CMD_GET_GLUCOSE % hours)
+    if status==0:
+        break
+    iteration=iteration+1
+    print("Iteration: %d. Sleeping %d seconds" % (iteration, WAIT))
+    time.sleep(WAIT)
 
 print("Writing output of '%s' to %s" % (CMD_GET_GLUCOSE, DEST))
 f = open(DEST, 'w')
@@ -125,8 +125,8 @@ print("Uploading to nightscout")
 
 display_time_list=[]
 for d in j1:
-	display_time_list.append(d["display_time"])
-	len_j1=len(j1)
+    display_time_list.append(d["display_time"])
+    len_j1=len(j1)
 
 print("Read %d records"% len_j1)
 sliding24h=j1
@@ -134,34 +134,34 @@ most_recent_cgm=display_time_list[0]
 print("Most recent cgm display time: %s" % most_recent_cgm)
 
 while (True):
-	iteration=iteration+1
-	wait=calculate_wait_until_next_cgm(most_recent_cgm)
-	print("Round: %d. Sleeping %d seconds" % (iteration, wait))
-	time.sleep(wait)
-	new=[]
-	hours=hours_since(most_recent_cgm)
-	(t, status, output) = gettimestatusoutput(CMD_GET_GLUCOSE % hours)
-	if status==0:
-		j2=json.loads(output)
-		for d in j2:
-			dt=d["display_time"]
-			if not (dt in display_time_list):
-				print("New: %s" % dt)
-				display_time_list.append(dt)
-				new.append(d)
-				most_recent_cgm=dt
+    iteration=iteration+1
+    wait=calculate_wait_until_next_cgm(most_recent_cgm)
+    print("Round: %d. Sleeping %d seconds" % (iteration, wait))
+    time.sleep(wait)
+    new=[]
+    hours=hours_since(most_recent_cgm)
+    (t, status, output) = gettimestatusoutput(CMD_GET_GLUCOSE % hours)
+    if status==0:
+        j2=json.loads(output)
+        for d in j2:
+            dt=d["display_time"]
+            if not (dt in display_time_list):
+                print("New: %s" % dt)
+                display_time_list.append(dt)
+                new.append(d)
+                most_recent_cgm=dt
 
-	if len(new)>0: # only do stuff if we have new cgm records
-		new=limitlist(new+sliding24h, CGMPER24H) # limit json to 24h of cgm values
-		sliding24h=new
-		f = open(DEST, 'w')
-		f.write(json.dumps(sliding24h, sort_keys=True, indent=4, separators=(',', ': ')))
-		f.close()
-		print("Rezoning and feeding to openaps")
-		(t,status, output) = gettimestatusoutput(CMD_OPENAPS_GET_BG)
+    if len(new)>0: # only do stuff if we have new cgm records
+        new=limitlist(new+sliding24h, CGMPER24H) # limit json to 24h of cgm values
+        sliding24h=new
+        f = open(DEST, 'w')
+        f.write(json.dumps(sliding24h, sort_keys=True, indent=4, separators=(',', ': ')))
+        f.close()
+        print("Rezoning and feeding to openaps")
+        (t,status, output) = gettimestatusoutput(CMD_OPENAPS_GET_BG)
 
-		print("Uploading to nightscout")
-		(t,status, output) = gettimestatusoutput(CMD_NS_UPLOAD_ENTRIES)
+        print("Uploading to nightscout")
+        (t,status, output) = gettimestatusoutput(CMD_NS_UPLOAD_ENTRIES)
 
 
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -616,6 +616,10 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     sudo cp $HOME/src/oref0/logrotate.rsyslog /etc/logrotate.d/rsyslog || die "Could not cp /etc/logrotate.d/rsyslog"
 
     test -d /var/log/openaps || sudo mkdir /var/log/openaps && sudo chown $USER /var/log/openaps || die "Could not create /var/log/openaps"
+    
+    if [[ -f /etc/cron.daily/logrotate ]]; then
+        mv -f /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
+    fi
 
     #TODO: remove this when IPv6 works reliably
     echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4

--- a/bin/oref0_autotune_export_to_xlsx.py
+++ b/bin/oref0_autotune_export_to_xlsx.py
@@ -20,7 +20,7 @@ import glob, os, sys
 try:
     import xlsxwriter
 except:
-    print "This software requires XlsxWriter package. Install it with 'sudo pip install XlsxWriter', see http://xlsxwriter.readthedocs.io/"
+    print("This software requires XlsxWriter package. Install it with 'sudo pip install XlsxWriter', see http://xlsxwriter.readthedocs.io/")
     sys.exit(1)
 
 import datetime
@@ -49,7 +49,7 @@ def expandProfile(l, valueField, offsetField):
         minutes1=calc_minutes(start1)
         offset1=l[i][offsetField]
         if minutes1!=offset1:
-            print "Error in JSON offSetField %s contains %s does not match start time %s (%d minutes). Please report this as a bug" % (offsetField, offset1, start1, minutes1) 
+            print("Error in JSON offSetField %s contains %s does not match start time %s (%d minutes). Please report this as a bug" % (offsetField, offset1, start1, minutes1))
             sys.exit(1)
         while (minutes<minutes1):
             r.append(value)
@@ -122,14 +122,14 @@ if __name__ == '__main__':
     # change to autotune directory
     os.chdir(args.dir)
 
-    print "Writing headers to Microsoft Excel file %s" % args.output
+    print("Writing headers to Microsoft Excel file %s" % args.output)
     workbook = xlsxwriter.Workbook(args.output)
     (worksheetBasal, worksheetIsf,excel_2decimals_format,excel_integer_format)=excel_init_workbook(workbook)
     row=1 # start on second row, row=0 is for headers
     filenamelist=glob.glob("profile.json")+glob.glob("profile.pump.json")+glob.glob("profile.[0-9].*.json")+glob.glob("profile.[0-9][0-9].*.json")
     for filename in filenamelist:
         f=open(filename, 'r')
-        print "Adding %s to Excel" % filename
+        print("Adding %s to Excel" % filename)
         j=json.load(f)
         basalProfile=j['basalprofile']
         isfProfile=j['isfProfile']['sensitivities']

--- a/tests/check-syntax.test.js
+++ b/tests/check-syntax.test.js
@@ -1,0 +1,100 @@
+// A unit test which checks Javascript, Python and bash files in oref0/bin and
+// oref0/lib for syntax errors. Uses "node --check" for Javascript,
+// "python3 -m py_compile" for Python, and "bash -n" for shell scripts. Python
+// is checked as Python 3 regardless of whether the #! line at the top says
+// it should be run as 2 or 3, since it's pretty easy to make a Python 2
+// program pass a syntax check as Python 3 and this is something that should
+// be done anyways.
+
+var dirsToCheck = [ "bin", "lib", "www" ];
+
+var fs = require("fs");
+var path = require("path");
+var child_process = require("child_process");
+var should = require('should');
+
+function getFileFormat(filename)
+{
+    if(filename.endsWith(".sh")) {
+        return "sh";
+    } else if(filename.endsWith(".js")) {
+        return "js";
+    } else if(filename.endsWith(".py")) {
+        return "py";
+    } else {
+        // If the filename doesn't identify the type, ignore it. (TODO: We
+        // could open it and read the #! line, and there are a few files
+        // getting skipped because we don't do that.)
+        return "unknown";
+    }
+}
+
+function checkFile(filename, type)
+{
+    switch(type)
+    {
+    case "sh":
+        var script = child_process.spawnSync("bash", ["-n", filename], {
+            timeout: 4000, //milliseconds
+            encoding: "UTF-8",
+        });
+        
+        should.equal(script.status, 0, "Shell script "+filename+" contains a syntax error.");
+        break;
+        
+    case "js":
+        var js = child_process.spawnSync("node", ["--check", filename], {
+            timeout: 4000, //milliseconds
+            encoding: "UTF-8",
+        });
+        
+        should.equal(js.status, 0, "Javascript file "+filename+" contains a syntax error.");
+        break;
+    
+    case "py":
+        // Check whether there's a .pyc file
+        var compiledName = pythonCompiledNameOf(filename);
+        
+        var py = child_process.spawnSync("python3", ["-m", "py_compile", filename], {
+            timeout: 4000, //milliseconds
+            encoding: "UTF-8",
+        });
+        
+        should.equal(py.status, 0, "Python file "+filename+" contains a syntax error.");
+        break;
+    }
+}
+
+function pythonCompiledNameOf(filename) {
+    if(filename.endsWith(".py"))
+        return filename+"c";
+    else
+        return filename+".pyc";
+}
+
+function recursiveListFiles(outList, dir) {
+    fs.readdirSync(dir).forEach(function(basename) {
+        var filename = path.join(dir, basename);
+        var stat = fs.statSync(filename);
+        if(stat.isDirectory()) {
+            recursiveListFiles(outList, filename);
+        } else {
+            outList.push(filename);
+        }
+    });
+}
+
+describe("Syntax checks", function() {
+    var filesToCheck = []
+    dirsToCheck.forEach(function(dir) {
+        recursiveListFiles(filesToCheck, dir);
+    });
+    filesToCheck.forEach(function(file) {
+        var type = getFileFormat(file);
+        if(type !== "unknown") {
+            it(file, function() {
+                checkFile(file, type);
+            });
+        }
+    });
+});


### PR DESCRIPTION
This adds a unit test which goes through the source (everything in
oref0/bin and oref0/lib) and attempts to compile/parse each Python,
Javascript and shell file, failing the test if there are syntax errors.
For Python, this is done with Python 3, regardless of whether the file
specifies Python 2 or Python 3 (currently there are some files using
each). Since Python 3 is stricter, some files were changed to pass
Python 3's stricter syntax rules, in particular, converting mixed spaces
and tabs to all spaces, and putting parentheses on print() statements.