### PR TITLE
Fix cob.js Crash

### DIFF
--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -30,6 +30,12 @@ function detectCarbAbsorption(inputs) {
     bucketed_data[0] = glucose_data[0];
     j=0;
     var foundPreMealBG = false;
+    var lastbgi = 0;
+
+    if (! glucose_data[0].glucose || glucose_data[0].glucose < 39) {
+      lastbgi = -1;
+    }
+
     for (var i=1; i < glucose_data.length; ++i) {
         var bgTime;
         var lastbgTime;
@@ -40,13 +46,13 @@ function detectCarbAbsorption(inputs) {
         } else { console.error("Could not determine BG time"); }
         if (bucketed_data[bucketed_data.length-1].display_time) {
             lastbgTime = new Date(bucketed_data[bucketed_data.length-1].display_time.replace('T', ' '));
-        } else if (glucose_data[i-1].display_time) {
-            lastbgTime = new Date(glucose_data[i-1].display_time.replace('T', ' '));
-        } else if (glucose_data[i-1].dateString) {
-            lastbgTime = new Date(glucose_data[i-1].dateString);
+        } else if ((lastbgi >= 0) && glucose_data[lastbgi].display_time) {
+            lastbgTime = new Date(glucose_data[lastbgi].display_time.replace('T', ' '));
+        } else if ((lastbgi >= 0) && glucose_data[lastbgi].dateString) {
+            lastbgTime = new Date(glucose_data[lastbgi].dateString);
         } else { console.error("Could not determine last BG time"); }
-        if (! glucose_data[i].glucose || glucose_data[i].glucose < 39 || glucose_data[i-1].glucose < 39) {
-//console.error("skipping:",glucose_data[i].glucose,glucose_data[i-1].glucose);
+        if (! glucose_data[i].glucose || glucose_data[i].glucose < 39) {
+//console.error("skipping:",glucose_data[i].glucose);
             continue;
         }
         // only consider BGs for 6h after a meal for calculating COB
@@ -70,7 +76,7 @@ function detectCarbAbsorption(inputs) {
     //console.error(bgTime, lastbgTime, elapsed_minutes);
         if(Math.abs(elapsed_minutes) > 8) {
             // interpolate missing data points
-            lastbg = glucose_data[i-1].glucose;
+            lastbg = glucose_data[lastbgi].glucose;
             // cap interpolation at a maximum of 4h
             elapsed_minutes = Math.min(240,Math.abs(elapsed_minutes));
             //console.error(elapsed_minutes);
@@ -97,6 +103,8 @@ function detectCarbAbsorption(inputs) {
         } else {
             bucketed_data[j].glucose = (bucketed_data[j].glucose + glucose_data[i].glucose)/2;
         }
+
+        lastbgi = i;
         //console.error(bucketed_data[j].date)
     }
     var currentDeviation;

--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -44,13 +44,6 @@ function detectCarbAbsorption(inputs) {
         } else if (glucose_data[i].dateString) {
             bgTime = new Date(glucose_data[i].dateString);
         } else { console.error("Could not determine BG time"); }
-        if (bucketed_data[bucketed_data.length-1].display_time) {
-            lastbgTime = new Date(bucketed_data[bucketed_data.length-1].display_time.replace('T', ' '));
-        } else if ((lastbgi >= 0) && glucose_data[lastbgi].display_time) {
-            lastbgTime = new Date(glucose_data[lastbgi].display_time.replace('T', ' '));
-        } else if ((lastbgi >= 0) && glucose_data[lastbgi].dateString) {
-            lastbgTime = new Date(glucose_data[lastbgi].dateString);
-        } else { console.error("Could not determine last BG time"); }
         if (! glucose_data[i].glucose || glucose_data[i].glucose < 39) {
 //console.error("skipping:",glucose_data[i].glucose);
             continue;
@@ -72,6 +65,13 @@ function detectCarbAbsorption(inputs) {
                 continue;
             }
         }
+        if (bucketed_data[bucketed_data.length-1].display_time) {
+            lastbgTime = new Date(bucketed_data[bucketed_data.length-1].display_time.replace('T', ' '));
+        } else if ((lastbgi >= 0) && glucose_data[lastbgi].display_time) {
+            lastbgTime = new Date(glucose_data[lastbgi].display_time.replace('T', ' '));
+        } else if ((lastbgi >= 0) && glucose_data[lastbgi].dateString) {
+            lastbgTime = new Date(glucose_data[lastbgi].dateString);
+        } else { console.error("Could not determine last BG time"); }
         var elapsed_minutes = (bgTime - lastbgTime)/(60*1000);
     //console.error(bgTime, lastbgTime, elapsed_minutes);
         if(Math.abs(elapsed_minutes) > 8) {


### PR DESCRIPTION
Under certain circumstances when NS has glucose calibration records, cob.js will crash due to avgDelta being undefined.

This PR updates the logic to avoid avgDelta the error causing the crash.