### PR TITLE
Fix for loss of wifi issue on Raspbian

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -852,11 +852,6 @@ if prompt_yn "" N; then
 
     echo Checking for BT Mac, BT Peb, Shareble, or xdrip-js
     if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" || ! -z $BLE_SERIAL || ! -z $DEXCOM_CGM_TX_ID ]]; then
-        if [ ! -z "$BT_MAC" ]; then
-          printf 'Checking for the bnep0 interface in the interfaces file and adding if missing...'
-          # Make sure the bnep0 interface is in the /etc/networking/interface
-          (grep -qa bnep0 /etc/network/interfaces && printf 'skipped.\n') || (printf '\n%s\n\n' "iface bnep0 inet dhcp" >> /etc/network/interfaces && printf 'added.\n') 
-        fi
         # Install Bluez for BT Tethering
         echo Checking bluez installation
         bluetoothdversion=$(bluetoothd --version || 0)


### PR DESCRIPTION
Removes lines that edit `/etc/network/interfaces` in `oref0-setup.sh`, which cause dhcpcd to crash on the latest Raspbian. See: https://github.com/openaps/oref0/pull/1150#issuecomment-449660472