### PR TITLE
Prevent increase in basal on low delta

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -972,8 +972,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     // if eventual BG is above min but BG is falling faster than expected Delta
     if (minDelta < expectedDelta) {
-        // if in SMB mode, don't cancel SMB zero temp
-        if (! (microBolusAllowed && enableSMB)) {
+        // don't increase the basal rate in response to a low delta
+        if (basal < currenttemp.rate) {
             if (glucose_status.delta < minDelta) {
                 rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Delta " + convert_bg(tick, profile) + " < Exp. Delta " + convert_bg(expectedDelta, profile);
             } else {


### PR DESCRIPTION
Revolve a situation in which a non-smb zero temp can be reverted to full basal when delta is less than expected.

Situation can occur where only enableSMB_with_COB is enabled and carbs hit zero after a smb. It can result in extra basal insulin when a zero temp is required.