### PR TITLE
Move sshd_config mod to after apt update

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -21,8 +21,6 @@ if [ -e /run/sshwarn ] ; then
     passwd pi
 fi
 
-grep "PermitRootLogin yes" /etc/ssh/sshd_config || echo "PermitRootLogin yes" > /etc/ssh/sshd_config
-
 # set timezone
 dpkg-reconfigure tzdata
 
@@ -31,6 +29,8 @@ dpkg-reconfigure tzdata
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate ntpdate ntp
 #check if edison user exists before trying to add it to groups
+
+grep "PermitRootLogin yes" /etc/ssh/sshd_config || echo "PermitRootLogin yes" > /etc/ssh/sshd_config
 
 if  getent passwd edison > /dev/null; then
   echo "Adding edison to sudo users"


### PR DESCRIPTION
This will avoid having to make a choice during the apt-get update between the modified sshd_config and the one included in the update.