### PR TITLE
fix sending escs before setting clock

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -213,9 +213,9 @@ function smb_reservoir_before {
     if (( $(bc <<< "$(to_epochtime $(cat monitor/clock-zoned.json)) - $(epochtime_now)") < -55 )) || (( $(bc <<< "$(to_epochtime $(cat monitor/clock-zoned.json)) - $(epochtime_now)") > 55 )); then
         echo Pump clock is more than 55s off: attempting to reset it and reload pumphistory
 	# Check for bolus in progress and issue 3xESC to back out of pump bolus menu
-        smb_verify_status && \
-        try_return timerun openaps use pump press_keys esc esc esc | jq .completed | grep true && \
-        oref0-set-device-clocks
+        smb_verify_status \
+        && try_return mdt -f internal button esc esc esc 2>&3 \
+        && oref0-set-device-clocks
        fi
     (( $(bc <<< "$(to_epochtime $(cat monitor/clock-zoned.json)) - $(epochtime_now)") > -90 )) \
     && (( $(bc <<< "$(to_epochtime $(cat monitor/clock-zoned.json)) - $(epochtime_now)") < 90 )) || { echo "Error: pump clock refresh error / mismatch"; fail "$@"; }


### PR DESCRIPTION
This came up in #1022 as something to do, but merging #1140 broke setting pump time for me so I thought now would be a good time to do it 😁. If `openaps-use` is still supposed to work on dev, I'd be happy to tweak this, but it doesn't look like it is in other places in the script.

`timerun` doesn't exist anymore...

```
34069-Pump clock is more than 55s off: attempting to reset it and reload pumphistory
34070-Checking pump status (suspended/bolusing): {"status":"normal","bolusing":false,"suspended":false}
34071:/usr/local/bin/oref0-pump-loop: line 978: timerun: command not found
```

...and after removing that, the `openaps use` command fails:
```
Pump clock is more than 55s off: attempting to reset it and reload pumphistory
Checking pump status (suspended/bolusing): {"status":"normal","bolusing":false,"suspended":false}
Traceback (most recent call last):
  File "/usr/local/bin/openaps-use", line 63, in <module>
    app( )
  File "/usr/local/lib/python2.7/dist-packages/openaps/cli/__init__.py", line 51, in __call__
    self.run(self.args)
  File "/usr/local/bin/openaps-use", line 57, in run
    output = app(args, self)
  File "/usr/local/lib/python2.7/dist-packages/openaps/uses/__init__.py", line 92, in __call__
    return self.method.selected(args)(args, app)
  File "/usr/local/lib/python2.7/dist-packages/openaps/uses/__init__.py", line 31, in __call__
    return self.method(args, app)
  File "/usr/local/lib/python2.7/dist-packages/openaps/uses/use.py", line 44, in __call__
    self.before_main(args, app)
  File "/usr/local/lib/python2.7/dist-packages/openaps/vendors/medtronic.py", line 62, in before_main
    self.setup_medtronic( )
  File "/usr/local/lib/python2.7/dist-packages/openaps/vendors/medtronic.py", line 161, in setup_medtronic
    self.uart.open( )
  File "/root/src/decocare/decocare/stick.py", line 874, in open
    log.info('%s' % self.product_info( ))
  File "/root/src/decocare/decocare/stick.py", line 515, in product_info
    return self.query(ProductInfo)
  File "/root/src/decocare/decocare/stick.py", line 509, in query
    return self.process( )
  File "/root/src/decocare/decocare/stick.py", line 490, in process
    raw = self.send_force_read( )
  File "/root/src/decocare/decocare/stick.py", line 606, in send_force_read
    self.link.write(reader.format( ))
  File "/root/src/decocare/decocare/link.py", line 47, in write
    r = self.serial.write( string )
  File "/usr/local/lib/python2.7/dist-packages/serial/serialposix.py", line 531, in write
    raise portNotOpenError
serial.serialutil.SerialException: Attempting to use a port that is not open
````

Tested this with pump on the bolus screen and it seems to work:
```
Pump clock is more than 55s off: attempting to reset it and reload pumphistory
Checking pump status (suspended/bolusing): {"status":"normal","bolusing":false,"suspended":false}
Waiting for ntpd to synchronize... OK!
Setting pump time to Sat Nov 24 23:25:57 CST 2018
2018/11/24 23:25:58 connected to CC111x radio on /dev/spidev5.1
2018/11/24 23:25:58 setting frequency to 916.500
2018/11/24 23:25:58 model 523 pump
2018/11/24 23:25:58 setting pump clock to 2018-11-24 23:25:58
2018/11/24 23:25:59 disconnecting CC111x radio on /dev/spidev5.1
Setting G4 CGM time to Sat Nov 24 23:25:59 CST 2018 with g4setclock
```

Also fixed the formatting to match other multiline bash commands.