### PR TITLE
Fix npm install/link, xdrip cgm sets bt_offline, file tests to preven…

### DIFF
--- a/bin/oref0-log-shortcuts.sh
+++ b/bin/oref0-log-shortcuts.sh
@@ -100,7 +100,7 @@ function remove_obsolete_aliases () {
 END
 )
     echo "$OBSOLETE_ALIASES" |(while read OBSOLETE_ALIAS; do
-        cat "$PROFILE_PATH" |grep -v "$OBSOLETE_ALIAS" >"$PROFILE_PATH".new$$
+        test -f "$PROFILE_PATH" && cat "$PROFILE_PATH" |grep -v "$OBSOLETE_ALIAS" >"$PROFILE_PATH".new$$ &&
         mv -f "$PROFILE_PATH".new$$ "$PROFILE_PATH"
     done)
 }
@@ -125,10 +125,10 @@ else
     for i in "$@"; do
     case "$i" in
         --add-to-profile)
-            add_aliases_to_profile "$HOME/.bash_profile"
+            test -f "$HOME/.bash_profile" && add_aliases_to_profile "$HOME/.bash_profile"
             ;;
         --add-to-profile=*)
-            add_aliases_to_profile "${i#*=}"
+            test -f "${i#*=}" && add_aliases_to_profile "${i#*=}"
             ;;
         *)
            echo "Unrecognized argument: $i"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -853,7 +853,7 @@ if prompt_yn "" N; then
     echo Checking for BT Mac, BT Peb, Shareble, or xdrip-js
     if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" || ! -z $BLE_SERIAL || ! -z $DEXCOM_CGM_TX_ID ]]; then
         if [ ! -z "$BT_MAC" ]; then
-          printf 'Checking for the bnep0 interface in the interfaces files and adding if missing...'
+          printf 'Checking for the bnep0 interface in the interfaces file and adding if missing...'
           # Make sure the bnep0 interface is in the /etc/networking/interface
           (grep -qa bnep0 /etc/network/interfaces && printf 'skipped.\n') || (printf '\n%s\n\n' "iface bnep0 inet dhcp" >> /etc/network/interfaces && printf 'added.\n') 
         fi

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",
-    "global-install": "npm install && sudo npm install -g && sudo npm link && sudo npm link oref0"
+    "global-install": "npm install && sudo npm link && sudo npm link oref0 && sudo npm install -g"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
…t stderr output, add bnep0 interface if doesn't exist, enhance bnep0 cycling logic, cleanup/standardization

Fix npm install/link, xdrip cgm sets bt_offline, file tests to prevent avoidable stderr output, add bnep0 interface if doesn't exist, enhance bnep0 cycling logic, cleanup/standardization of parsing files

Fixes #1145 for me