### PR TITLE
Autotune: Properly parse AndroidAPS Temp Basal records

### DIFF
--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -289,7 +289,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             temp.date = temp.started_at.getTime();
             temp.insulin = current.insulin;
             tempBoluses.push(temp);
-        } else if (current.eventType == "Temp Basal" && current.enteredBy=="HAPP_App") {
+        } else if (current.eventType == "Temp Basal" && (current.enteredBy == "HAPP_App" || current.enteredBy == "openaps://AndroidAPS")) {
             var temp = {};
             temp.rate = current.absolute;
             temp.duration = current.duration;
@@ -357,6 +357,10 @@ function calcTempTreatments (inputs, zeroTempDuration) {
     for (var i=0; i+1 < tempHistory.length; i++) {
         if (tempHistory[i].date + tempHistory[i].duration*60*1000 > tempHistory[i+1].date) {
             tempHistory[i].duration = (tempHistory[i+1].date - tempHistory[i].date)/60/1000;
+            // Delete AndroidAPS "Cancel TBR records" in which duration is not populated
+            if (tempHistory[i+1].duration == null) {
+                tempHistory.splice(i+1, 1);
+            }
         }
     }
 


### PR DESCRIPTION
This change lets Autotune recognize Nightscout AndroidAPS Temp Basal records. It also addresses the way AndroidAPS cancels Temp Basals (by creating a record without duration and rate).

I have tested the changes with OpenAPS data (no change) and AndroidAPS data.

It does not address the following issues:
- Some pumps used with AndroidAPS create Temp Basal entries on a percentage basis instead of absolute values
- Autotune does not use AndroidAPS profile switches but makes its recommendations based on the profile used by OpenAPS

AndroidAPS Temp Basal entry (with Combo pump)
```
{ 
    "_id" : ObjectId("123456"), 
    "eventType" : "Temp Basal", 
    "duration" : NumberInt(15), 
    "absolute" : 0.48400000000000004, 
    "created_at" : "2018-01-20T02:33:56Z", 
    "enteredBy" : "openaps://AndroidAPS", 
    "NSCLIENT_ID" : 12345678.0
}
```
AndroidAPS Cancel TBR record
```
{ 
    "_id" : ObjectId("123457"), 
    "eventType" : "Temp Basal", 
    "created_at" : "2018-06-04T04:03:18Z", 
    "enteredBy" : "openaps://AndroidAPS", 
    "NSCLIENT_ID" : 12345678.0
}
```
