### PR TITLE
Bypass smb_verify_status with x12 pumps

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -365,6 +365,10 @@ function smb_verify_status {
     rm -rf monitor/status.json
     echo -n "Checking pump status (suspended/bolusing): "
     ( check_status || check_status ) 2>&3 >&4 \
+    && if grep -q 12 monitor/status.json; then
+    echo -n "x12 model detected."
+        return 0
+    fi \
     && cat monitor/status.json | colorize_json \
     && grep -q '"status": "normal"' monitor/status.json \
     && grep -q '"bolusing": false' monitor/status.json \
@@ -373,10 +377,6 @@ function smb_verify_status {
         unsuspend_if_no_temp
         refresh_pumphistory_and_meal
         false
-    fi \
-    && if grep -q 12 monitor/status.json; then
-    echo -n "x12 model detected."
-        true
     fi
 }
 
@@ -804,8 +804,8 @@ function check_model() {
 }
 function check_status() {
   set -o pipefail
-  if ( grep 12 settings/model.json ); then
-    touch monitor/status.json
+  if ( grep -q 12 settings/model.json ); then
+    echo '{ "status":"status on x12 not supported" }' > monitor/status.json
   else
     mdt status 2>&3 | tee monitor/status.json 2>&3 >&4 && cat monitor/status.json | colorize_json .status
   fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -366,7 +366,7 @@ function smb_verify_status {
     echo -n "Checking pump status (suspended/bolusing): "
     ( check_status || check_status ) 2>&3 >&4 \
     && if grep -q 12 monitor/status.json; then
-    echo -n "x12 model detected."
+    echo -n "x12 model detected. "
         return 0
     fi \
     && cat monitor/status.json | colorize_json \


### PR DESCRIPTION
This creates json data in `monitor/status.json` which will bypass `smb_verify_status` for x12 model pumps.