### PR TITLE
ability to add script plugins to oref0-pump-loop

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -87,12 +87,17 @@ main() {
             touch /tmp/pump_loop_success
             echo Completed oref0-pump-loop at $(date)
             update_display
+            run_plugins
             echo
         else
             # pump-loop errored out for some reason
             fail "$@"
         fi
     fi
+}
+
+function run_plugins {
+    :
 }
 
 function update_display {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -101,14 +101,16 @@ function run_script() {
 
   if [[ -x "$file" ]]
   then
-    echo "Running script file ($file)"
+    echo "Running plugin script ($file)... "
     timeout 60 $file
+
+    thedate=$(date)
+    echo "Plugins Completed - $thedate"
+
     if [[ "$2" == "-d" ]]
     then
-      echo "Removing script file ($file)"
+      #echo "Removing script file ($file)"
       rm $file
-    else
-      echo "Not Removing script file ($file)"
     fi
   fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -96,8 +96,34 @@ main() {
     fi
 }
 
+function run_script() {
+  file=$1
+
+  if [[ -x "$file" ]]
+  then
+    echo "Running script file ($file)"
+    timeout 60 $file
+    if [[ "$2" == "-d" ]]
+    then
+      echo "Removing script file ($file)"
+      rm $file
+    else
+      echo "Not Removing script file ($file)"
+    fi
+  fi
+}
+
+
 function run_plugins {
-    :
+        once=plugins/once
+        every=plugins/every
+        mkdir -p $once
+        mkdir -p $every
+        echo "scripts placed in this directory will run once after curent loop and be removed" > $once/readme.txt
+        echo "scripts placed in this directory will run after every loop" > $every/readme.txt
+        find $once/* | while read file; do run_script "$file" -d ; done
+        find $every/* | while read file; do run_script "$file" ; done
+
 }
 
 function update_display {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -87,12 +87,12 @@ main() {
             touch /tmp/pump_loop_success
             echo Completed oref0-pump-loop at $(date)
             update_display
-            run_plugins
             echo
         else
             # pump-loop errored out for some reason
             fail "$@"
         fi
+        run_plugins
     fi
 }
 
@@ -104,10 +104,9 @@ function run_script() {
   then
     echo "Running plugin script ($file)... "
     timeout 60 $file
+    echo "Completed plugin script ($file). "
 
-    thedate=$(date)
-    echo "Plugins Completed - $thedate"
-
+    # -d means to only run the script once, so remove it once run
     if [[ "$2" == "-d" ]]
     then
       #echo "Removing script file ($file)"

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -90,7 +90,6 @@ main() {
             run_plugins
             echo
         else
-            run_plugins
             # pump-loop errored out for some reason
             fail "$@"
         fi
@@ -158,6 +157,7 @@ function fail {
         echo Error: syntax error in preferences.json: please go correct your typo.
     fi
     update_display
+    run_plugins
     echo
     exit 1
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -87,12 +87,13 @@ main() {
             touch /tmp/pump_loop_success
             echo Completed oref0-pump-loop at $(date)
             update_display
+            run_plugins
             echo
         else
+            run_plugins
             # pump-loop errored out for some reason
             fail "$@"
         fi
-        run_plugins
     fi
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -99,19 +99,15 @@ main() {
 function run_script() {
   file=$1
 
-  # only run plugin script files if they have the executable bit set
-  if [[ -x "$file" ]]
-  then
-    echo "Running plugin script ($file)... "
-    timeout 60 $file
-    echo "Completed plugin script ($file). "
+  echo "Running plugin script ($file)... "
+  timeout 60 $file
+  echo "Completed plugin script ($file). "
 
-    # -d means to only run the script once, so remove it once run
-    if [[ "$2" == "-d" ]]
-    then
-      #echo "Removing script file ($file)"
-      rm $file
-    fi
+  # -d means to only run the script once, so remove it once run
+  if [[ "$2" == "-d" ]]
+  then
+    #echo "Removing script file ($file)"
+    rm $file
   fi
 }
 
@@ -123,8 +119,8 @@ function run_plugins {
         mkdir -p $every
         echo "scripts placed in this directory will run once after curent loop and be removed" > $once/readme.txt
         echo "scripts placed in this directory will run after every loop" > $every/readme.txt
-        find $once/* | while read file; do run_script "$file" -d ; done
-        find $every/* | while read file; do run_script "$file" ; done
+        find $once/* -executable | while read file; do run_script "$file" -d ; done
+        find $every/* -executable | while read file; do run_script "$file" ; done
 
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -99,6 +99,7 @@ main() {
 function run_script() {
   file=$1
 
+  # only run plugin script files if they have the executable bit set
   if [[ -x "$file" ]]
   then
     echo "Running plugin script ($file)... "


### PR DESCRIPTION
This PR adds the ability to inject custom script(s) to run synchronously at the end of every oref0-pump-loop. Any script files with executable flag set will be run as follows:

If the script file is placed in the plugins/every folder then the script runs at the end of every loop.
If the script file is placed in the plugins/once folder then the script once at the end of the current loop.

Script files placed in the plugins/once folder will be removed once run. This allows for a use case such as the following:

Logger and Lookout both call a pump utility called fakemeter that helps out users in offline mode by sending the current CGM (Dexcom) glucose value as a meter glucose value. This shows the glucose on the pump every 5 minutes and allows you to quickly see the current glucose value on the pump. Since this script requires communication with the pump, it will collide with oref0 pump communications on occasion. This oref0-pump-loop plugin capability will allow Logger and Lookout to run fakemeter synchronously at the end of the pump loop and avoid any radio collisions. 

