### PR TITLE
Turn off screen only after 5 minutes.

### DIFF
--- a/bin/oref0-cron-every-minute.sh
+++ b/bin/oref0-cron-every-minute.sh
@@ -126,3 +126,13 @@ fi
 if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
     oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log &
 fi
+
+# check if 5 minutes have passed, and if yes, turn of the screen to save power
+ttyport="$(get_pref_string .ttyport)"
+upSeconds="$(cat /proc/uptime | grep -o '^[0-9]\+')"
+upMins=$((${upSeconds} / 60))
+
+if [[ "${upMins}" -gt "5" && "$ttyport" =~ spidev0.[01] ]]; then
+    # disable HDMI on Explorer HAT rigs to save battery
+    /usr/bin/tvservice -o &
+fi

--- a/bin/oref0-cron-post-reboot.sh
+++ b/bin/oref0-cron-post-reboot.sh
@@ -25,8 +25,3 @@ oref0-delete-future-entries &
     export FLASK_APP=app.py
     flask run -p 80 --host=0.0.0.0 | tee -a /var/log/openaps/flask.log
 ) &
-
-if [[ "$ttyport" =~ "spidev0.0" ]]; then
-    # disable HDMI on Explorer HAT rigs to save battery
-    /usr/bin/tvservice -o &
-fi


### PR DESCRIPTION
Some times, (many times starting on first install) one can not connect the pi to WiFi, but can connect a screen.
This pr will give them 5 minutes before the screen is turned off, to allow them to either enable connection to WiFi, or disable screen turning off.

One more thing that is changes is that hat might be on spidev0.[01] so screen is shutdown in both cases. (without this change, on adafruit bonnet screen is not turned off at all).

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>