### PR TITLE
Allow specifying another branch on the command line to openaps-install

### DIFF
--- a/bin/openaps-bootstrap.sh
+++ b/bin/openaps-bootstrap.sh
@@ -30,7 +30,8 @@ ifdown wlan0; ifup wlan0
 sleep 10
 echo -ne "\nWifi SSID: "; iwgetid -r
 sleep 5
-read -p "Enter the OREF0 branch name to install. default [master]" -r
+echo "Press Enter to continue installing the current release (master) of oref0,"
+read -p "or enter the oref0 branch name to install." -r
 BRANCH=${REPLY:-master}
 curl https://raw.githubusercontent.com/openaps/oref0/$BRANCH/bin/openaps-install.sh > /tmp/openaps-install.sh $BRANCH
 bash /tmp/openaps-install.sh

--- a/bin/openaps-bootstrap.sh
+++ b/bin/openaps-bootstrap.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 (
+BRANCH=master
 dmesg -D
 echo Scanning for wifi networks:
 ifup wlan0
@@ -29,6 +30,8 @@ ifdown wlan0; ifup wlan0
 sleep 10
 echo -ne "\nWifi SSID: "; iwgetid -r
 sleep 5
-curl https://raw.githubusercontent.com/openaps/oref0/master/bin/openaps-install.sh > /tmp/openaps-install.sh
+read -p "Enter the OREF0 branch name to install. default [master]" -r
+BRANCH=${REPLY:-master}
+curl https://raw.githubusercontent.com/openaps/oref0/$BRANCH/bin/openaps-install.sh > /tmp/openaps-install.sh $BRANCH
 bash /tmp/openaps-install.sh
 )

--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+BRANCH=${1:-master}
 read -p "Enter your rig's new hostname (this will be your rig's "name" in the future, so make sure to write it down): " -r
 myrighostname=$REPLY
 echo $myrighostname > /etc/hostname
@@ -43,8 +44,8 @@ fi
 sed -i "s/daily/hourly/g" /etc/logrotate.conf
 sed -i "s/#compress/compress/g" /etc/logrotate.conf
 
-curl -s https://raw.githubusercontent.com/openaps/oref0/master/bin/openaps-packages.sh | bash -
-mkdir -p ~/src; cd ~/src && git clone git://github.com/openaps/oref0.git || (cd oref0 && git checkout master && git pull)
-echo "Press Enter to run oref0-setup with the current release (master branch) of oref0,"
+curl -s https://raw.githubusercontent.com/openaps/oref0/$BRANCH/bin/openaps-packages.sh | bash -
+mkdir -p ~/src; cd ~/src && git clone git://github.com/openaps/oref0.git || (cd oref0 && git checkout $BRANCH && git pull)
+echo "Press Enter to run oref0-setup with the current release ($BRANCH branch) of oref0,"
 read -p "or press ctrl-c to cancel. " -r
 cd && ~/src/oref0/bin/oref0-setup.sh


### PR DESCRIPTION
I haven't tested this, but i think it should work. 
It will allow testing `openaps-packages.sh` from a different branch and also automatically do the fresh install from a different branch than master.