### PR TITLE
Support for pi-buttons

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1233,9 +1233,15 @@ if prompt_yn "" N; then
         echo "i2c-dev" > /etc/modules-load.d/i2c.conf
         echo "Installing socat and ntp..."
         apt-get install -y socat ntp
+        echo "Installing pi-buttons..."
+        systemctl stop pi-buttons
+        cd $HOME/src && git clone git://github.com/bnielsen1965/pi-buttons.git || (cd $HOME/src/pi-buttons && git checkout master && git pull)
+        echo "Make and install pi-buttons..."
+        ( cd $HOME/src/pi-buttons/src && make && sudo make install && sudo make install_service ) || die "Couldn't install pi-buttons"
+        systemctl enable pi-buttons && systemctl restart pi-buttons
         echo "Installing openaps-menu..."
         cd $HOME/src && git clone git://github.com/openaps/openaps-menu.git || (cd openaps-menu && git checkout master && git pull)
-        cd $HOME/src/openaps-menu && sudo npm install
+        cd $HOME/src/openaps-menu && sudo npm install || die "Couldn't install openaps-menu"
         cp $HOME/src/openaps-menu/openaps-menu.service /etc/systemd/system/ && systemctl enable openaps-menu
     fi
 


### PR DESCRIPTION
Will install pi-buttons repository (standalone button interface service), depends on a commit to openaps-menu to support this new interface (https://github.com/openaps/openaps-menu/pull/22)