### PR TITLE
Fix typo in filename of /tmp/autosens-completed

### DIFF
--- a/bin/oref0-autosens-loop.sh
+++ b/bin/oref0-autosens-loop.sh
@@ -9,7 +9,7 @@ main() {
     fi
 
     autosens 2>&1
-    touch /tmp/autons-completed
+    touch /tmp/autosens-completed
     echo Completed oref0-autons-loop at $(date)
 }
 


### PR DESCRIPTION
Fix a typo that would cause completed_recently in oref0-autosens-loop.sh to always be false. This effectively disabled a feature that was supposed to make autosens recalculation happen less frequently when under high load.