### PR TITLE
Prevent basal rate increase on low delta

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -972,19 +972,26 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     // if eventual BG is above min but BG is falling faster than expected Delta
     if (minDelta < expectedDelta) {
-        // don't increase the basal rate in response to a low delta
-        if (basal < currenttemp.rate) {
+        // if in SMB mode, don't cancel SMB zero temp
+        if (! (microBolusAllowed && enableSMB)) {
             if (glucose_status.delta < minDelta) {
                 rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Delta " + convert_bg(tick, profile) + " < Exp. Delta " + convert_bg(expectedDelta, profile);
             } else {
                 rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Min. Delta " + minDelta.toFixed(2) + " < Exp. Delta " + convert_bg(expectedDelta, profile);
             }
-            if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
-                rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
-                return rT;
+
+            // don't increase the basal rate in response to a low delta
+            if (currenttemp.duration > 0 && basal > currenttemp.rate) {
+                rT.reason += "; extending current temp basal of " + currenttemp.rate + " U/hr. for 10 minutes. ";
+                return tempBasalFunctions.setTempBasal(currenttemp.rate, currenttemp.duration + 10, profile, rT, currenttemp);
             } else {
-                rT.reason += "; setting current basal of " + basal + " as temp. ";
-                return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+                if (currenttemp.duration > 15 && (round_basal(basal, profile) === round_basal(currenttemp.rate, profile))) {
+                    rT.reason += ", temp " + currenttemp.rate + " ~ req " + basal + "U/hr. ";
+                    return rT;
+                } else {
+                    rT.reason += "; setting current basal of " + basal + " as temp. ";
+                    return tempBasalFunctions.setTempBasal(basal, 30, profile, rT, currenttemp);
+                }
             }
         }
     }

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -972,8 +972,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
 
     // if eventual BG is above min but BG is falling faster than expected Delta
     if (minDelta < expectedDelta) {
-        // if in SMB mode, don't cancel SMB zero temp
-        if (! (microBolusAllowed && enableSMB)) {
+        // don't increase the basal rate in response to a low delta
+        if (basal < currenttemp.rate) {
             if (glucose_status.delta < minDelta) {
                 rT.reason += "Eventual BG " + convert_bg(eventualBG, profile) + " > " + convert_bg(min_bg, profile) + " but Delta " + convert_bg(tick, profile) + " < Exp. Delta " + convert_bg(expectedDelta, profile);
             } else {

--- a/tests/determine-basal.test.js
+++ b/tests/determine-basal.test.js
@@ -408,6 +408,16 @@ describe('determine-basal', function ( ) {
         output.reason.should.match(/Eventual BG.*>.*but.*Delta.*< Exp.*/);
     });
 
+    it('should not cancel low-temp when high and delta falling faster than BGI', function () {
+        var currenttemp = {"duration":20,"rate":0,"temp":"absolute"};
+        var glucose_status = {"delta":-5,"glucose":175,"long_avgdelta":-4,"short_avgdelta":-4};
+        var iob_data = {"iob":1,"activity":0.01,"bolussnooze":0};
+        var output = determine_basal(glucose_status, currenttemp, iob_data, profile, autosens, meal_data, tempBasalFunctions);
+        output.rate.should.equal(0);
+        output.duration.should.equal(30);
+        output.reason.should.match(/Eventual BG.*>.*but.*Delta.*< Exp.*/);
+    });
+
     it('should do nothing when no temp and high and delta falling faster than BGI', function () {
         var currenttemp = {"duration":0,"rate":0,"temp":"absolute"};
         var glucose_status = {"delta":-5,"glucose":175,"long_avgdelta":-4,"short_avgdelta":-4};


### PR DESCRIPTION

Revolve a situation in which a non-smb zero temp can be reverted to full basal when delta is less than expected.

Situation can occur where only enableSMB_with_COB is enabled and carbs hit zero after a smb. It can result in extra basal insulin when a zero tempt is required.