### PR TITLE
Fixed currentRate calculation when using autosens.

### DIFF
--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -513,7 +513,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
                 //process.stderr.write("Autosens ratio: "+sensitivityRatio+"; ");
             }
             if ( sensitivityRatio ) {
-                currentRate = profile_data.current_basal * sensitivityRatio;
+                currentRate = currentRate * sensitivityRatio;
             }
 
             var netBasalRate = currentItem.rate - currentRate;


### PR DESCRIPTION
Using the profile_data.current_basal rather than the basal rate for the time of the insulin delivery event creates a scenario where the basal rate used for all of the insulin delivery events is only the current rate rather than the scheduled rate.