### PR TITLE
fix wait_for_bg with mdt

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -860,7 +860,7 @@ function onbattery {
 }
 
 function wait_for_bg {
-    if grep "MDT cgm" openaps.ini 2>&3 >&4; then
+    if [ "$(get_pref_string .cgm '')" == "mdt" ]; then
         echo "MDT CGM configured; not waiting"
     elif egrep -q "Warning:" enact/smb-suggested.json 2>&3; then
         echo "Retrying without waiting for new BG"


### PR DESCRIPTION
wait_for_bg was waiting even though mdt was configured. Old grep command wasn't working any more and was replaced by get_pref_string function.