### PR TITLE
Switch xDripAPS to a more up to date - maintained fork release

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1096,7 +1096,7 @@ if prompt_yn "" N; then
     if [[ ${CGM,,} =~ "xdrip" || ${CGM,,} =~ "xdrip-js" ]]; then
         echo xdrip or xdrip-js selected as CGM, so configuring xDripAPS
         sudo apt-get -y install sqlite3 || die "Can't add xdrip cgm - error installing sqlite3"
-        git clone https://github.com/colinlennon/xDripAPS.git $HOME/.xDripAPS
+        git clone https://github.com/renegadeandy/xDripAPS.git $HOME/.xDripAPS
         mkdir -p $HOME/.xDripAPS_data
         do_openaps_import $HOME/src/oref0/lib/oref0-setup/xdrip-cgm.json
         touch /tmp/reboot-required


### PR DESCRIPTION
Switched repo from colinlennon to my fork of the xDripAPS code which adds a lot of new capabilities. This has been tested by me for 2 months, without any issues. It has also been tested by a member of the openaps community - @jpcunningh.

@jpcunningh Can you please comment here to show the community you tried my release without issues?