### PR TITLE
Webpack

### DIFF
--- a/lib/webpack-exports.js
+++ b/lib/webpack-exports.js
@@ -1,0 +1,26 @@
+var autotune_prep = require('./autotune-prep');
+var autotune = require('./autotune');
+
+function run_autotune(inputs) {
+        var prep_inputs = {
+            history: inputs.treatments,
+            profile: inputs.profile,
+            pumpprofile: inputs.pump_profile,
+            glucose: inputs.glucose_entries,
+            carbs: {},
+            categorize_uam_as_basal: inputs.categorize_uam_as_basal,
+            tune_insulin_curve: inputs.tune_insulin_curve
+        };
+        var prepped_glucose = autotune_prep(prep_inputs);
+        var autotune_inputs = {
+            preppedGlucose: prepped_glucose,
+            previousAutotune: inputs.autotune_profile,
+            pumpProfile: inputs.pump_profile
+        }
+        var autotune_result = autotune(autotune_inputs);
+        return autotune_result;
+    }
+
+module.exports = {
+    run_autotune: run_autotune
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "openaps oref0 reference implementation of the reference design",
   "scripts": {
     "test": "make test",
-    "global-install": "npm install && sudo npm link && sudo npm link oref0 && sudo npm install -g"
+    "global-install": "npm install && sudo npm link && sudo npm link oref0 && sudo npm install -g",
+    "webpack": "webpack"
   },
   "repository": {
     "type": "git",
@@ -110,7 +111,9 @@
     "istanbul": "^0.4.4",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.2.0",
-    "should": "^7.1.0"
+    "should": "^7.1.0",
+    "webpack": "^4.28.3",
+    "webpack-cli": "^3.2.0"
   },
   "config": {
     "blanket": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,13 @@
+var path = require('path');
+var webpack = require('webpack');
+module.exports = {
+    mode: 'production',
+    entry: './lib/webpack-exports.js',
+    target: 'node',
+    output: {
+        path: path.resolve(__dirname, 'build'),
+        filename: 'bundle.js',
+        libraryTarget: 'var',
+        library: 'OpenAPS'
+    }
+};


### PR DESCRIPTION
This PR adds support for Webpack. After running `npm run webpack` via the command line it will resolve all the dependencies needed for `lib/webpack-exports.js`, combine them into a single file and output that to `build/bundle.js`.
This way it is a lot easier to use OpenAPS in other applications since you do not need to care about providing all the required dependencies.
For now it exports only a single function for executing Autotune which can be called by `OpenAPS.run_autotune(inputs)`.