### PR TITLE
Support Low Battery File

### DIFF
--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -152,9 +152,9 @@ function battery_status {
     elif [ -e monitor/low-battery.json ]; then
         low=$(cat monitor/low-battery.json)
         if [ "$low" = True ]; then
-          echo '{"batteryVoltage":3000, "battery":9}'
+          echo '{"batteryVoltage":3000, "battery":9}' | tee monitor/edison-battery.json
         else
-          echo '{"batteryVoltage":3680, "battery":50}'
+          echo '{"batteryVoltage":3680, "battery":50}' | tee monitor/edison-battery.json
         fi
     fi
 }

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -149,6 +149,13 @@ function battery_status {
         sudo ~/src/EdisonVoltage/voltage json batteryVoltage battery | tee monitor/edison-battery.json | colorize_json
     elif [ -e /root/src/openaps-menu/scripts/getvoltage.sh ]; then
         sudo /root/src/openaps-menu/scripts/getvoltage.sh | tee monitor/edison-battery.json | colorize_json
+    elif [ -e monitor/low-battery.json ]; then
+        low=$(cat monitor/low-battery.json)
+        if [ "$low" = True ]; then
+          echo '{"batteryVoltage":3000, "battery":9}'
+        else
+          echo '{"batteryVoltage":3680, "battery":50}'
+        fi
     fi
 }
 


### PR DESCRIPTION
This adds support for a low-battery file that contains True or False.

It's purpose is to support a low battery notification for rigs that have a low-battery discrete instead of a battery meter.