### PR TITLE
Split the pre-bolus ESC key presses in two commands.

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -425,7 +425,7 @@ function smb_bolus {
         echo -n "Sending ESC ESC ESC ESC to exit any open menus before SMBing "
         try_return mdt -f internal button esc 2>&3 \
         && sleep 0.5s \  
-        && try_return mdt -f internal button esc esc esc 2>&3 \
+        && try_return mdt -f internal button esc esc esc esc 2>&3 \
         && echo -n "and bolusing " && jq .units enact/smb-suggested.json | nonl && echo " units" \
         && ( try_return mdt bolus enact/smb-suggested.json 2>&3 && jq '.  + {"received": true}' enact/smb-suggested.json > enact/bolused.json ) \
         && rm -rf enact/smb-suggested.json

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -423,8 +423,8 @@ function smb_bolus {
     && if (grep -q '"units":' enact/smb-suggested.json 2>&3); then
         # press ESC four times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
         echo -n "Sending ESC ESC ESC ESC to exit any open menus before SMBing "
-        try_return mdt -f internal button esc 2>&3 \
-        && sleep 0.5s \  
+        try_return mdt -f internal button esc esc 2>&3 \
+        && sleep 0.5s \
         && try_return mdt -f internal button esc esc esc esc 2>&3 \
         && echo -n "and bolusing " && jq .units enact/smb-suggested.json | nonl && echo " units" \
         && ( try_return mdt bolus enact/smb-suggested.json 2>&3 && jq '.  + {"received": true}' enact/smb-suggested.json > enact/bolused.json ) \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -422,7 +422,7 @@ function smb_bolus {
     file_is_recent enact/smb-suggested.json \
     && if (grep -q '"units":' enact/smb-suggested.json 2>&3); then
         # press ESC four times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
-        echo -n "Sending ESC ESC ESC ESC to exit any open menus before SMBing "
+        echo -n "Sending ESC ESC, ESC ESC ESC ESC to exit any open menus before SMBing "
         try_return mdt -f internal button esc esc 2>&3 \
         && sleep 0.5s \
         && try_return mdt -f internal button esc esc esc esc 2>&3 \

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -423,7 +423,9 @@ function smb_bolus {
     && if (grep -q '"units":' enact/smb-suggested.json 2>&3); then
         # press ESC four times on the pump to exit Bolus Wizard before SMBing, to help prevent A52 errors
         echo -n "Sending ESC ESC ESC ESC to exit any open menus before SMBing "
-        try_return mdt -f internal button esc esc esc esc 2>&3 \
+        try_return mdt -f internal button esc 2>&3 \
+        && sleep 0.5s \  
+        && try_return mdt -f internal button esc esc esc 2>&3 \
         && echo -n "and bolusing " && jq .units enact/smb-suggested.json | nonl && echo " units" \
         && ( try_return mdt bolus enact/smb-suggested.json 2>&3 && jq '.  + {"received": true}' enact/smb-suggested.json > enact/bolused.json ) \
         && rm -rf enact/smb-suggested.json


### PR DESCRIPTION
The 4 ESC seems to be done too quickly now that we moved to the go library.
It seems like it isn't as good at avoiding A52 errors as what
was done on master. I think on master the pump is wakened up again between
each key presses, or the python layer adds some latency which isn't
there on the new version.

The compromise here is to send the first ESC, wait for 0.5s before sending the
remaining ESC. From testing on a test pump, this seems to reduce the
chance of getting an A52 error. 