### PR TITLE
Set cgm_loop_path for plugged-in G5 receiver

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -920,6 +920,7 @@ if prompt_yn "" N; then
     if [[ ${CGM,,} =~ "g5" || ${CGM,,} =~ "g5-upload" ]]; then
         openaps use cgm config --G5
         openaps report add raw-cgm/raw-entries.json JSON cgm oref0_glucose --hours "24.0" --threshold "100" --no-raw
+        set_pref_string .cgm_loop_path "$directory"
     ## TODO: figure out if any of this is still needed
     #elif [[ ${CGM,,} =~ "g4-go" ]]; then
         #echo Checking Adafruit_BluefruitLE installation


### PR DESCRIPTION
Fix for https://github.com/openaps/oref0/issues/1149