### PR TITLE
Fix check for WW pumps

### DIFF
--- a/bin/oref0-mmtune.sh
+++ b/bin/oref0-mmtune.sh
@@ -28,7 +28,7 @@ fi
 
 function mmtune_Go() {
   set -o pipefail
-  if ( get_pref_string .radio_locale =~ ww ); then
+  if [ "$(get_pref_string .radio_locale '')" == "WW" ]; then
     Go-mmtune -ww | tee monitor/mmtune.json
   else
     Go-mmtune | tee monitor/mmtune.json


### PR DESCRIPTION
Bug introduced by #1176: oref0-mmtune was always starting Go-mmtune with the -ww flag; this should make the check do what it's supposed to.