### PR TITLE
Use status.sh instead of status.js, if possible

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -97,7 +97,10 @@ main() {
 
 function update_display {
     # TODO: install this globally
-    if [ -e /root/src/openaps-menu/scripts/status.js ]; then
+    if [ -e /root/src/openaps-menu/scripts/status.sh ]; then
+        /root/src/openaps-menu/scripts/status.sh
+    elif [ -e /root/src/openaps-menu/scripts/status.js ]; then
+        echo "Updating HAT Display..."
         node /root/src/openaps-menu/scripts/status.js
     fi
 }


### PR DESCRIPTION
The next version of openaps-menu will use a socket server interface for external control of the display, so we don't need to call status.js if the user has the new interface script (status.sh).