### PR TITLE
Re-run apt-get update after dist-upgrade

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -28,7 +28,7 @@ dpkg-reconfigure tzdata
 #dpkg -P nodejs nodejs-dev
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
-apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate ntpdate
+apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate ntpdate
 #check if edison user exists before trying to add it to groups
 
 if  getent passwd edison > /dev/null; then


### PR DESCRIPTION
Fixes an issue where openaps-install.sh cannot find packages on the pi after running a dist-upgrade.