### PR TITLE
Stop cron during setup in 0.7.0-dev

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -556,6 +556,9 @@ echocolor -n "Continue? y/[N] "
 read -r
 if [[ $REPLY =~ ^[Yy]$ ]]; then
 
+    # Having the loop run in the background during setup slows things way down and lengthens the time before first loop
+    service cron stop
+
     # Attempting to remove git to make install --nogit by default for existing users
     echo Removing any existing git in $directory/.git
     rm -rf $directory/.git
@@ -1286,6 +1289,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     fi
 
 fi # from 'read -p "Continue? y/[N] " -r' after interactive setup is complete
+
+# Start cron back up in case the user doesn't decide to reboot
+service cron start
 
 if [ -e /tmp/reboot-required ]; then
   read -p "Reboot required.  Press enter to reboot or Ctrl-C to cancel"


### PR DESCRIPTION
Stops the cron service after the user agrees to run the setup process. Not as much on the Edison, but on the Pi Zero npm slows to a crawl while the loop is running, adding nearly 10 minutes to the setup process. At the end cron is started back up in case the user chooses not to restart immediately.