### PR TITLE
Fix G4 w/ share crontab entry logic and other file existence adjustments

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -783,7 +783,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
                         echo "Latest version of bluez @ $(find $HOME/src -name "bluez-*" -type d | sort -rn | head -1) is missing or has extra copies of bluetoothd or bluetoothctl, unable to replace older binaries"
                     fi       
                 fi
-            done < <(find / \( -name "bluetoothctl" -o -name "bluetoothd" \) ! -path "*/src/bluez-*") # Find all locations with bluetoothctl or bluetoothd excluding directories with *bluez* in the path
+            done < <(find / \( -name "bluetoothctl" -o -name "bluetoothd" \) ! -path "*/src/bluez-*" ! -path "*.rootfs/*") # Find all locations with bluetoothctl or bluetoothd excluding directories with *bluez* in the path
             
             oref0-bluetoothup
         else

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1244,7 +1244,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         # add crontab entries
         (crontab -l; crontab -l | grep -q "NIGHTSCOUT_HOST" || echo NIGHTSCOUT_HOST=$NIGHTSCOUT_HOST) | crontab -
         (crontab -l; crontab -l | grep -q "API_SECRET=" || echo API_SECRET=$API_HASHED_SECRET) | crontab -
-        if validate_g4share_serial; then
+        if validate_g4share_serial $BLE_SERIAL; then
             (crontab -l; crontab -l | grep -q "DEXCOM_CGM_ID=" || echo DEXCOM_CGM_ID=$BLE_SERIAL) | crontab -
         fi
         (crontab -l; crontab -l | grep -q "PATH=" || echo "PATH=$PATH" ) | crontab -

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -791,9 +791,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
         fi
         echo Installing prerequisites and configs for local-only hotspot
         apt-get install -y hostapd dnsmasq || die "Couldn't install hostapd dnsmasq"
-        ls /etc/dnsmasq.conf.bak 2>/dev/null || mv /etc/dnsmasq.conf /etc/dnsmasq.conf.bak
+        test ! -f  /etc/dnsmasq.conf.bak && mv /etc/dnsmasq.conf /etc/dnsmasq.conf.bak
         cp $HOME/src/oref0/headless/dnsmasq.conf /etc/dnsmasq.conf || die "Couldn't copy dnsmasq.conf"
-        ls /etc/hostapd/hostapd.conf.bak 2>/dev/null || mv /etc/hostapd/hostapd.conf /etc/hostapd/hostapd.conf.bak
+        test ! -f  /etc/hostapd/hostapd.conf.bak && mv /etc/hostapd/hostapd.conf /etc/hostapd/hostapd.conf.bak
         cp $HOME/src/oref0/headless/hostapd.conf /etc/hostapd/hostapd.conf || die "Couldn't copy hostapd.conf"
         sed -i.bak -e "s|DAEMON_CONF=$|DAEMON_CONF=/etc/hostapd/hostapd.conf|g" /etc/init.d/hostapd
         cp $HOME/src/oref0/headless/interfaces.ap /etc/network/ || die "Couldn't copy interfaces.ap"
@@ -853,7 +853,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     # TODO: deprecate g4-upload and g4-local-only
     if [[ ${CGM,,} =~ "g4-upload" ]]; then
         mkdir -p $directory-cgm-loop
-        if ( cd $directory-cgm-loop && ls openaps.ini &>/dev/null && openaps use -h >/dev/null ); then
+        if ( cd $directory-cgm-loop && test -f openaps.ini && openaps use -h >/dev/null ); then
             echo $directory-cgm-loop already exists
         elif openaps init $directory-cgm-loop --nogit; then
             echo $directory-cgm-loop initialized


### PR DESCRIPTION
Provided the variable for the `validate_g4share_serial` to actually check... wasn't passing so g4-go loop wasn't working.

Changed `ls` commands to check for file existence to `test -f`