### PR TITLE
Fix latest-ns-treatment to return an object instead of array

### DIFF
--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -162,7 +162,7 @@ extra_ns_help
 }
 case $NAME in
 latest-openaps-treatment)
-  ns-get treatments.json'?find[enteredBy]=/openaps:\/\//&count=1' $* | jq .
+  ns-get treatments.json'?find[enteredBy]=/openaps:\/\//&count=1' $* | jq .[0]
   ;;
 ns)
   NIGHTSCOUT_HOST=$1


### PR DESCRIPTION
I found a bug with the convert json to jq PR that prevents the latest NS treatment time from being correctly produced for the NS loop.  

This corrects the error.