### PR TITLE
Apply default limits to autosens if none provided.

### DIFF
--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -269,7 +269,7 @@ function tuneAllTheThings (inputs) {
             // cap adjustments at autosens_max and autosens_min
             if (typeof pumpProfile.autosens_max !== 'undefined') {
                 var autotuneMax = pumpProfile.autosens_max;
-	    } else {
+            } else {
                 var autotuneMax = 1.2;
             }
             if (typeof pumpProfile.autosens_min !== 'undefined') {

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -274,9 +274,9 @@ function tuneAllTheThings (inputs) {
             }
             if (typeof pumpProfile.autosens_min !== 'undefined') {
                 var autotuneMin = pumpProfile.autosens_min;
-	    } else {
+            } else {
                 var autotuneMin = 0.7;
-	    }
+            }
             var maxRate = hourlyPumpProfile[hour].rate * autotuneMax;
             var minRate = hourlyPumpProfile[hour].rate * autotuneMin;
             if (newHourlyBasalProfile[hour].rate > maxRate ) {

--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -267,8 +267,16 @@ function tuneAllTheThings (inputs) {
         for (hour=0; hour < 24; hour++) {
             //console.error(newHourlyBasalProfile[hour],hourlyPumpProfile[hour].rate*1.2);
             // cap adjustments at autosens_max and autosens_min
-            var autotuneMax = pumpProfile.autosens_max;
-            var autotuneMin = pumpProfile.autosens_min;
+            if (typeof pumpProfile.autosens_max !== 'undefined') {
+                var autotuneMax = pumpProfile.autosens_max;
+	    } else {
+                var autotuneMax = 1.2;
+            }
+            if (typeof pumpProfile.autosens_min !== 'undefined') {
+                var autotuneMin = pumpProfile.autosens_min;
+	    } else {
+                var autotuneMin = 0.7;
+	    }
             var maxRate = hourlyPumpProfile[hour].rate * autotuneMax;
             var minRate = hourlyPumpProfile[hour].rate * autotuneMin;
             if (newHourlyBasalProfile[hour].rate > maxRate ) {


### PR DESCRIPTION
If `autosens_min` or `autosens_max` are not defined in profile, use the default recommended values of `0.7` and `1.2`.

As [reported on gitter](https://gitter.im/openaps/autotune?at=5c98bc356a3d2e230d20f654), running without this gives me:
```
Parameter      | Pump        | Autotune    | Days Missing                                                    
---------------------------------------------------------                                                    
ISF [mg/dL/U]  | 56.000      | 184.800     |                                                                 
Carb Ratio[g/U]| 14.000      | 14.000      |                                                                 
```
while with this I'm getting
```
Parameter      | Pump        | Autotune    | Days Missing
---------------------------------------------------------
ISF [mg/dL/U]  | 56.000      | 60.800      |
Carb Ratio[g/U]| 14.000      | 14.000      |
```
for same time period without any `autosens` limits present in profile.