### PR TITLE
Remove old golang install before reinstalling.

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1273,14 +1273,17 @@ if prompt_yn "" N; then
     # Install Golang
     mkdir -p $HOME/go
     source $HOME/.bash_profile
-    if go version | grep go1.11.; then
+    golangversion=1.11
+    if go version | grep go${golangversion}.; then
         echo Go already installed
     else
+        echo "Removing possible old go install..."
+        rm -rf /usr/local/go
         echo "Installing Golang..."
         if uname -m | grep armv; then
-            cd /tmp && wget -c https://storage.googleapis.com/golang/go1.11.linux-armv6l.tar.gz && tar -C /usr/local -xzvf /tmp/go1.11.linux-armv6l.tar.gz
+            cd /tmp && wget -c https://storage.googleapis.com/golang/go${golangversion}.linux-armv6l.tar.gz && tar -C /usr/local -xzvf /tmp/go${golangversion}.linux-armv6l.tar.gz
         elif uname -m | grep i686; then
-            cd /tmp && wget -c https://dl.google.com/go/go1.11.linux-386.tar.gz && tar -C /usr/local -xzvf /tmp/go1.11.linux-386.tar.gz
+            cd /tmp && wget -c https://dl.google.com/go/go${golangversion}.linux-386.tar.gz && tar -C /usr/local -xzvf /tmp/go${golangversion}.linux-386.tar.gz
         fi
     fi
     if ! grep GOROOT $HOME/.bash_profile; then

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1273,12 +1273,12 @@ if prompt_yn "" N; then
     # Install Golang
     mkdir -p $HOME/go
     source $HOME/.bash_profile
-    golangversion=1.11
+    golangversion=1.12.5
     if go version | grep go${golangversion}.; then
         echo Go already installed
     else
         echo "Removing possible old go install..."
-        rm -rf /usr/local/go
+        rm -rf /usr/local/go/*
         echo "Installing Golang..."
         if uname -m | grep armv; then
             cd /tmp && wget -c https://storage.googleapis.com/golang/go${golangversion}.linux-armv6l.tar.gz && tar -C /usr/local -xzvf /tmp/go${golangversion}.linux-armv6l.tar.gz


### PR DESCRIPTION
Remove old golang install before re-installing. 

Installing a new version of golang on top of an old version gives difficult to diagnose compile errors. 

Also changed the golang version to 1.12.5. I compiled the pump communication library with 1.12.5 while troubleshooting my issue, and everything worked well so might as well update it here i think.