### PR TITLE
Full pumphistory refresh after bolus/enact if no new BG yet

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -455,7 +455,7 @@ function refresh_after_bolus_or_enact {
         else
             # if we don't have a new BG waiting for us yet, do a full pumphistory refresh
             # to fix any race conditions introduced by incremental refreshes
-            read_full_pumphistory || return 1
+            retry_return read_full_pumphistory || return 1
         fi
         # TODO: check that last pumphistory record is newer than last bolus and refresh again if not
         calculate_iob && determine_basal 2>&3 \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -448,7 +448,13 @@ function refresh_after_bolus_or_enact {
         fi
         # refresh profile if >5m old to give SMB a chance to deliver
         refresh_profile 3
-        refresh_pumphistory_and_meal || return 1
+        if glucose-fresh; then
+            refresh_pumphistory_and_meal || return 1
+        else
+            # if we don't have a new BG waiting for us yet, do a full pumphistory refresh
+            # to fix any race conditions introduced by incremental refreshes
+            read_full_pumphistory || return 1
+        fi
         # TODO: check that last pumphistory record is newer than last bolus and refresh again if not
         calculate_iob && determine_basal 2>&3 \
         && cp -up enact/smb-suggested.json enact/suggested.json \


### PR DESCRIPTION
We've seen intermittent reports in Gitter of what looks like it might be a race condition around incremental pumphistory refreshes during bolus wizard events, which can cause the carb portion of the bolus wizard record to be recorded but not the insulin portion. This presents a safety issue, so to mitigate it this PR performs a full pumphistory refresh at the end of any loop where a bolus is delivered or a temp basal is set, and there's time before the next BG comes in and we need to start the next loop.  This should dramatically shrink the window in which a bad incremental pumphistory refresh could impact dosing decisions, without negatively impacting loop speed or reliability.