### PR TITLE
Fixes for openaps-packages.sh in dev

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -58,7 +58,9 @@ fi
 sed -i "s/daily/hourly/g" /etc/logrotate.conf
 sed -i "s/#compress/compress/g" /etc/logrotate.conf
 
-curl -s https://raw.githubusercontent.com/openaps/oref0/$BRANCH/bin/openaps-packages.sh | bash -
+# Change the openaps-packages.sh curl command to the following before merging dev to master:
+#curl -s https://raw.githubusercontent.com/openaps/oref0/$BRANCH/bin/openaps-packages.sh | bash -
+curl -s https://raw.githubusercontent.com/openaps/oref0/dev/bin/openaps-packages.sh | bash -
 mkdir -p ~/src; cd ~/src && git clone git://github.com/openaps/oref0.git ; (cd oref0 && git checkout $BRANCH && git pull)
 echo "Press Enter to run oref0-setup with the current release ($BRANCH branch) of oref0,"
 read -p "or press ctrl-c to cancel. " -r

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -27,6 +27,7 @@ if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' &> /dev/null ; then
             sudo apt-get install -y nodejs || die "Couldn't install nodejs"
         else
             sudo apt-get install -y nodejs npm || die "Couldn't install nodejs and npm"
+            npm install npm@latest -g || die "Couldn't update npm"
         fi
         ## You may also need development tools to build native addons:
         ##sudo apt-get install gcc g++ make

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 
-source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
-
-usage "$@" <<EOT
-Usage: $self
-
-Downloads OpenAPS packages using pip, and dependencies using apt-get and npm.
-This is normally invoked from openaps-install.sh.
-EOT
+die() {
+    echo "$@"
+    exit 1
+}
 
 # TODO: remove the `Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
@@ -17,16 +13,21 @@ sudo apt-get update && sudo apt-get -y upgrade
 sudo apt-get install -y git python python-dev software-properties-common python-numpy python-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
 
 # We require jq >= 1.5 for --slurpfile for merging preferences. Debian Jessie ships with 1.4
-if is_debian_jessie; then
+if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /dev/null; then
    sudo apt-get -y -t jessie-backports install jq || die "Couldn't install jq from jessie-backports"
 else
    sudo apt-get -y install jq || die "Couldn't install jq"
 fi
 
 # install/upgrade to latest node 8 if neither node 8 nor node 10+ LTS are installed
-if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' ; then
-        sudo bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -" || die "Couldn't setup node 8"
-        sudo apt-get install -y nodejs || die "Couldn't install nodejs"
+if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' &> /dev/null ; then
+        # nodesource doesn't support armv6
+        if ! arch | grep -e 'armv6' &> /dev/null ; then
+            sudo bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -" || die "Couldn't setup node 8"
+            sudo apt-get install -y nodejs || die "Couldn't install nodejs"
+        else
+            sudo apt-get install -y nodejs npm || die "Couldn't install nodejs and npm"
+        fi
         ## You may also need development tools to build native addons:
         ##sudo apt-get install gcc g++ make
 fi


### PR DESCRIPTION
- Remove calls to oref0-bash-common-functions.sh (it is not present on fresh installs)
- Add `die()` to the script so critical errors will stop the install
- Use nodesource (installs nodejs+npm) on all platforms except armv6 (pi0)
- Use `dev` openaps-packages.sh instead of $BRANCH (remove this before merging `dev` to `master`)
- Update npm to latest version on armv6 (pi0) using npm's self-updater (integrates https://github.com/openaps/docs/pull/1444)