### PR TITLE
JSON tester

### DIFF
--- a/tests/json-wf.sh
+++ b/tests/json-wf.sh
@@ -8,13 +8,11 @@ rc=0
 
 myloc=$(dirname ${0})
 
-cd ${myloc}/..
-
 red='\033[1;31m'
 green='\033[1;32m'
 nocolor='\033[0m'
 
-for jsonfile in $(find . -name '*.json'); do
+for jsonfile in $(find ${myloc}/.. -name '*.json'); do
   realfile=$(realpath ${jsonfile})
   jq . ${jsonfile} >/dev/null 2>/dev/null
   ret=$?

--- a/tests/json-wf.sh
+++ b/tests/json-wf.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# tests for json well-formedness by throwing each file through
+# jq, reporting state to the terminal with color and producing
+# an end return code suitable for CI
+
+rc=0
+
+myloc=$(dirname ${0})
+
+cd ${myloc}/..
+
+red='\033[1;31m'
+green='\033[1;32m'
+nocolor='\033[0m'
+
+for jsonfile in $(find . -name '*.json'); do
+  realfile=$(realpath ${jsonfile})
+  jq . ${jsonfile} >/dev/null 2>/dev/null
+  ret=$?
+  # accumulate failures
+  rc=$((rc|ret))
+  if [ ${ret} -eq 0 ]; then
+    echo -e "${green}${realfile}${nocolor}"
+  else
+    echo -e "${red}${realfile} ${rc}${nocolor}"
+  fi
+done
+
+exit ${rc}  


### PR DESCRIPTION
this adds a quick effective repo-scope JSON tester as a shell script in the `tests` directory (later leverage-able by CI)

monochrome doesn't really do it justice, but there are two files already not well-formed (...next PR), still detectable by the "4" in the line indicating the `jq` return code for not legit JSON, as well as an overall fail

```
$ tests/json-wf.sh  ; echo $?
/home/thecubic/code/oref0/lib/oref0-setup/device.json
/home/thecubic/code/oref0/lib/oref0-setup/dexcom.json
/home/thecubic/code/oref0/lib/oref0-setup/pancreoptions.json
/home/thecubic/code/oref0/lib/oref0-setup/shareble.json
/home/thecubic/code/oref0/lib/oref0-setup/supermicrobolus.json
/home/thecubic/code/oref0/lib/oref0-setup/vendor.json
/home/thecubic/code/oref0/lib/oref0-setup/basal_profile.json
/home/thecubic/code/oref0/lib/oref0-setup/report.json
/home/thecubic/code/oref0/lib/oref0-setup/settings.json
/home/thecubic/code/oref0/lib/oref0-setup/alias.json
/home/thecubic/code/oref0/lib/oref0-setup/autotune.json
/home/thecubic/code/oref0/lib/oref0-setup/cgm-loop.json
/home/thecubic/code/oref0/lib/oref0-setup/edisonbattery.json
/home/thecubic/code/oref0/lib/oref0-setup/mdt-cgm.json
/home/thecubic/code/oref0/lib/oref0-setup/xdrip-cgm.json
/home/thecubic/code/oref0/lib/oref0-setup/bg_targets_raw.json 4
/home/thecubic/code/oref0/lib/oref0-setup/pancreabble.json 4
/home/thecubic/code/oref0/package.json
4
```