### PR TITLE
Add network module dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "moment-timezone": "0.5.23",
+    "network": "^0.4.1",
     "request": "^2.88.0",
     "share2nightscout-bridge": "^0.2.1",
     "yargs": "^13.2.2"


### PR DESCRIPTION
This fixes the issue of `Cannot find module 'network'` in the ns-looplog.

During the merge from sulkaharo's fork into the main dev branch it seems like this was left out because it was added in a later commit: https://github.com/sulkaharo/oref0/commit/b9cf6b84bde2a8d5bef9238c0306975ac9b92419#diff-b9cfc7f2cdf78a7f4b91a753d10865a2