### PR TITLE
Fix nodejs-legacy breakage on latest raspbian

### DIFF
--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -3,7 +3,8 @@
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true install -y sudo
 sudo apt-get -o Acquire::ForceIPv4=true update && sudo apt-get -o Acquire::ForceIPv4=true -y upgrade
-sudo apt-get -o Acquire::ForceIPv4=true install -y git python python-dev software-properties-common python-numpy python-pip nodejs-legacy npm watchdog strace tcpdump screen acpid vim locate jq lm-sensors && \
+sudo apt-get -o Acquire::ForceIPv4=true install -y git python python-dev software-properties-common python-numpy python-pip npm watchdog strace tcpdump screen acpid vim locate jq lm-sensors && \
+if getent passwd edison > /dev/null; then sudo apt-get -o Acquire::ForceIPv4=true install -y nodejs-legacy; fi && \
 sudo pip install -U openaps && \
 sudo pip install -U openaps-contrib && \
 sudo openaps-install-udev-rules && \


### PR DESCRIPTION
The latest node-js for raspbian deprecates the use of nodejs-legacy, which breaks this script on new pi installs. This will make it so that nodejs-legacy is only installed on the edison.