### PR TITLE
Added additional falsy check for sensitivityRatio

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -456,8 +456,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         ci = maxCI;
     }
     var remainingCATimeMin = 3; // h; duration of expected not-yet-observed carb absorption
-    // adjust remainingCATime (instead of CR) for autosens
-    remainingCATimeMin = remainingCATimeMin / sensitivityRatio;
+    // adjust remainingCATime (instead of CR) for autosens if sensitivityRatio defined
+    if (sensitivityRatio){
+        remainingCATimeMin = remainingCATimeMin / sensitivityRatio;
+    }
     // 20 g/h means that anything <= 60g will get a remainingCATimeMin, 80g will get 4h, and 120g 6h
     // when actual absorption ramps up it will take over from remainingCATime
     var assumedCarbAbsorptionRate = 20; // g/h; maximum rate to assume carbs will absorb if no CI observed


### PR DESCRIPTION
Added additional falsy check for sensitivityRatio in determine-basal to mitigate subsequent use from a possibly 'undefined' value, here for remainingCATimeMin