### PR TITLE
fix mdt-cgm.json

### DIFF
--- a/lib/oref0-setup/mdt-cgm.json
+++ b/lib/oref0-setup/mdt-cgm.json
@@ -101,5 +101,5 @@
       "json_default": "True"
     },
     "name": "nightscout/glucose.json"
-  },
+  }
 ]


### PR DESCRIPTION
Remove wrong trailing comma in mdt-cgm.json to make setup working again for MDT users.