### PR TITLE
don't loop on too-flat CGM data (to master)

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -74,11 +74,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     }
-    // if BG is too old/noisy, or is completely unchanging, cancel any high temps and shorten any long zero temps
-    if ( glucose_status.short_avgdelta == 0 && glucose_status.long_avgdelta == 0 ) {
+    // if BG is too old/noisy, or is changing less than 1 mg/dL/5m for 45m, cancel any high temps and shorten any long zero temps
+    if ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
         rT.reason = "Error: CGM data is unchanged for the past ~45m";
     }
-    if (bg <= 10 || bg == 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta == 0 && glucose_status.long_avgdelta == 0 ) ) {
+    if (bg <= 10 || bg == 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
         if (currenttemp.rate >= basal) { // high temp is running
             rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
             rT.deliverAt = deliverAt;

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -78,7 +78,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     if ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
         rT.reason = "Error: CGM data is unchanged for the past ~45m";
     }
-    if (bg <= 10 || bg == 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) {
+    if (bg <= 10 || bg == 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {
         if (currenttemp.rate >= basal) { // high temp is running
             rT.reason += ". Canceling high temp basal of "+currenttemp.rate;
             rT.deliverAt = deliverAt;

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -78,7 +78,7 @@ describe('determine-basal', function ( ) {
    //function determine_basal(glucose_status, currenttemp, iob_data, profile)
 
     // standard initial conditions for all determine-basal test cases unless overridden
-    var glucose_status = {"delta":0,"glucose":115,"long_avgdelta":0.1,"short_avgdelta":0};
+    var glucose_status = {"delta":0,"glucose":115,"long_avgdelta":1.1,"short_avgdelta":0};
     var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
     var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
     var profile = {"max_iob":2.5,"dia":3,"type":"current","current_basal":0.9,"max_daily_basal":1.3,"max_basal":3.5,"max_bg":120,"min_bg":110,"sens":40,"carb_ratio":10};
@@ -246,7 +246,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when LOW w/ positive IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":1.1,"short_avgdelta":0};
         var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0.5};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);
@@ -255,7 +255,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should low temp when LOW w/ negative IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":1.1,"short_avgdelta":0};
         var iob_data = {"iob":-2.5,"activity":-0.03,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.be.below(0.8);
@@ -264,7 +264,7 @@ describe('determine-basal', function ( ) {
     });
 
     it('should temp to 0 when LOW w/ no IOB', function () {
-        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":0.1,"short_avgdelta":0};
+        var glucose_status = {"delta":0,"glucose":39,"long_avgdelta":1.1,"short_avgdelta":0};
         var iob_data = {"iob":0,"activity":0,"bolussnooze":0};
         var output = determine_basal(glucose_status, currenttemp, iob_data, profile, undefined, meal_data, tempBasalFunctions);
         output.rate.should.equal(0);


### PR DESCRIPTION
As detailed at https://github.com/openaps/oref0/issues/1257, a failing Libre sensor, uploaded to Nightscout via LimiTTer/xDrip+, can result in falsely high and too-flat CGM readings and incorrect insulin delivery.  The existing mitigation for this, to avoid looping on completely unchanging CGM data, was insufficient in this case.  To further mitigate this and similar issues, this PR changes that check to look for CGM data that is changing less than 1 mg/dL/5m for 45m.  As shown at https://gist.github.com/scottleibrand/4c8c84d9989afc98bc92214a08e849f0, that would have been sufficient to prevent further insulin dosing in this case after CGM data falsely flattened out at 290 mg/dL.

This will likely result in occasional false-positives when BG is truly flat for an extended period of time, or transiently when both the short_avgdelta and long_avgdelta are between -1 and 1 mg/dL/5m.  However, such false-positives should be brief, and will simply result in OpenAPS refraining from SMBs or high-temps until more-plausible CGM data arrives.

See also https://github.com/openaps/oref0/pull/1258 for the same change to `dev`