### PR TITLE
Install ntp daemon as used to set system and device clocks.

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -28,7 +28,7 @@ dpkg-reconfigure tzdata
 #dpkg -P nodejs nodejs-dev
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
-apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate ntpdate
+apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate ntpdate ntp
 #check if edison user exists before trying to add it to groups
 
 if  getent passwd edison > /dev/null; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oref0",
-  "version": "0.6.2-dev",
+  "version": "0.6.2",
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",

--- a/release-master.sh
+++ b/release-master.sh
@@ -1,8 +1,17 @@
-git checkout master && \
-git pull origin master && \
-npm version patch && \
-git tag -l && \
-echo Publishing in 10s: Ctrl-C to cancel && \
-sleep 10 && \
-npm publish && \
+#!/bin/bash
+
+# exit script immediately on any error
+set -eu
+
+git checkout master
+git pull origin master
+echo "New version to be published in npm:"
+npm version patch
+echo "Publishing in 60s: Ctrl-C to cancel"
+sleep 60
+echo "Running npm publish:"
+npm publish
+echo "Full list of git tags:"
+git tag -l
+echo "Pushing git tags to origin:"
 git push --tags origin master


### PR DESCRIPTION
I'm fairly confident `ntpdate` is not used and is not required, since it is [deprecated](http://support.ntp.org/bin/view/Dev/DeprecatingNtpdate), but I have not taken the time to test removing it.

The scripts for setting clocks use the ntp daemon and this PR installs it. Did a fresh install today and was required to install it manually (error about `/etc/init.d/ntp` not found.)

[oref0-set-system-clock.sh](https://github.com/openaps/oref0/blob/2be51a45950da2a68f46d72c528207e2915e934e/bin/oref0-set-system-clock.sh#L44)
[oref0-set-device-clocks.sh](https://github.com/openaps/oref0/blob/682d7f8d4f833d640cf89b9694e3c74ff9504cff/bin/oref0-set-device-clocks.sh#L44)

If someone else can validate `ntpdate` can be deleted, I can change that as well.