### PR TITLE
Compare both RMSD and MAE

### DIFF
--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -92,7 +92,7 @@ function generate (inputs) {
         }
       }
 
-      consoleError('Optimum insulinEndTime', newDIA, 'mean deviation:', minDeviations, '(mg/dL)');
+      consoleError('Optimum insulinEndTime', newDIA, 'mean deviation:', minDeviations/basalGlucose.length, '(mg/dL)');
       //consoleError(diaDeviations);
 
       minDeviations = 1000000;
@@ -160,7 +160,7 @@ function generate (inputs) {
         }
       }
 
-      consoleError('Optimum insulinPeakTime', newPeak, 'mean deviation:', minDeviations, '(mg/dL)');
+      consoleError('Optimum insulinPeakTime', newPeak, 'mean deviation:', minDeviations/basalGlucose.length, '(mg/dL)');
       //consoleError(peakDeviations);
       autotune_prep_output.peakDeviations = peakDeviations;
 

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -92,7 +92,7 @@ function generate (inputs) {
         }
       }
 
-      consoleError('Optimum insulinEndTime', newDIA, 'mean deviation:', minDeviations/basalGlucose.length, '(mg/dL)');
+      consoleError('Optimum insulinEndTime', newDIA, 'mean deviation:', Math.round(minDeviations/basalGlucose.length*1000)/1000, '(mg/dL)');
       //consoleError(diaDeviations);
 
       minDeviations = 1000000;
@@ -160,7 +160,7 @@ function generate (inputs) {
         }
       }
 
