### PR TITLE
don't loop on too-flat CGM data

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -86,7 +86,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             rT.reason = "Error: CGM data is unchanged for the past ~45m";
         }
     }
-    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
+    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {
         if (currenttemp.rate >= basal) { // high temp is running
             rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
             rT.deliverAt = deliverAt;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -79,14 +79,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     // if BG is too old/noisy, or is changing less than 1 mg/dL/5m for 45m, cancel any high temps and shorten any long zero temps
-    } else if ( bg > 60 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
+    } else if ( bg > 60 && glucose_status == 0 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
         if ( glucose_status.last_cal && glucose_status.last_cal < 3 ) {
             rT.reason = "CGM was just calibrated";
         } else {
             rT.reason = "Error: CGM data is unchanged for the past ~45m";
         }
     }
-    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( bg > 60 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {
+    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( bg > 60 && glucose_status == 0 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {
         if (currenttemp.rate > basal) { // high temp is running
             rT.reason += ". Replacing high temp basal of "+currenttemp.rate+" with neutral temp of "+basal;
             rT.deliverAt = deliverAt;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -79,7 +79,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     // if BG is too old/noisy, or is changing less than 1 mg/dL/5m for 45m, cancel any high temps and shorten any long zero temps
-    if ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
+    } else if ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
         if ( glucose_status.last_cal && glucose_status.last_cal < 3 ) {
             rT.reason = "CGM was just calibrated";
         } else {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -79,14 +79,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     // if BG is too old/noisy, or is changing less than 1 mg/dL/5m for 45m, cancel any high temps and shorten any long zero temps
-    } else if ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
+    } else if ( bg > 60 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
         if ( glucose_status.last_cal && glucose_status.last_cal < 3 ) {
             rT.reason = "CGM was just calibrated";
         } else {
             rT.reason = "Error: CGM data is unchanged for the past ~45m";
         }
     }
-    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {
+    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( bg > 60 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {
         if (currenttemp.rate >= basal) { // high temp is running
             rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
             rT.deliverAt = deliverAt;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -87,12 +87,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
     if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( bg > 60 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {
-        if (currenttemp.rate >= basal) { // high temp is running
-            rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
+        if (currenttemp.rate > basal) { // high temp is running
+            rT.reason += ". Replacing high temp basal of "+currenttemp.rate+" with neutral temp of "+basal;
             rT.deliverAt = deliverAt;
             rT.temp = 'absolute';
-            rT.duration = 0;
-            rT.rate = 0;
+            rT.duration = 30;
+            rT.rate = basal;
             return rT;
             //return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
         } else if ( currenttemp.rate === 0 && currenttemp.duration > 30 ) { //shorten long zero temps to 30m

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -78,7 +78,7 @@ describe('determine-basal', function ( ) {
    //function determine_basal(glucose_status, currenttemp, iob_data, profile)
 
     // standard initial conditions for all determine-basal test cases unless overridden
-    var glucose_status = {"delta":0,"glucose":115,"long_avgdelta":0.1,"short_avgdelta":0};
+    var glucose_status = {"delta":0,"glucose":115,"long_avgdelta":1.1,"short_avgdelta":0};
     var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
     var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
     var autosens = {"ratio":1.0};
@@ -126,7 +126,7 @@ describe('determine-basal', function ( ) {
     it('should do nothing when low and rising w/o IOB', function () {
         var glucose_status = {"delta":6,"glucose":75,"long_avgdelta":6,"short_avgdelta":6};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens, meal_data, tempBasalFunctions);
-        console.log(output);
+        //console.log(output);
         output.rate.should.equal(0.9);
         output.duration.should.equal(30);
         //output.reason.should.match(/75<80.*setting current basal/);
@@ -248,27 +248,30 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when LOW w/ positive IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":-1.1,"short_avgdelta":0};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens, meal_data, tempBasalFunctions);
+        //console.log(output);
         output.rate.should.equal(0);
         output.duration.should.be.above(29);
         //output.reason.should.match(/BG 39<80/);
     });
 
     it('should low temp when LOW w/ negative IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":-1.1,"short_avgdelta":0};
         var iob_data = {"iob":-2.5,"activity":-0.03,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens, meal_data, tempBasalFunctions);
+        //console.log(output);
         output.rate.should.be.below(0.8);
         output.duration.should.be.above(29);
         //output.reason.should.match(/BG 39<80/);
     });
 
     it('should temp to 0 when LOW w/ no IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":-1.1,"short_avgdelta":0};
         var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens, meal_data, tempBasalFunctions);
+        //console.log(output);
         output.rate.should.equal(0);
         output.duration.should.be.above(29);
         //output.reason.should.match(/BG 39<80/);
@@ -725,6 +728,7 @@ describe('determine-basal', function ( ) {
         profile.current_basal = 0.825;
         profile.model = "523";
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens, meal_data, tempBasalFunctions);
+        //console.log(output);
         //output.rate.should.equal(0);
         //output.duration.should.equal(0);
         output.rate.should.equal(0.825);
@@ -738,6 +742,7 @@ describe('determine-basal', function ( ) {
         profile.current_basal = 0.875;
         profile.model = "522";
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens, meal_data, tempBasalFunctions);
+        //console.log(output);
         //output.rate.should.equal(0);
         //output.duration.should.equal(0);
         output.rate.should.equal(0.9);

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -479,7 +479,7 @@ describe('determine-basal', function ( ) {
         var output = determine_basal({glucose:10},currenttemp, iob_data, profile, autosens, meal_data, tempBasalFunctions);
         //console.log(output);
         output.rate.should.be.below(1);
-        output.reason.should.match(/Canceling high temp/);
+        output.reason.should.match(/Replacing high temp/);
     });
 
     it('profile should contain min_bg,max_bg', function () {


### PR DESCRIPTION
As detailed at https://github.com/openaps/oref0/issues/1257, a failing Libre sensor, uploaded to Nightscout via LimiTTer/xDrip+, can result in falsely high and too-flat CGM readings and incorrect insulin delivery.  The existing mitigation for this, to avoid looping on completely unchanging CGM data, was insufficient in this case.  To further mitigate this and similar issues, this PR changes that check to look for CGM data that is changing less than 1 mg/dL/5m for 45m.  As shown at https://gist.github.com/scottleibrand/4c8c84d9989afc98bc92214a08e849f0, that would have been sufficient to prevent further insulin dosing in this case after CGM data falsely flattened out at 290 mg/dL.

This will likely result in occasional false-positives when BG is truly flat for an extended period of time, or transiently when both the short_avgdelta and long_avgdelta are between -1 and 1 mg/dL/5m.  However, such false-positives should be brief, and will simply result in OpenAPS refraining from SMBs or high-temps until more-plausible CGM data arrives.