### PR TITLE
Fix not getting an IP on BT connection

### DIFF
--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -160,7 +160,8 @@ function bt_connect {
                 sudo bt-pan client $MAC -d
             for i in {1..3}
             do
-                sudo bt-pan client $MAC && sudo dhclient bnep0
+                sudo bt-pan client $MAC
+                sudo dhclient bnep0
             done
                 echo "...done."
             else


### PR DESCRIPTION
For some reason the ```&&``` appendage breaks the dhclient command for the `bnep0` interface while connected to wifi with the new wifi and bt-options

Splitting the commands out fixes it.....