-      consoleError('Optimum insulinPeakTime', newPeak, 'mean deviation:', minDeviations/basalGlucose.length, '(mg/dL)');
+      consoleError('Optimum insulinPeakTime', newPeak, 'mean deviation:', Math.round(minDeviations/basalGlucose.length*1000)/1000, '(mg/dL)');
       //consoleError(peakDeviations);
       autotune_prep_output.peakDeviations = peakDeviations;
 

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -40,6 +40,7 @@ function generate (inputs) {
       var startDIA=currentDIA - 2;
       var endDIA=currentDIA + 2;
       for (var dia=startDIA; dia <= endDIA; ++dia) {
+        var sqrtDeviations = 0;
         var deviations = 0;
         var deviationsSq = 0;
 
@@ -65,17 +66,25 @@ function generate (inputs) {
             var myHour = BGTime.getHours();
             if (hour == myHour) {
               //console.error(basalGlucose[i].deviation);
+              sqrtDeviations += Math.pow(parseFloat(basalGlucose[i].deviation), 0.5);
               deviations += parseFloat(basalGlucose[i].deviation);
               deviationsSq += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
             }
           }
         }
 
-        consoleError('insulinEndTime', dia, ', sum of deviations:', Math.round(deviations*1000)/1000, '(mg/dL), sum of squared deviations:', Math.round(deviationsSq*1000)/1000, '(mg/dL)^2');
+        consoleError('insulinEndTime', dia)
+        var meanDeviation = Math.round(deviations/basalGlucose.length*1000)/1000;
+        consoleError('meanDeviation:', meanDeviation, '(mg/dL)');
+        var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
+        consoleError('square of mean of square roots (SMR) of deviations:', SMRDeviation, '(mg/dL)');
+        var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
+        consoleError('square root of mean of squared (RMS) deviations:', RMSDeviation, '(mg/dL)');
         diaDeviations.push({
             dia: dia,
-            deviations: Math.round(deviations*1000)/1000
-            devSquared: Math.round(deviationsSq*1000)/1000
+            meanDeviation: meanDeviation,
+            SMRDeviation: SMRDeviation,
+            RMSDeviation: RMSDeviation,
         });
         autotune_prep_output.diaDeviations = diaDeviations;
 

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -108,7 +108,9 @@ function generate (inputs) {
       var startPeak=opts.profile.insulinPeakTime - 10;
       var endPeak=opts.profile.insulinPeakTime + 10;
       for (var peak=startPeak; peak <= endPeak; peak=(peak+5)) {
+        var sqrtDeviations = 0;
         var deviations = 0;
+        var deviationsSq = 0;
 
         opts.profile.insulinPeakTime = peak;
 

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -92,7 +92,7 @@ function generate (inputs) {
         }
       }
 
-      consoleError('Optimum insulinEndTime', newDIA, 'mean deviation:', Math.round(minDeviations/basalGlucose.length*1000)/1000, '(mg/dL)');
+      // consoleError('Optimum insulinEndTime', newDIA, 'mean deviation:', Math.round(minDeviations/basalGlucose.length*1000)/1000, '(mg/dL)');
       //consoleError(diaDeviations);
 
       minDeviations = 1000000;
@@ -160,7 +160,7 @@ function generate (inputs) {
         }
       }
 
-      consoleError('Optimum insulinPeakTime', newPeak, 'mean deviation:', Math.round(minDeviations/basalGlucose.length*1000)/1000, '(mg/dL)');
+      //consoleError('Optimum insulinPeakTime', newPeak, 'mean deviation:', Math.round(minDeviations/basalGlucose.length*1000)/1000, '(mg/dL)');
       //consoleError(peakDeviations);
       autotune_prep_output.peakDeviations = peakDeviations;
 

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -146,7 +146,7 @@ function generate (inputs) {
         var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose.length,0.5)*1000)/1000;
         consoleError('insulinPeakTime', peak, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
         peakDeviations.push({
-            dia: dia,
+            peak: peak,
             meanDeviation: meanDeviation,
             SMRDeviation: SMRDeviation,
             RMSDeviation: RMSDeviation,

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -73,13 +73,10 @@ function generate (inputs) {
           }
         }
 
-        consoleError('insulinEndTime', dia)
         var meanDeviation = Math.round(deviations/basalGlucose.length*1000)/1000;
-        consoleError('meanDeviation:', meanDeviation, '(mg/dL)');
         var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
-        consoleError('square of mean of square roots (SMR) of deviations:', SMRDeviation, '(mg/dL)');
         var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
-        consoleError('square root of mean of squared (RMS) deviations:', RMSDeviation, '(mg/dL)');
+        consoleError('insulinEndTime', dia, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
         diaDeviations.push({
             dia: dia,
             meanDeviation: meanDeviation,
@@ -95,7 +92,7 @@ function generate (inputs) {
         }
       }
 
-      consoleError('Optimum insulinEndTime', newDIA, 'total sum squared deviations:', minDeviations, '(mg/dL)^2');
+      consoleError('Optimum insulinEndTime', newDIA, 'mean deviation:', minDeviations, '(mg/dL)');
       //consoleError(diaDeviations);
 
       minDeviations = 1000000;
@@ -136,13 +133,23 @@ function generate (inputs) {
             var myHour = BGTime.getHours();
             if (hour == myHour) {
               //console.error(basalGlucose[i].deviation);
-              deviations += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
+              sqrtDeviations += Math.pow(parseFloat(basalGlucose[i].deviation), 0.5);
+              deviations += parseFloat(basalGlucose[i].deviation);
+              deviationsSq += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
             }
           }
         }
 
-        consoleError('insulinPeakTime', peak, 'total sum squared deviations:', Math.round(deviations*1000)/1000, '(mg/dL)^2');
-        peakDeviations.push({peak: peak, devSquared: Math.round(deviations*1000)/1000});
+        var meanDeviation = Math.round(deviations/basalGlucose.length*1000)/1000;
+        var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
+        var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
+        consoleError('insulinPeakTime', dia, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
+        peakDeviations.push({
+            dia: dia,
+            meanDeviation: meanDeviation,
+            SMRDeviation: SMRDeviation,
+            RMSDeviation: RMSDeviation,
+        });
 
         deviations = Math.round(deviations*1000)/1000;
         if (deviations < minDeviations) {
@@ -151,7 +158,7 @@ function generate (inputs) {
         }
       }
 
-      consoleError('Optimum insulinPeakTime', newPeak, 'total sum squared deviations:', minDeviations, '(mg/dL)^2');
+      consoleError('Optimum insulinPeakTime', newPeak, 'mean deviation:', minDeviations, '(mg/dL)');
       //consoleError(peakDeviations);
       autotune_prep_output.peakDeviations = peakDeviations;
 

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -75,7 +75,7 @@ function generate (inputs) {
 
         var meanDeviation = Math.round(Math.abs(deviations/basalGlucose.length)*1000)/1000;
         var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
-        var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
+        var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose.length,0.5)*1000)/1000;
         consoleError('insulinEndTime', dia, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
         diaDeviations.push({
             dia: dia,
@@ -143,7 +143,7 @@ function generate (inputs) {
 
         var meanDeviation = Math.round(deviations/basalGlucose.length*1000)/1000;
         var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
-        var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
+        var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose.length,0.5)*1000)/1000;
         consoleError('insulinPeakTime', peak, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
         peakDeviations.push({
             dia: dia,

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -41,6 +41,7 @@ function generate (inputs) {
       var endDIA=currentDIA + 2;
       for (var dia=startDIA; dia <= endDIA; ++dia) {
         var deviations = 0;
+        var deviationsSq = 0;
 
         opts.profile.dia = dia;
 
@@ -64,13 +65,18 @@ function generate (inputs) {
             var myHour = BGTime.getHours();
             if (hour == myHour) {
               //console.error(basalGlucose[i].deviation);
-              deviations += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
+              deviations += parseFloat(basalGlucose[i].deviation);
+              deviationsSq += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
             }
           }
         }
 
-        consoleError('insulinEndTime', dia, 'total sum squared deviations:', Math.round(deviations*1000)/1000, '(mg/dL)^2');
-        diaDeviations.push({dia: dia, devSquared: Math.round(deviations*1000)/1000});
+        consoleError('insulinEndTime', dia, ', sum of deviations:', Math.round(deviations*1000)/1000, '(mg/dL), sum of squared deviations:', Math.round(deviationsSq*1000)/1000, '(mg/dL)^2');
+        diaDeviations.push({
+            dia: dia,
+            deviations: Math.round(deviations*1000)/1000
+            devSquared: Math.round(deviationsSq*1000)/1000
+        });
         autotune_prep_output.diaDeviations = diaDeviations;
 
         deviations = Math.round(deviations*1000)/1000;

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -139,11 +139,12 @@ function generate (inputs) {
             }
           }
         }
+        console.error(deviationsSq);
 
         var meanDeviation = Math.round(Math.abs(deviations/basalGlucose.length)*1000)/1000;
         var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
         var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
-        consoleError('insulinPeakTime', dia, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
+        consoleError('insulinPeakTime', peak, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
         peakDeviations.push({
             dia: dia,
             meanDeviation: meanDeviation,

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -67,7 +67,7 @@ function generate (inputs) {
             if (hour == myHour) {
               //console.error(basalGlucose[i].deviation);
               sqrtDeviations += Math.pow(parseFloat(Math.abs(basalGlucose[i].deviation)), 0.5);
-              deviations += parseFloat(basalGlucose[i].deviation);
+              deviations += Math.abs(parseFloat(basalGlucose[i].deviation));
               deviationsSq += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
             }
           }
@@ -134,14 +134,14 @@ function generate (inputs) {
             if (hour == myHour) {
               //console.error(basalGlucose[i].deviation);
               sqrtDeviations += Math.pow(parseFloat(Math.abs(basalGlucose[i].deviation)), 0.5);
-              deviations += parseFloat(basalGlucose[i].deviation);
+              deviations += Math.abs(parseFloat(basalGlucose[i].deviation));
               deviationsSq += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
             }
           }
         }
         console.error(deviationsSq);
 
-        var meanDeviation = Math.round(Math.abs(deviations/basalGlucose.length)*1000)/1000;
+        var meanDeviation = Math.round(deviations/basalGlucose.length*1000)/1000;
         var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
         var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
         consoleError('insulinPeakTime', peak, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');

--- a/lib/autotune-prep/index.js
+++ b/lib/autotune-prep/index.js
@@ -66,14 +66,14 @@ function generate (inputs) {
             var myHour = BGTime.getHours();
             if (hour == myHour) {
               //console.error(basalGlucose[i].deviation);
-              sqrtDeviations += Math.pow(parseFloat(basalGlucose[i].deviation), 0.5);
+              sqrtDeviations += Math.pow(parseFloat(Math.abs(basalGlucose[i].deviation)), 0.5);
               deviations += parseFloat(basalGlucose[i].deviation);
               deviationsSq += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
             }
           }
         }
 
-        var meanDeviation = Math.round(deviations/basalGlucose.length*1000)/1000;
+        var meanDeviation = Math.round(Math.abs(deviations/basalGlucose.length)*1000)/1000;
         var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
         var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
         consoleError('insulinEndTime', dia, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
@@ -133,14 +133,14 @@ function generate (inputs) {
             var myHour = BGTime.getHours();
             if (hour == myHour) {
               //console.error(basalGlucose[i].deviation);
-              sqrtDeviations += Math.pow(parseFloat(basalGlucose[i].deviation), 0.5);
+              sqrtDeviations += Math.pow(parseFloat(Math.abs(basalGlucose[i].deviation)), 0.5);
               deviations += parseFloat(basalGlucose[i].deviation);
               deviationsSq += Math.pow(parseFloat(basalGlucose[i].deviation), 2);
             }
           }
         }
 
-        var meanDeviation = Math.round(deviations/basalGlucose.length*1000)/1000;
+        var meanDeviation = Math.round(Math.abs(deviations/basalGlucose.length)*1000)/1000;
         var SMRDeviation = Math.round(Math.pow(sqrtDeviations/basalGlucose.length,2)*1000)/1000;
         var RMSDeviation = Math.round(Math.pow(deviationsSq/basalGlucose,0.5)*1000)/1000;
         consoleError('insulinPeakTime', dia, 'meanDeviation:', meanDeviation, 'SMRDeviation:', SMRDeviation, 'RMSDeviation:',RMSDeviation, '(mg/dL)');
@@ -150,6 +150,7 @@ function generate (inputs) {
             SMRDeviation: SMRDeviation,
             RMSDeviation: RMSDeviation,
         });
+        autotune_prep_output.diaDeviations = diaDeviations;
 
         deviations = Math.round(deviations*1000)/1000;
         if (deviations < minDeviations) {

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -51,23 +51,25 @@ function tuneAllTheThings (inputs) {
     // tune DIA
     var newDIA = DIA;
     if (diaDeviations) {
-        var currentDIADevSq = diaDeviations[2].devSquared;
-        //console.error(DIA,currentDIADevSq);
+        var currentDIAMeanDev = diaDeviations[2].meanDeviation;
+        //var currentDIAMeanDev = diaDeviations[2].RMSDeviation;
+        //var currentDIAMeanDev = diaDeviations[2].SMRDeviation;
+        //console.error(DIA,currentDIAMeanDev);
         var minDeviations = 1000000;
         var best = 2;
         for (var i=0; i < diaDeviations.length; i++) {
-            var deviations = diaDeviations[i].devSquared;
+            var deviations = diaDeviations[i].meanDeviation;
             if (deviations < minDeviations) {
                 minDeviations = Math.round(deviations*1000)/1000;
                 var best = i;
             }
         }
         if ( best < 2 ) {
-            if ( diaDeviations[1].devSquared < currentDIADevSq * 0.99 ) {
+            if ( diaDeviations[1].meanDeviation < currentDIAMeanDev * 0.99 ) {
                 newDIA = diaDeviations[1].dia;
             }
         } else if ( best > 2 ) {
-            if ( diaDeviations[3].devSquared < currentDIADevSq * 0.99 ) {
+            if ( diaDeviations[3].meanDeviation < currentDIAMeanDev * 0.99 ) {
                 newDIA = diaDeviations[3].dia;
             }
         }
@@ -83,23 +85,25 @@ function tuneAllTheThings (inputs) {
     // tune insulinPeakTime
     var newPeak = peak;
     if (peakDeviations) {
-        var currentPeakDevSq = peakDeviations[2].devSquared;
-        //console.error(currentPeakDevSq);
+        var currentPeakMeanDev = peakDeviations[2].meanDeviation;
+        //var currentPeakMeanDev = peakDeviations[2].RMSDeviation;
+        //var currentPeakMeanDev = peakDeviations[2].SMRDeviation;
+        //console.error(currentPeakMeanDev);
         var minDeviations = 1000000;
         var best = 2;
         for (var i=0; i < peakDeviations.length; i++) {
-            var deviations = peakDeviations[i].devSquared;
+            var deviations = peakDeviations[i].meanDeviation;
             if (deviations < minDeviations) {
                 minDeviations = Math.round(deviations*1000)/1000;
                 var best = i;
             }
         }
         if ( best < 2 ) {
-            if ( peakDeviations[1].devSquared < currentPeakDevSq * 0.99 ) {
+            if ( peakDeviations[1].meanDeviation < currentPeakMeanDev * 0.99 ) {
                 newPeak = peakDeviations[1].peak;
             }
         } else if ( best > 2 ) {
-            if ( peakDeviations[3].devSquared < currentPeakDevSq * 0.99 ) {
+            if ( peakDeviations[3].meanDeviation < currentPeakMeanDev * 0.99 ) {
                 newPeak = peakDeviations[3].peak;
             }
         }

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -87,6 +87,8 @@ function tuneAllTheThings (inputs) {
         }
         if ( newDIA != DIA ) {
             console.error("Adjusting insulinEndTime from",DIA,"to",newDIA,"hours");
+        } else {
+            console.error("Leaving insulinEndTime unchanged at",DIA);
         }
     }
 
@@ -112,8 +114,8 @@ function tuneAllTheThings (inputs) {
                 var RMSBest = i;
             }
         }
-        console.error("Best insulinPeakTime for meanDeviations:",peakDeviations[meanBest].peak,"hours");
-        console.error("Best insulinPeakTime for RMSDeviations:",peakDeviations[RMSBest].peak,"hours");
+        console.error("Best insulinPeakTime for meanDeviations:",peakDeviations[meanBest].peak,"minutes");
+        console.error("Best insulinPeakTime for RMSDeviations:",peakDeviations[RMSBest].peak,"minutes");
         if ( meanBest < 2 && RMSBest < 2 ) {
             if ( peakDeviations[1].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[1].RMSDeviation < currentDIARMSDev * 0.99 ) {
                 newPeak = peakDeviations[1].peak;
@@ -125,6 +127,8 @@ function tuneAllTheThings (inputs) {
         }
         if ( newPeak != peak ) {
             console.error("Adjusting insulinPeakTime from",peak,"to",newPeak,"minutes");
+        } else {
+            console.error("Leaving insulinPeakTime unchanged at",peak);
         }
     }
 

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -117,11 +117,11 @@ function tuneAllTheThings (inputs) {
         console.error("Best insulinPeakTime for meanDeviations:",peakDeviations[meanBest].peak,"minutes");
         console.error("Best insulinPeakTime for RMSDeviations:",peakDeviations[RMSBest].peak,"minutes");
         if ( meanBest < 2 && RMSBest < 2 ) {
-            if ( peakDeviations[1].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[1].RMSDeviation < currentDIARMSDev * 0.99 ) {
+            if ( peakDeviations[1].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[1].RMSDeviation < currentPeakRMSDev * 0.99 ) {
                 newPeak = peakDeviations[1].peak;
             }
         } else if ( meanBest > 2 ) {
-            if ( peakDeviations[3].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[3].RMSDeviation < currentDIARMSDev * 0.99 ) {
+            if ( peakDeviations[3].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[3].RMSDeviation < currentPeakRMSDev * 0.99 ) {
                 newPeak = peakDeviations[3].peak;
             }
         }

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -70,8 +70,8 @@ function tuneAllTheThings (inputs) {
                 var RMSBest = i;
             }
         }
-        console.error("Best insulinEndTime for meanDeviations:",meanBest,"hours");
-        console.error("Best insulinEndTime for RMSDeviations:",meanBest,"hours");
+        console.error("Best insulinEndTime for meanDeviations:",diaDeviations[meanBest].dia,"hours");
+        console.error("Best insulinEndTime for RMSDeviations:",diaDeviations[RMSBest].dia,"hours");
         if ( meanBest < 2 && RMSBest < 2 ) {
             if ( diaDeviations[1].meanDeviation < currentDIAMeanDev * 0.99 && diaDeviations[1].RMSDeviation < currentDIARMSDev * 0.99 ) {
                 newDIA = diaDeviations[1].dia;
@@ -112,6 +112,8 @@ function tuneAllTheThings (inputs) {
                 var RMSBest = i;
             }
         }
+        console.error("Best insulinPeakTime for meanDeviations:",peakDeviations[meanBest].peak,"hours");
+        console.error("Best insulinPeakTime for RMSDeviations:",peakDeviations[RMSBest].peak,"hours");
         if ( meanBest < 2 && RMSBest < 2 ) {
             if ( peakDeviations[1].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[1].RMSDeviation < currentDIARMSDev * 0.99 ) {
                 newPeak = peakDeviations[1].peak;

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -70,6 +70,8 @@ function tuneAllTheThings (inputs) {
                 var RMSBest = i;
             }
         }
+        console.error("Best insulinEndTime for meanDeviations:",meanBest,"hours");
+        console.error("Best insulinEndTime for RMSDeviations:",meanBest,"hours");
         if ( meanBest < 2 && RMSBest < 2 ) {
             if ( diaDeviations[1].meanDeviation < currentDIAMeanDev * 0.99 && diaDeviations[1].RMSDeviation < currentDIARMSDev * 0.99 ) {
                 newDIA = diaDeviations[1].dia;

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -52,24 +52,30 @@ function tuneAllTheThings (inputs) {
     var newDIA = DIA;
     if (diaDeviations) {
         var currentDIAMeanDev = diaDeviations[2].meanDeviation;
-        //var currentDIAMeanDev = diaDeviations[2].RMSDeviation;
-        //var currentDIAMeanDev = diaDeviations[2].SMRDeviation;
-        //console.error(DIA,currentDIAMeanDev);
-        var minDeviations = 1000000;
-        var best = 2;
+        var currentDIARMSDev = diaDeviations[2].RMSDeviation;
+        //console.error(DIA,currentDIAMeanDev,currentDIARMSDev);
+        var minMeanDeviations = 1000000;
+        var minRMSDeviations = 1000000;
+        var meanBest = 2;
+        var RMSBest = 2;
         for (var i=0; i < diaDeviations.length; i++) {
-            var deviations = diaDeviations[i].meanDeviation;
-            if (deviations < minDeviations) {
-                minDeviations = Math.round(deviations*1000)/1000;
-                var best = i;
+            var meanDeviations = diaDeviations[i].meanDeviation;
+            var RMSDeviations = diaDeviations[i].RMSDeviation;
+            if (meanDeviations < minMeanDeviations) {
+                minMeanDeviations = Math.round(meanDeviations*1000)/1000;
+                var meanBest = i;
+            }
+            if (RMSDeviations < minRMSDeviations) {
+                minRMSDeviations = Math.round(RMSDeviations*1000)/1000;
+                var RMSBest = i;
             }
         }
-        if ( best < 2 ) {
-            if ( diaDeviations[1].meanDeviation < currentDIAMeanDev * 0.99 ) {
+        if ( meanBest < 2 && RMSBest < 2 ) {
+            if ( diaDeviations[1].meanDeviation < currentDIAMeanDev * 0.99 && diaDeviations[1].RMSDeviation < currentDIARMSDev * 0.99 ) {
                 newDIA = diaDeviations[1].dia;
             }
-        } else if ( best > 2 ) {
-            if ( diaDeviations[3].meanDeviation < currentDIAMeanDev * 0.99 ) {
+        } else if ( meanBest > 2 && RMSBest > 2 ) {
+            if ( diaDeviations[3].meanDeviation < currentDIAMeanDev * 0.99 && diaDeviations[3].RMSDeviation < currentDIARMSDev * 0.99 ) {
                 newDIA = diaDeviations[3].dia;
             }
         }
@@ -86,24 +92,30 @@ function tuneAllTheThings (inputs) {
     var newPeak = peak;
     if (peakDeviations) {
         var currentPeakMeanDev = peakDeviations[2].meanDeviation;
-        //var currentPeakMeanDev = peakDeviations[2].RMSDeviation;
-        //var currentPeakMeanDev = peakDeviations[2].SMRDeviation;
+        var currentPeakRMSDev = peakDeviations[2].RMSDeviation;
         //console.error(currentPeakMeanDev);
-        var minDeviations = 1000000;
-        var best = 2;
+        var minMeanDeviations = 1000000;
+        var minRMSDeviations = 1000000;
+        var meanBest = 2;
+        var RMSBest = 2;
         for (var i=0; i < peakDeviations.length; i++) {
-            var deviations = peakDeviations[i].meanDeviation;
-            if (deviations < minDeviations) {
-                minDeviations = Math.round(deviations*1000)/1000;
-                var best = i;
+            var meanDeviations = peakDeviations[i].meanDeviation;
+            var RMSDeviations = peakDeviations[i].RMSDeviation;
+            if (meanDeviations < minMeanDeviations) {
+                minMeanDeviations = Math.round(meanDeviations*1000)/1000;
+                var meanBest = i;
+            }
+            if (RMSDeviations < minRMSDeviations) {
+                minRMSDeviations = Math.round(RMSDeviations*1000)/1000;
+                var RMSBest = i;
             }
         }
-        if ( best < 2 ) {
-            if ( peakDeviations[1].meanDeviation < currentPeakMeanDev * 0.99 ) {
+        if ( meanBest < 2 && RMSBest < 2 ) {
+            if ( peakDeviations[1].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[1].RMSDeviation < currentDIARMSDev * 0.99 ) {
                 newPeak = peakDeviations[1].peak;
             }
-        } else if ( best > 2 ) {
-            if ( peakDeviations[3].meanDeviation < currentPeakMeanDev * 0.99 ) {
+        } else if ( meanBest > 2 ) {
+            if ( peakDeviations[3].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[3].RMSDeviation < currentDIARMSDev * 0.99 ) {
                 newPeak = peakDeviations[3].peak;
             }
         }

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -120,7 +120,7 @@ function tuneAllTheThings (inputs) {
             if ( peakDeviations[1].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[1].RMSDeviation < currentPeakRMSDev * 0.99 ) {
                 newPeak = peakDeviations[1].peak;
             }
-        } else if ( meanBest > 2 ) {
+        } else if ( meanBest > 2 && RMSBest > 2 ) {
             if ( peakDeviations[3].meanDeviation < currentPeakMeanDev * 0.99 && peakDeviations[3].RMSDeviation < currentPeakRMSDev * 0.99 ) {
                 newPeak = peakDeviations[3].peak;
             }


### PR DESCRIPTION
Rather that just comparing the square of deviations, this PR modifies the insulinPeakTime and insulinEndTime tuning to use both the Root-Mean-Square Error/Deviation (RMSE) and Mean Absolute Error (MAE), and only adjusts peak/end time if both RMSE and MAE are in agreement as to which direction to tune.

Background on RMSE and MAE: https://medium.com/human-in-a-machine-world/mae-and-rmse-which-metric-is-better-e60ac3bde13d

RMSE is referred to in the code as RMSDeviation, and MAE as meanDeviation, as I picked those names before I realized that the statisticians had formal names of their own already.  :-)  There's also a Square-Mean-Root value that I calculate but don't currently use, as it seems to give the same answers as MAE.