### PR TITLE
Reduce onbattery threshold, refresh data faster

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -68,6 +68,8 @@ main() {
                 fi
             fi
             touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
+	    # before each of these (optional) refresh checks, make sure we don't have fresh glucose data
+	    # if we do, then skip the optional checks to finish up this loop and start the next one
             if ! glucose-fresh; then
                 if onbattery; then
                     refresh_profile 30

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -74,8 +74,10 @@ main() {
                 else
                     refresh_profile 15
                 fi
-                pumphistory_daily_refresh
-                refresh_after_bolus_or_enact
+		if ! glucose-fresh; then
+		    pumphistory_daily_refresh
+                    refresh_after_bolus_or_enact
+		fi
             fi
             cat /tmp/oref0-updates.txt 2>&3
             touch /tmp/pump_loop_success

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -74,12 +74,12 @@ main() {
                 else
                     refresh_profile 15
                 fi
-		if ! glucose-fresh; then
-		    pumphistory_daily_refresh
-		    if ! glucose-fresh; then
+                if ! glucose-fresh; then
+                    pumphistory_daily_refresh
+                    if ! glucose-fresh; then
                         refresh_after_bolus_or_enact
                     fi
-		fi
+                fi
             fi
             cat /tmp/oref0-updates.txt 2>&3
             touch /tmp/pump_loop_success

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -76,7 +76,9 @@ main() {
                 fi
 		if ! glucose-fresh; then
 		    pumphistory_daily_refresh
-                    refresh_after_bolus_or_enact
+		    if ! glucose-fresh; then
+                        refresh_after_bolus_or_enact
+                    fi
 		fi
             fi
             cat /tmp/oref0-updates.txt 2>&3

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -68,8 +68,8 @@ main() {
                 fi
             fi
             touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
-	    # before each of these (optional) refresh checks, make sure we don't have fresh glucose data
-	    # if we do, then skip the optional checks to finish up this loop and start the next one
+            # before each of these (optional) refresh checks, make sure we don't have fresh glucose data
+            # if we do, then skip the optional checks to finish up this loop and start the next one
             if ! glucose-fresh; then
                 if onbattery; then
                     refresh_profile 30

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -74,10 +74,8 @@ main() {
                 else
                     refresh_profile 15
                 fi
-                if ! glucose-fresh; then
-                    pumphistory_daily_refresh
-                    refresh_after_bolus_or_enact
-                fi
+                pumphistory_daily_refresh
+                refresh_after_bolus_or_enact
             fi
             cat /tmp/oref0-updates.txt 2>&3
             touch /tmp/pump_loop_success

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -76,9 +76,7 @@ main() {
                 fi
                 if ! glucose-fresh; then
                     pumphistory_daily_refresh
-                    if ! glucose-fresh && ! onbattery; then
-                        refresh_after_bolus_or_enact
-                    fi
+                    refresh_after_bolus_or_enact
                 fi
             fi
             cat /tmp/oref0-updates.txt 2>&3
@@ -821,11 +819,11 @@ function refresh_profile {
 }
 
 function onbattery {
-    # check whether battery level is < 98%
+    # check whether battery level is < 90%
     if is_edison; then
-        jq --exit-status ".battery < 98 and (.battery > 70 or .battery < 60)" monitor/edison-battery.json >&4
+        jq --exit-status ".battery < 90 and (.battery > 70 or .battery < 60)" monitor/edison-battery.json >&4
     else
-        jq --exit-status ".battery < 98" monitor/edison-battery.json >&4
+        jq --exit-status ".battery < 90" monitor/edison-battery.json >&4
     fi
 }
 


### PR DESCRIPTION
 - Lowers the threshold used in `onbattery` to determine whether the device is plugged in to 90%
 - Removes a call to `onbattery` that causes Nightscout to be updated closer to real-time (and removes two therefore redundant if statements)