### PR TITLE
Update oref0-bluetooth for pi

### DIFF
--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -7,11 +7,12 @@ Usage: $self
 Attempt to establish a Bluetooth tethering connection.
 EOT
 
-DAEMON_PATHS=(/usr/local/bin/bluetoothd /usr/sbin/bluetoothd /usr/libexec/bluetooth/bluetoothd)
+DAEMON_PATHS=(/usr/local/bin/bluetoothd /usr/libexec/bluetooth/bluetoothd /usr/sbin/bluetoothd)
 
 for EXEC_PATH in ${DAEMON_PATHS[@]}; do
   if [ -x $EXEC_PATH ]; then
     EXECUTABLE=$EXEC_PATH
+    break;
   fi
 done
 

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -16,6 +16,9 @@ for EXEC_PATH in ${DAEMON_PATHS[@]}; do
   fi
 done
 
+# Send stderr and stdout to log file
+exec 2>&1
+
 if [ "$DEBUG" != "" ]; then
   EXECUTABLE="$EXECUTABLE -d -n"
 fi

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -17,7 +17,7 @@ for EXEC_PATH in ${DAEMON_PATHS[@]}; do
 done
 
 if [ "$DEBUG" != "" ]; then
-  EXECUTABLE=$EXECUTABLE -d -n
+  EXECUTABLE="$EXECUTABLE -d -n"
 fi
 
 # start bluetoothd if bluetoothd is not running

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -7,21 +7,33 @@ Usage: $self
 Attempt to establish a Bluetooth tethering connection.
 EOT
 
+DAEMON_PATHS=(/usr/local/bin/bluetoothd /usr/sbin/bluetoothd /usr/libexec/bluetooth/bluetoothd)
+
+for EXEC_PATH in ${DAEMON_PATHS[@]}; do
+  if [ -x $EXEC_PATH ]; then
+    EXECUTABLE=$EXEC_PATH
+  fi
+done
+
 # start bluetoothd if bluetoothd is not running
 if ! ( ps -fC bluetoothd >/dev/null ) ; then
-   sudo /usr/local/bin/bluetoothd &
+   echo bluetoothd not running! Starting bluetoothd...
+   sudo $EXECUTABLE &
 fi
 
 if is_edison && ! ( hciconfig -a | grep -q "PSCAN" ) ; then
+   echo Bluetooth PSCAN not enabled! Restarting bluetoothd...
    sudo killall bluetoothd
-   sudo /usr/local/bin/bluetoothd &
+   sudo $EXECUTABLE &
 fi
 
 if ( hciconfig -a | grep -q "DOWN" ) ; then
+   echo Bluetooth hci DOWN! Bringing it to UP.
    sudo hciconfig hci0 up
-   sudo /usr/local/bin/bluetoothd &
+   sudo $EXECUTABLE &
 fi
 
 if !( hciconfig -a | grep -q $HOSTNAME ) ; then
+   echo Bluetooth hci name does not match hostname: $HOSTNAME. Setting bluetooth hci name.
    sudo hciconfig hci0 name $HOSTNAME
 fi

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -16,6 +16,10 @@ for EXEC_PATH in ${DAEMON_PATHS[@]}; do
   fi
 done
 
+if [ "$DEBUG" != "" ]; then
+  EXECUTABLE=$EXECUTABLE -d -n
+fi
+
 # start bluetoothd if bluetoothd is not running
 if ! ( ps -fC bluetoothd >/dev/null ) ; then
    echo bluetoothd not running! Starting bluetoothd...

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -19,19 +19,19 @@ done
 # start bluetoothd if bluetoothd is not running
 if ! ( ps -fC bluetoothd >/dev/null ) ; then
    echo bluetoothd not running! Starting bluetoothd...
-   sudo $EXECUTABLE &
+   sudo $EXECUTABLE | tee -a /var/log/openaps/bluetoothd.log &
 fi
 
 if is_edison && ! ( hciconfig -a | grep -q "PSCAN" ) ; then
    echo Bluetooth PSCAN not enabled! Restarting bluetoothd...
    sudo killall bluetoothd
-   sudo $EXECUTABLE &
+   sudo $EXECUTABLE | tee -a /var/log/openaps/bluetoothd.log &
 fi
 
 if ( hciconfig -a | grep -q "DOWN" ) ; then
    echo Bluetooth hci DOWN! Bringing it to UP.
    sudo hciconfig hci0 up
-   sudo $EXECUTABLE &
+   sudo $EXECUTABLE | tee -a /var/log/openaps/bluetoothd.log &
 fi
 
 if !( hciconfig -a | grep -q $HOSTNAME ) ; then

--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -16,9 +16,6 @@ for EXEC_PATH in ${DAEMON_PATHS[@]}; do
   fi
 done
 
-# Send stderr and stdout to log file
-exec 2>&1
-
 if [ "$DEBUG" != "" ]; then
   EXECUTABLE="$EXECUTABLE -d -n"
 fi
@@ -26,19 +23,19 @@ fi
 # start bluetoothd if bluetoothd is not running
 if ! ( ps -fC bluetoothd >/dev/null ) ; then
    echo bluetoothd not running! Starting bluetoothd...
-   sudo $EXECUTABLE | tee -a /var/log/openaps/bluetoothd.log &
+   sudo $EXECUTABLE 2>&1 | tee -a /var/log/openaps/bluetoothd.log &
 fi
 
 if is_edison && ! ( hciconfig -a | grep -q "PSCAN" ) ; then
    echo Bluetooth PSCAN not enabled! Restarting bluetoothd...
    sudo killall bluetoothd
-   sudo $EXECUTABLE | tee -a /var/log/openaps/bluetoothd.log &
+   sudo $EXECUTABLE 2>&1 | tee -a /var/log/openaps/bluetoothd.log &
 fi
 
 if ( hciconfig -a | grep -q "DOWN" ) ; then
    echo Bluetooth hci DOWN! Bringing it to UP.
    sudo hciconfig hci0 up
-   sudo $EXECUTABLE | tee -a /var/log/openaps/bluetoothd.log &
+   sudo $EXECUTABLE 2>&1 | tee -a /var/log/openaps/bluetoothd.log &
 fi
 
 if !( hciconfig -a | grep -q $HOSTNAME ) ; then


### PR DESCRIPTION
This adds some log messages and provides support for various locations of the bluetoothd executable.

My Pi location from Pi Bakery image was /usr/sbin/bluetooth. I've upgraded by building from source, and the location is now /usr/libexec/bluetooth.