### PR TITLE
Bgproxy integration.

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -88,6 +88,7 @@ main() {
             echo Completed oref0-pump-loop at $(date)
             update_display
             run_plugins
+            update_bgproxy
             echo
         else
             # pump-loop errored out for some reason
@@ -111,6 +112,16 @@ function run_script() {
   fi
 }
 
+
+function update_bgproxy {
+    if [ "$(get_pref_string .enableEnliteBgproxy '')" == "true" ]; then
+        echo Calling Bgproxy
+        jq 'map({sgv:.sgv, date:.date, dateString:.dateString})' monitor/glucose.json  > monitor/bgproxydata.json
+        bgproxy -f monitor/bgproxydata.json
+        echo Bgproxy completed
+    fi
+
+}
 
 function run_plugins {
         once=plugins/once

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -62,6 +62,9 @@ function defaults ( ) {
     , offline_hotspot: false // enabled an offline-only local wifi hotspot if no Internet available
     , noisyCGMTargetMultiplier: 1.3 // increase target by this amount when looping off raw/noisy CGM data
     , suspend_zeros_iob: true // recognize pump suspends as non insulin delivery events
+    // send the glucose data to the pump emulating an enlite sensor. This allows to setup high / low warnings when offline and see trend.
+    // To enable this feature, enable the sensor, set a sensor with id 0000000, go to start sensor and press find lost sensor.
+    , enableEnliteBgproxy: false
     // TODO: make maxRaw a preference here usable by oref0-raw in myopenaps-cgm-loop
     //, maxRaw: 200 // highest raw/noisy CGM value considered safe to use for looping
   };


### PR DESCRIPTION
A new preference option is added enableEnliteBgproxy. When set to true
the bgproxy command will be call at the end of every loop sending the
glucose data to the medtronic pump.

This gives an option to setup low and high alarms directly from the
pumps and also see the glucose trend when offline.

To enable this feature:
 - set enableEnliteBgproxy: true in preferences.json
 - turn on the sensor feature in the medtronic pump.
 - set the sensor id to 0000000 in Sensor setup
 - select sensor->sensor start->Find lost sensor. Glucose should appear after a couple of
cycles.