### PR TITLE
activate exercise_mode / high_temptarget_raises_sensitivity at 101

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -129,7 +129,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         var halfBasalTarget = 160; // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
         // 80 mg/dL with low_temptarget_lowers_sensitivity would give 1.5x basal, but is limited to autosens_max (1.2x by default)
     }
-    if ( high_temptarget_raises_sensitivity && profile.temptargetSet && target_bg > normalTarget + 10
+    if ( high_temptarget_raises_sensitivity && profile.temptargetSet && target_bg > normalTarget
         || profile.low_temptarget_lowers_sensitivity && profile.temptargetSet && target_bg < normalTarget ) {
         // w/ target 100, temp target 110 = .89, 120 = 0.8, 140 = 0.67, 160 = .57, and 200 = .44
         // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -14,12 +14,12 @@ function defaults ( ) {
     , autosens_min: 0.7
     , rewind_resets_autosens: true // reset autosensitivity to neutral for awhile after each pump rewind
     // , autosens_adjust_targets: false // when autosens detects sensitivity/resistance, also adjust BG target accordingly
-    , high_temptarget_raises_sensitivity: false // raise sensitivity for temptargets >= 111.  synonym for exercise_mode
+    , high_temptarget_raises_sensitivity: false // raise sensitivity for temptargets >= 101.  synonym for exercise_mode
     , low_temptarget_lowers_sensitivity: false // lower sensitivity for temptargets <= 99.
     , sensitivity_raises_target: true // raise BG target when autosens detects sensitivity
     , resistance_lowers_target: false // lower BG target when autosens detects resistance
     , adv_target_adjustments: false // lower target automatically when BG and eventualBG are high
-    , exercise_mode: false // when true, > 105 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before. synonmym for high_temptarget_raises_sensitivity
+    , exercise_mode: false // when true, > 100 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before. synonmym for high_temptarget_raises_sensitivity
     , half_basal_exercise_target: 160 // when temptarget is 160 mg/dL *and* exercise_mode=true, run 50% basal at this level (120 = 75%; 140 = 60%)
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.


### PR DESCRIPTION
The current cutoff for activating exercise_mode / high_temptarget_raises_sensitivity is > 110 ( >= 111 ).  This seems to cause confusion over the behavior of temp targets in the 101-110 range.  To simplify things, this PR proposes removing the + 10 threshold, so that exercise_mode / high_temptarget_raises_sensitivity apply proportionally to any temp target > 100 ( >= 101 ).