### PR TITLE
Trying to update the 'clock' on xdripaps causes an un-needed loop fail

### DIFF
--- a/bin/oref0-set-device-clocks.sh
+++ b/bin/oref0-set-device-clocks.sh
@@ -47,6 +47,10 @@ if checkNTP; then
     sudo ntpdate -s -b time.nist.gov
     echo Setting pump time to $(date)
     openaps use $PUMP set_clock --to now 2>&1 >/dev/null | tail -1
-    echo Setting CGM time to $(date)
-    openaps use $CGM UpdateTime --to now 2>&1 >/dev/null | tail -1
+    # xdripaps CGM does not have a clock to set, so don't try. 
+    if [ ! -f xdrip.ini ] 
+    then
+      echo Setting CGM time to $(date)
+      openaps use $CGM UpdateTime --to now 2>&1 >/dev/null | tail -1
+    fi
 fi


### PR DESCRIPTION
Stop trying to set-device-clocks for CGM on xdripaps installs.

When this command is executed, it results in a loop failure due to 'failure' to set the pump clock, when in reality the pump clock was set, but the non-existent xdripaps CGM clock was not.

While this is normally 'OK' on the next loop, it is somewhat inefficient to have to redo the entire loop because a command that shouldn't have been executed, was executed. 

Fixed by looking for the xdrip.ini file & skipping the CGM clock update if it is found.