### PR TITLE
Empty target fix

### DIFF
--- a/lib/autotune/index.js
+++ b/lib/autotune/index.js
@@ -100,7 +100,7 @@ function tuneAllTheThings (inputs) {
 
     // tune insulinPeakTime
     var newPeak = peak;
-    if (peakDeviations) {
+    if (peakDeviations && peakDeviations[2]) {
         var currentPeakMeanDev = peakDeviations[2].meanDeviation;
         var currentPeakRMSDev = peakDeviations[2].RMSDeviation;
         //console.error(currentPeakMeanDev);

--- a/lib/profile/targets.js
+++ b/lib/profile/targets.js
@@ -47,6 +47,9 @@ function lookup (inputs, profile) {
             //console.error(temptargets_data[i]);
             tempTargets = bgTargets;
             break;
+        } else if (! temptargets_data[i].targetBottom || ! temptargets_data[i].targetTop) {
+            console.error("eventualBG target range invalid: " + temptargets_data[i].targetBottom + "-" + temptargets_data[i].targetTop);
+            break;
         } else if (now >= start && now < expires ) {
             //console.error(temptargets_data[i]);
             tempTargets.high = temptargets_data[i].targetTop;


### PR DESCRIPTION
Fixes #1271, where a temp target entry without a min/max target value would bypass the existing validity checks and result in insufficient insulin dosing for the duration of the temp target.

This PR skips any temp target values without a valid min (and max, if wide_bg_target_range is set) target value.