### PR TITLE
Allow G4 Share serial to be blank

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -328,7 +328,7 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
     echocolor "Ok, $CGM it is."
     echo
     if [[ ${CGM,,} =~ "g4-go" ]]; then
-        prompt_and_validate BLE_SERIAL "If your G4 has Share, what is your G4 Share Serial Number? (i.e. SM12345678)" validate_g4share_serial
+        prompt_and_validate BLE_SERIAL "If your G4 has Share, what is your G4 Share Serial Number? (i.e. SM12345678)" validate_g4share_serial ""
         BLE_SERIAL=$REPLY
         echo "$BLE_SERIAL? Got it."
         echo


### PR DESCRIPTION
A small bug in `oref0-setup.sh` made it so that you couldn't proceed without providing a G4 Share serial number, breaking the use case where you don't have G4 Share. The problem is that `prompt_and_validate` takes an optional fourth argument for a default value, and if no default value is provided, then `prompt_and_validate` will re-prompt until you enter something that isn't blank.