### PR TITLE
Inverted logic fix for oref0-mmtune.sh, and bug fix for oref0-pump-loop.sh

### DIFF
--- a/bin/oref0-mmtune.sh
+++ b/bin/oref0-mmtune.sh
@@ -44,7 +44,7 @@ fi
 #Read and zero pad best frequency from mmtune, and store/set it so Go commands can use it,
 #but only if it's not the default frequency
 if [ -s monitor/mmtune.json ]; then 
-  if $(jq -e .usedDefault monitor/mmtune.json); then
+  if ! $(jq -e .usedDefault monitor/mmtune.json); then
     freq=`jq -e .setFreq monitor/mmtune.json | tr -d "."`
     while [ ${#freq} -ne 9 ];
       do

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -484,12 +484,13 @@ function prep {
         upto30s=$(head -1 /tmp/wait_for_silence)
         upto45s=$(head -1 /tmp/wait_for_silence)
     fi
+    #We don't need to get the tty port anymore...
     # read tty port from preferences
-    eval $(get_pref_string .ttyport | sed "s/ //g")
+    #eval $(get_pref_string .ttyport | sed "s/ //g")
     # if that fails, try the Explorer board default port
-    if [ -z $port ]; then
-        port=/dev/spidev5.1
-    fi
+    #if [ -z $port ]; then
+    #    port=/dev/spidev5.1
+    #fi
 
     # necessary to enable SPI communication over edison GPIO 110 on Edison + Explorer Board
     [ -f /sys/kernel/debug/gpio_debug/gpio110/current_pinmux ] && echo mode0 > /sys/kernel/debug/gpio_debug/gpio110/current_pinmux


### PR DESCRIPTION
- Comments out code in oref0-pump-loop that doesn't do anything except show an error in the logs
- Logic of this check was inverted by #1176, this should fix it.