### PR TITLE
Fix default input detection in prompt_yn common function

### DIFF
--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -161,13 +161,13 @@ noquotes () {
 # "(NOT VALID JSON: <reason>)" at the end. Return success in any case.
 colorize_json () {
     local INPUT="$(cat)"
-    
+
     if [[ "$INPUT" == "" ]]; then
         echo "(NOT VALID JSON: empty)"
     else
         local COLORIZED_OUTPUT
         COLORIZED_OUTPUT="$(echo "$INPUT" |jq -C -c "${@-.}" 2>&1)"
-        
+
         if [[ $? != 0 ]]; then
             # If jq returned failure, it also wrote an error message.
             echo "$INPUT (NOT VALID JSON: $(echo $COLORIZED_OUTPUT))"
@@ -200,7 +200,7 @@ script_is_sourced () {
 # something other than yes or no, ask the question again.
 prompt_yn () {
     while true; do
-        if [[ "$2" == "y" ]]; then
+        if [[ "$2" =~ ^[Yy]$ ]]; then
             read -p "$1 [Y]/n " -r
         else
             read -p "$1 y/[N] " -r
@@ -242,16 +242,16 @@ prompt_and_validate () {
     local QUESTION="$2"
     local VALIDATOR="${3-true}"
     local DEFAULT="$4"
-    
+
     local LAST_VALUE=""
-    
+
     while true; do
         if [[ $# -ge 4 ]]; then
             read -p "$QUESTION [$DEFAULT] " -r "$VARNAME"
         else
             read -p "$QUESTION " -r "$VARNAME"
         fi
-        
+
         if [[ "${!VARNAME}" == "" ]]; then
             # User entered the empty string? Use the default value, if there is one.
             if [[ $# -ge 4 ]]; then
@@ -400,7 +400,7 @@ get_pref_float () {
 get_pref_string () {
     RESULT="$(get_prefs_json |jq --exit-status --raw-output "$1")"
     RETURN_CODE=$?
-    
+
     if [[ $RETURN_CODE == 0 ]]; then
         echo "$RESULT"
         return 0
@@ -425,7 +425,7 @@ set_pref_json () {
     else
         local NEW_PREFS="$(echo '{}' |jq "$1 |= $2")"
     fi
-    
+
     # Write the whole file and move into place, so that the change is atomic
     echo "$NEW_PREFS" >"${PREFERENCES_FILE}.new"
     mv -f "${PREFERENCES_FILE}.new" "$PREFERENCES_FILE"
@@ -473,7 +473,7 @@ function wait_for_silence {
         if ! listen -t $waitfor's' ; then
             echo "No interfering pump comms detected from other rigs (this is a good thing!)"
             echo -n "Continuing oref0-pump-loop at "; date
-            return 0 
+            return 0
         else
             sleep 1
         fi


### PR DESCRIPTION
I noticed that a few of the usages of `prompt_yn` in `oref0-setup.sh` were feeding the function a default value of `Y`, but the `prompt_yn` only displayed correctly when given `y`. The default value would still be correct, but the text displayed to the user was wrong. I updated the conditional to allow `Y` or `y` as the default value.