### PR TITLE
Fix Stale Autotune Profile

### DIFF
--- a/bin/oref0-autotune-core.js
+++ b/bin/oref0-autotune-core.js
@@ -26,6 +26,12 @@ var stringify = require('json-stable-stringify');
 if (!module.parent) {
     var argv = require('yargs')
         .usage("$0 [--tune-insulin-curve] <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>")
+        .option('tune-insulin-curve', {
+          alias: 't',
+          describe: "Tune insulin curve",
+          boolean: true,
+          default: false
+        })
         .demand(3)
         .strict(true)
         .help('help');

--- a/bin/oref0-autotune-core.js
+++ b/bin/oref0-autotune-core.js
@@ -25,7 +25,7 @@ var stringify = require('json-stable-stringify');
 
 if (!module.parent) {
     var argv = require('yargs')
-        .usage("$0 <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>")
+        .usage("$0 [--tune-insulin-curve] <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>")
         .demand(3)
         .strict(true)
         .help('help');
@@ -45,6 +45,12 @@ if (!module.parent) {
     } catch (e) {
         console.log('{ "error": "Could not parse input data" }');
         return console.error("Could not parse input data: ", e);
+    }
+
+    // if not tuning the insulinEndTime and insulinPeakTime, then use data from pump profile
+    if (!params["tune-insulin-curve"]) {
+      previous_autotune_data.dia = pumpprofile_data.dia;
+      previous_autotune_data.insulinPeakTime = pumpprofile_data.insulinPeakTime;
     }
 
     var inputs = {

--- a/bin/oref0-autotune-core.js
+++ b/bin/oref0-autotune-core.js
@@ -25,13 +25,7 @@ var stringify = require('json-stable-stringify');
 
 if (!module.parent) {
     var argv = require('yargs')
-        .usage("$0 [--tune-insulin-curve] <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>")
-        .option('tune-insulin-curve', {
-          alias: 't',
-          describe: "Tune insulin curve",
-          boolean: true,
-          default: false
-        })
+        .usage("$0 <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>")
         .demand(3)
         .strict(true)
         .help('help');
@@ -53,8 +47,10 @@ if (!module.parent) {
         return console.error("Could not parse input data: ", e);
     }
 
-    // if not tuning the insulinEndTime and insulinPeakTime, then use data from pump profile
-    if (!params["tune-insulin-curve"]) {
+    // Pump profile has an up to date copy of useCustomPeakTime from preferences
+    // If the preferences file has useCustomPeakTime use the previous autotune dia and PeakTime.
+    // Otherwise, use data from pump profile.
+    if (!pumpprofile_data.useCustomPeakTime) {
       previous_autotune_data.dia = pumpprofile_data.dia;
       previous_autotune_data.insulinPeakTime = pumpprofile_data.insulinPeakTime;
     }

--- a/bin/oref0-autotune-core.js
+++ b/bin/oref0-autotune-core.js
@@ -27,12 +27,6 @@ if (!module.parent) {
     var argv = require('yargs')
         .usage("$0 <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>")
         .demand(3)
-        .option('uploader', {
-            alias: 'u',
-            nargs: 1,
-            describe: "Uploader battery status",
-            default: false
-        })
         .strict(true)
         .help('help');
 

--- a/bin/oref0-autotune-core.js
+++ b/bin/oref0-autotune-core.js
@@ -27,6 +27,12 @@ if (!module.parent) {
     var argv = require('yargs')
         .usage("$0 <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>")
         .demand(3)
+        .option('uploader', {
+            alias: 'u',
+            nargs: 1,
+            describe: "Uploader battery status",
+            default: false
+        })
         .strict(true)
         .help('help');
 

--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -84,6 +84,15 @@ if (!module.parent) {
         }
     }
 
+    // get insulin curve from pump profile that is maintained
+    profile_data.curve = pumpprofile_data.curve;
+
+    // if not tuning the insulinEndTime and insulinPeakTime, then use data from pump profile
+    if (!tune_insulin_curve) {
+      profile_data.dia = pumpprofile_data.dia;
+      profile_data.insulinPeakTime = pumpprofile_data.insulinPeakTime;
+    }
+
     try {
         var glucose_data = JSON.parse(fs.readFileSync(glucose_input, 'utf8'));
     } catch (e) {

--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -87,8 +87,10 @@ if (!module.parent) {
     // get insulin curve from pump profile that is maintained
     profile_data.curve = pumpprofile_data.curve;
 
-    // if not tuning the insulinEndTime and insulinPeakTime, then use data from pump profile
-    if (!params['tune-insulin-curve']) {
+    // Pump profile has an up to date copy of useCustomPeakTime from preferences
+    // If the preferences file has useCustomPeakTime use the previous autotune dia and PeakTime.
+    // Otherwise, use data from pump profile.
+    if (!pumpprofile_data.useCustomPeakTime) {
       profile_data.dia = pumpprofile_data.dia;
       profile_data.insulinPeakTime = pumpprofile_data.insulinPeakTime;
     }

--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -88,7 +88,7 @@ if (!module.parent) {
     profile_data.curve = pumpprofile_data.curve;
 
     // if not tuning the insulinEndTime and insulinPeakTime, then use data from pump profile
-    if (!tune_insulin_curve) {
+    if (!params['tune-insulin-curve']) {
       profile_data.dia = pumpprofile_data.dia;
       profile_data.insulinPeakTime = pumpprofile_data.insulinPeakTime;
     }

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -241,7 +241,7 @@ do
     
     # Autotune  (required args, <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>), 
     # output autotuned profile or what will be used as <autotune/autotune.json> in the next iteration
-    echo "oref0-autotune-core autotune.$i.json profile.json profile.pump.json > newprofile.$i.json"
+    echo "oref0-autotune-core $TUNE_INSULIN_CURVE_OPT autotune.$i.json profile.json profile.pump.json > newprofile.$i.json"
     if ! oref0-autotune-core $TUNE_INSULIN_CURVE_OPT autotune.$i.json profile.json profile.pump.json > newprofile.$i.json; then
         if cat profile.json | jq --exit-status .carb_ratio==null; then
             echo "ERROR: profile.json contains null carb_ratio: using profile.pump.json"

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -242,7 +242,7 @@ do
     # Autotune  (required args, <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>), 
     # output autotuned profile or what will be used as <autotune/autotune.json> in the next iteration
     echo "oref0-autotune-core autotune.$i.json profile.json profile.pump.json > newprofile.$i.json"
-    if ! oref0-autotune-core autotune.$i.json profile.json profile.pump.json > newprofile.$i.json; then
+    if ! oref0-autotune-core $TUNE_INSULIN_CURVE_OPT autotune.$i.json profile.json profile.pump.json > newprofile.$i.json; then
         if cat profile.json | jq --exit-status .carb_ratio==null; then
             echo "ERROR: profile.json contains null carb_ratio: using profile.pump.json"
             cp profile.pump.json profile.json

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -241,8 +241,8 @@ do
     
     # Autotune  (required args, <autotune/glucose.json> <autotune/autotune.json> <settings/profile.json>), 
     # output autotuned profile or what will be used as <autotune/autotune.json> in the next iteration
-    echo "oref0-autotune-core $TUNE_INSULIN_CURVE_OPT autotune.$i.json profile.json profile.pump.json > newprofile.$i.json"
-    if ! oref0-autotune-core $TUNE_INSULIN_CURVE_OPT autotune.$i.json profile.json profile.pump.json > newprofile.$i.json; then
+    echo "oref0-autotune-core autotune.$i.json profile.json profile.pump.json > newprofile.$i.json"
+    if ! oref0-autotune-core autotune.$i.json profile.json profile.pump.json > newprofile.$i.json; then
         if cat profile.json | jq --exit-status .carb_ratio==null; then
             echo "ERROR: profile.json contains null carb_ratio: using profile.pump.json"
             cp profile.pump.json profile.json

--- a/tests/command-behavior.tests.sh
+++ b/tests/command-behavior.tests.sh
@@ -111,17 +111,6 @@ test-autotune-core () {
     cat stderr_output | grep -q CRTotalCarbs || fail_test "oref0-autotune-core didn't contain expected stderr output"
 
     # Make sure output has accurate carb ratio data
-    cat stdout_output | jq .dia | grep -q 8 || fail_test "oref0-autotune-core didn't contain expected dia output"
-    cat stdout_output | jq .insulinPeakTime | grep -q 90 || fail_test "oref0-autotune-core didn't contain expected insulinPeakTime output"
-
-    # Run autotune-core and capture output
-    ../bin/oref0-autotune-core.js --tune-insulin-curve autotune.data.json profile.json pumpprofile.json 2>stderr_output 1>stdout_output
-
-    ERROR_LINE_COUNT=$( cat stderr_output | wc -l )
-    ERROR_LINES=$( cat stderr_output )
-    cat stderr_output | grep -q CRTotalCarbs || fail_test "oref0-autotune-core didn't contain expected stderr output"
-
-    # Make sure output has accurate carb ratio data
     cat stdout_output | jq .dia | grep -q 7 || fail_test "oref0-autotune-core didn't contain expected dia output"
     cat stdout_output | jq .insulinPeakTime | grep -q 85 || fail_test "oref0-autotune-core didn't contain expected insulinPeakTime output"
 

--- a/tests/command-behavior.tests.sh
+++ b/tests/command-behavior.tests.sh
@@ -104,14 +104,26 @@ test-ns-status () {
 
 test-autotune-core () {
     # Run autotune-core and capture output
-    ../bin/oref0-autotune-core.js autotune.data.json profile.json profile.json 2>stderr_output 1>stdout_output
+    ../bin/oref0-autotune-core.js autotune.data.json profile.json pumpprofile.json 2>stderr_output 1>stdout_output
 
     ERROR_LINE_COUNT=$( cat stderr_output | wc -l )
     ERROR_LINES=$( cat stderr_output )
     cat stderr_output | grep -q CRTotalCarbs || fail_test "oref0-autotune-core didn't contain expected stderr output"
 
     # Make sure output has accurate carb ratio data
-    cat stdout_output | jq .carb_ratio | grep -q 22.142 || fail_test "oref0-autotune-core didn't contain expected carb_ratio output"
+    cat stdout_output | jq .dia | grep -q 8 || fail_test "oref0-autotune-core didn't contain expected dia output"
+    cat stdout_output | jq .insulinPeakTime | grep -q 90 || fail_test "oref0-autotune-core didn't contain expected insulinPeakTime output"
+
+    # Run autotune-core and capture output
+    ../bin/oref0-autotune-core.js --tune-insulin-curve autotune.data.json profile.json pumpprofile.json 2>stderr_output 1>stdout_output
+
+    ERROR_LINE_COUNT=$( cat stderr_output | wc -l )
+    ERROR_LINES=$( cat stderr_output )
+    cat stderr_output | grep -q CRTotalCarbs || fail_test "oref0-autotune-core didn't contain expected stderr output"
+
+    # Make sure output has accurate carb ratio data
+    cat stdout_output | jq .dia | grep -q 7 || fail_test "oref0-autotune-core didn't contain expected dia output"
+    cat stdout_output | jq .insulinPeakTime | grep -q 85 || fail_test "oref0-autotune-core didn't contain expected insulinPeakTime output"
 
     # If we made it here, the test passed
     echo "oref0-autotune-core test passed"
@@ -543,6 +555,111 @@ EOT
    "half_basal_exercise_target": 160,
    "high_temptarget_raises_sensitivity": false,
    "insulinPeakTime": 85,
+   "isfProfile": {
+      "first": 1,
+      "sensitivities": [
+         {
+            "endOffset": 1440,
+            "i": 0,
+            "offset": 0,
+            "sensitivity": 100,
+            "start": "00:00:00",
+            "x": 0
+         }
+      ],
+      "units": "mg/dL",
+      "user_preferred_units": "mg/dL"
+   },
+   "low_temptarget_lowers_sensitivity": false,
+   "maxCOB": 120,
+   "maxSMBBasalMinutes": 30,
+   "max_basal": 2.8,
+   "max_bg": 110,
+   "max_daily_basal": 0.75,
+   "max_daily_safety_multiplier": 3,
+   "max_iob": 7,
+   "min_5m_carbimpact": 8,
+   "min_bg": 110,
+   "model": "723",
+   "offline_hotspot": false,
+   "out_units": "mg/dL",
+   "remainingCarbsCap": 90,
+   "remainingCarbsFraction": 1,
+   "resistance_lowers_target": false,
+   "rewind_resets_autosens": true,
+   "sens": 100,
+   "sensitivity_raises_target": true,
+   "suspend_zeros_iob": true,
+   "unsuspend_if_no_temp": false,
+   "useCustomPeakTime": true,
+   "wide_bg_target_range": false
+}
+EOT
+
+    # Make a dummy pumpprofile.json
+    cat >pumpprofile.json <<EOT
+{
+   "A52_risk_enable": false,
+   "adv_target_adjustments": false,
+   "allowSMB_with_high_temptarget": false,
+   "autosens_max": 1.2,
+   "autosens_min": 0.8,
+   "autotune_isf_adjustmentFraction": 0,
+   "basalprofile": [
+      {
+         "i": 0,
+         "minutes": 0,
+         "rate": 0.63,
+         "start": "00:00:00"
+      }
+   ],
+   "bg_targets": {
+      "first": 0,
+      "targets": [
+         {
+            "high": 110,
+            "i": 0,
+            "low": 110,
+            "max_bg": 110,
+            "min_bg": 110,
+            "offset": 0,
+            "start": "00:00:00",
+            "x": 0
+         }
+      ],
+      "units": "mg/dL",
+      "user_preferred_units": "mg/dL"
+   },
+   "bolussnooze_dia_divisor": 2,
+   "carb_ratio": 22.142,
+   "carb_ratios": {
+      "first": 1,
+      "schedule": [
+         {
+            "i": 0,
+            "offset": 0,
+            "ratio": 20,
+            "start": "00:00:00",
+            "x": 0
+         }
+      ],
+      "units": "grams"
+   },
+   "carbsReqThreshold": 1,
+   "csf": 3.815,
+   "current_basal": 0.65,
+   "current_basal_safety_multiplier": 4,
+   "curve": "rapid-acting",
+   "dia": 8,
+   "enableSMB_after_carbs": false,
+   "enableSMB_always": true,
+   "enableSMB_with_COB": true,
+   "enableSMB_with_temptarget": true,
+   "enableUAM": true,
+   "exercise_mode": false,
+   "half_basal_exercise_target": 160,
+   "high_temptarget_raises_sensitivity": false,
+   "insulinPeakTime": 90,
    "isfProfile": {
       "first": 1,
       "sensitivities": [


### PR DESCRIPTION
This is an attempt to address #1093.

Having tested Fiasp a couple of weeks ago, we noticed the same behavior.

This uses the pump profile to keep curve, dia, and peak up to date.