### PR TITLE
Variable name typo'd in declaration

### DIFF
--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -3,7 +3,8 @@
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true install -y sudo
 sudo apt-get -o Acquire::ForceIPv4=true update && sudo apt-get -o Acquire::ForceIPv4=true -y upgrade
-sudo apt-get -o Acquire::ForceIPv4=true install -y git python python-dev software-properties-common python-numpy python-pip nodejs-legacy npm watchdog strace tcpdump screen acpid vim locate jq lm-sensors && \
+sudo apt-get -o Acquire::ForceIPv4=true install -y git python python-dev software-properties-common python-numpy python-pip npm watchdog strace tcpdump screen acpid vim locate jq lm-sensors && \
+if getent passwd edison > /dev/null; then sudo apt-get -o Acquire::ForceIPv4=true install -y nodejs-legacy; fi && \
 sudo pip install -U openaps && \
 sudo pip install -U openaps-contrib && \
 sudo openaps-install-udev-rules && \

--- a/lib/round-basal.js
+++ b/lib/round-basal.js
@@ -25,7 +25,7 @@ var round_basal = function round_basal(basal, profile) {
         }
     }
 
-    var rounded_result = basal;
+    var rounded_basal = basal;
     // Shouldn't need to check against 0 as pumps can't deliver negative basal anyway?
     if (basal < 1)
     {


### PR DESCRIPTION
`rounded_result` never used, `rounded_basal` never declared, conclude `rounded_result` must be a typo