### PR TITLE
Travis CI: Run node_js tests on "8", "10", and "node"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ python-steps: &python-steps
 
 matrix:
   include:
-    - node_js: "8.11.1"
+    - node_js: "8"
+      <<: *node_js-steps
+    - node_js: "10"
       <<: *node_js-steps
     - node_js: "node"  # current version of Node.js on Travis CI
       <<: *node_js-steps


### PR DESCRIPTION
As discussed at https://github.com/openaps/oref0/pull/1176#issuecomment-464483637

“__node__” is currently v11.10.0