### PR TITLE
Stop local go binaries before overwriting. Fixes #1049.

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -258,8 +258,7 @@ function add_to_crontab () {
 function request_stop_local_binary () {
     if [[ -x /usr/local/bin/$1 ]]; then
         if pgrep -x $1 > /dev/null; then
-            read -p "Need to stop $1 to complete installation. OK? [Y]N" -r
-            if [[ $REPLY =~ ^[^Nn]*$ ]]; then
+            if prompt_yn "Need to stop $1 to complete installation. OK?" y; then
                 pgrep -x $1 | xargs kill
             fi
         fi

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -255,6 +255,32 @@ function add_to_crontab () {
     (crontab -l; crontab -l |grep -q "$1" || echo "$2" "$3") | crontab -
 }
 
+function request_stop_local_binary () {
+    if [[ -x /usr/local/bin/$1 ]]; then
+        if pgrep -x $1 > /dev/null; then
+            read -p "Need to stop $1 to complete installation. OK? [Y]N" -r
+            if [[ $REPLY =~ ^[^Nn]*$ ]]; then
+                pgrep -x $1 | xargs kill
+            fi
+        fi
+    fi
+}
+
+function copy_go_binaries () {
+    for gobinary in $HOME/go/bin/*; do
+        request_stop_local_binary `basename $gobinary`
+    done
+    request_stop_local_binary Go-mmtune
+
+    cp -pruv $HOME/go/bin/* /usr/local/bin/ || die "Couldn't copy go/bin"
+}
+
+function move_mmtune () {
+    request_stop_local_binary Go-mmtune
+    mv /usr/local/bin/mmtune /usr/local/bin/Go-mmtune || die "Couldn't mv mmtune"
+}
+
+
 if ! validate_cgm "${CGM}"; then
     DIR="" # to force a Usage prompt
 fi
@@ -348,14 +374,14 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
         buildgofromsource=true
         echo "Building Go pump binaries from source"
         buildgofromsource=true
-        read -p "What type of radio do you use? [1] for cc1101 [2] for CC1110 or CC1111 [3] for RFM69HCW radio module 1/[2]/3 " -r 
+        read -p "What type of radio do you use? [1] for cc1101 [2] for CC1110 or CC1111 [3] for RFM69HCW radio module 1/[2]/3 " -r
         if [[ $REPLY =~ ^[1]$ ]]; then
           radiotags="cc1101"
         elif [[ $REPLY =~ ^[2]$ ]]; then
           radiotags="cc111x"
         elif [[ $REPLY =~ ^[3]$ ]]; then
           radiotags="rfm69"
-        else 
+        else
           radiotags="cc111x"
         fi
         echo "Building Go pump binaries from source with " + radiotags + " tags."
@@ -655,7 +681,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     if [[ ${CGM,,} =~ "xdrip" || ${CGM,,} =~ "xdrip-js" ]]; then
         mkdir -p xdrip || die "Can't mkdir xdrip"
     fi
-    
+
     # check whether decocare-0.0.31 has been installed
     #if ! ls /usr/local/lib/python2.7/dist-packages/decocare-0.0.31-py2.7.egg/ 2>/dev/null >/dev/null; then
         # install decocare with setuptools since 0.0.31 (with the 6.4U/h fix) isn't published properly to pypi
@@ -675,7 +701,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     #echo Installing decocare 0.1.0-dev
     #cd $HOME/src/decocare
     #sudo python setup.py develop || die "Couldn't install decocare 0.1.0-dev"
-	
+
     if [ -d "$HOME/src/oref0/" ]; then
         echo "$HOME/src/oref0/ already exists; pulling latest"
         (cd $HOME/src/oref0 && git fetch && git pull) || die "Couldn't pull latest oref0"
@@ -744,7 +770,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     #if [[ ! -z "$DEXCOM_CGM_TX_ID" ]]; then
         #set_pref_string .dexcom_cgm_tx_id "$DEXCOM_CGM_TX_ID"
     #fi
-    
+
     cat preferences.json
 
     # fix log rotate file
@@ -757,7 +783,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     sudo cp $HOME/src/oref0/logrotate.rsyslog /etc/logrotate.d/rsyslog || die "Could not cp /etc/logrotate.d/rsyslog"
 
     test -d /var/log/openaps || sudo mkdir /var/log/openaps && sudo chown $USER /var/log/openaps || die "Could not create /var/log/openaps"
-    
+
     if [[ -f /etc/cron.daily/logrotate ]]; then
         mv -f /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
     fi
@@ -830,21 +856,21 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             killall bluetoothd &>/dev/null #Kill current running version if its out of date and we are updating it
             sudo cp ./src/bluetoothd /usr/local/bin/ || die "Couldn't install bluez"
             sudo apt-get install bluez-tools
-            
+
             # Replace all other instances of bluetoothd and bluetoothctl to make sure we are always using the self-compiled version
-            while IFS= read -r bt_location; do 
+            while IFS= read -r bt_location; do
                 if [[ $($bt_location -v|awk -F': ' '{print ($NF < 5.48)?1:0}') -eq 1 ]]; then
                     # Find latest version of bluez under $HOME/src and copy it to locations which have a version of bluetoothd/bluetoothctl < 5.48
                     if [[ $(find $(find $HOME/src -name "bluez-*" -type d | sort -rn | head -1) -name bluetoothd -o -name bluetoothctl | wc -l) -eq 2 ]]; then
                         killall $(basename $bt_location) &>/dev/null #Kill current running version if its out of date and we are updating it
                         sudo cp -p $(find $(find $HOME/src -name "bluez-*" -type d | sort -rn | head -1) -name $(basename $bt_location)) $bt_location || die "Couldn't replace $(basename $bt_location) in $(dirname $bt_location)"
                         touch /tmp/reboot-required
-                    else 
+                    else
                         echo "Latest version of bluez @ $(find $HOME/src -name "bluez-*" -type d | sort -rn | head -1) is missing or has extra copies of bluetoothd or bluetoothctl, unable to replace older binaries"
-                    fi       
+                    fi
                 fi
             done < <(find / \( -name "bluetoothctl" -o -name "bluetoothd" \) ! -path "*/src/bluez-*" ! -path "*.rootfs/*") # Find all locations with bluetoothctl or bluetoothd excluding directories with *bluez* in the path
-            
+
             oref0-bluetoothup
         else
             echo bluez version ${bluetoothdversion} already installed
@@ -1175,7 +1201,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     echo "export DEXCOM_CGM_RECV_ID" >> $HOME/.bash_profile
     #echo DEXCOM_CGM_TX_ID="$DEXCOM_CGM_TX_ID" >> $HOME/.bash_profile
     #echo "export DEXCOM_CGM_TX_ID" >> $HOME/.bash_profile
-    echo 
+    echo
 
     echo
 
@@ -1253,8 +1279,6 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
           #cd ../mmtune && go install -tags cc111x || die "Couldn't go install mmtune"
           #cd ../pumphistory && go install -tags cc111x || die "Couldn't go install pumphistory"
           #cd ../listen && go install -tags cc111x || die "Couldn't go install listen"
-          cp -pruv $HOME/go/bin/* /usr/local/bin/ || die "Couldn't copy go/bin"
-          mv /usr/local/bin/mmtune /usr/local/bin/Go-mmtune || die "Couldn't mv mmtune"
           ln -sf $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq $directory/ || die "Couldn't softlink openaps.jq"
         else
           arch=arm-spi
@@ -1268,9 +1292,10 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
           wget -qO- $downloadUrl | tar xJv -C $HOME/go/bin || die "Couldn't download and extract Go pump binaries"
           echo "Installing Go pump binaries ..."
           ln -sf $HOME/go/bin/openaps.jq $directory/ || die "Couldn't softlink openaps.jq"
-          cp -pruv $HOME/go/bin/* /usr/local/bin/ || die "Couldn't copy go/bin"
-          mv /usr/local/bin/mmtune /usr/local/bin/Go-mmtune || die "Couldn't mv mmtune"
         fi
+
+        copy_go_binaries
+        move_mmtune
     fi
     if [[ ${CGM,,} =~ "g4-go" ]]; then
         if [ ! -d $HOME/go/bin ]; then mkdir -p $HOME/go/bin; fi
@@ -1291,8 +1316,9 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
             echo "Downloading Go dexcom binaries from:" $downloadUrl
             wget -qO- $downloadUrl | tar xJv -C $HOME/go/bin || die "Couldn't download and extract Go dexcom binaries"
         fi
-        cp -pruv $HOME/go/bin/* /usr/local/bin/ || die "Couldn't copy go/bin"
-        mv /usr/local/bin/mmtune /usr/local/bin/Go-mmtune || die "Couldn't mv mmtune"
+
+        copy_go_binaries
+        move_mmtune
     fi
 
     #if [[ "$ttyport" =~ "spi" ]]; then


### PR DESCRIPTION
If the local go binaries are running, the copy will fail and setup will die. This PR asks the user if it's okay to kill any running binaries and then kills them if requested.

My editor also auto-fixed some inconsistent spacing; lmk if this should be undone.