### PR TITLE
Fix MRAA installation on newer RPi kernels

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -808,16 +808,16 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     if [[ "$ttyport" =~ "spi" ]] && [[ ${CGM,,} =~ "mdt" ]]; then
         echo Checking kernel for spi_serial installation
         if ! python -c "import spi_serial" 2>/dev/null; then
-            if uname -r 2>&1 | egrep "^4.1[0-9]"; then # kernel >= 4.10+, use pietergit version of spi_serial (does not use mraa)
-                echo Installing spi_serial && sudo pip install --upgrade git+https://github.com/pietergit/spi_serial.git || die "Couldn't install pietergit/spi_serial"
-            else # kernel < 4.10, use scottleibrand version of spi_serial (requires mraa)
+            #if uname -r 2>&1 | egrep "^4.1[0-9]"; then # kernel >= 4.10+, use pietergit version of spi_serial (does not use mraa)
+            #    echo Installing spi_serial && sudo pip install --upgrade git+https://github.com/pietergit/spi_serial.git || die "Couldn't install pietergit/spi_serial"
+            #else # kernel < 4.10, use scottleibrand version of spi_serial (requires mraa)
                 if [[ "$ttyport" =~ "spidev0.0" ]]; then
                     echo Installing spi_serial && sudo pip install --upgrade git+https://github.com/scottleibrand/spi_serial.git@explorer-hat || die "Couldn't install scottleibrand/spi_serial for explorer-hat"
                     sed -i.bak -e "s/#dtparam=spi=on/dtparam=spi=on/" /boot/config.txt
                 else
                     echo Installing spi_serial && sudo pip install --upgrade git+https://github.com/scottleibrand/spi_serial.git || die "Couldn't install scottleibrand/spi_serial"
                 fi
-            fi
+            #fi
             #echo Installing spi_serial && sudo pip install --upgrade git+https://github.com/EnhancedRadioDevices/spi_serial || die "Couldn't install spi_serial"
         fi
 
@@ -831,9 +831,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
                 openaps alias add mmtune "! bash -c \"oref0_init_pump_comms.py --ww_ti_usb_reset=yes -v; find monitor/ -size +5c | grep -q mmtune && cp monitor/mmtune.json mmtune_old.json; echo {} > monitor/mmtune.json; echo -n \"mmtune: \" && openaps report invoke monitor/mmtune.json; grep -v setFreq monitor/mmtune.json | grep -A2 $(cat monitor/mmtune.json | jq -r .setFreq) | while read line; do echo -n \"$line \"; done\""
         fi
         echo Checking kernel for mraa installation
-        if uname -r 2>&1 | egrep "^4.1[0-9]"; then # don't install mraa on 4.10+ kernels
-            echo "Skipping mraa install for kernel 4.10+"
-        else # check if mraa is installed
+        #if uname -r 2>&1 | egrep "^4.1[0-9]"; then # don't install mraa on 4.10+ kernels
+        #    echo "Skipping mraa install for kernel 4.10+"
+        #else # check if mraa is installed
             if ! ldconfig -p | grep -q mraa; then # if not installed, install it
                 echo Installing swig etc.
                 sudo apt-get install -y libpcre3-dev git cmake python-dev swig || die "Could not install swig etc."
@@ -854,7 +854,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
                 make && sudo make install && echo && touch /tmp/reboot-required && echo mraa installed. Please reboot before using. && echo ) || die "Could not compile mraa"
                 sudo bash -c "grep -q i386-linux-gnu /etc/ld.so.conf || echo /usr/local/lib/i386-linux-gnu/ >> /etc/ld.so.conf && ldconfig" || die "Could not update /etc/ld.so.conf"
             fi
-        fi
+        #fi
     fi
 
     #echo Checking openaps dev installation


### PR DESCRIPTION
After the 4/18/2018 release of Raspbian the kernel version is >4.10, but we still need MRAA installed. 