### PR TITLE
fix systemctl syntax in oref0-bluetoothup

### DIFF
--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -31,7 +31,7 @@ if ! ( ps -fC bluetoothd >/dev/null ) ; then
       sudo $EXECUTABLE 2>&1 | tee -a /var/log/openaps/bluetoothd.log &
    else
       echo bluetoothd not running! Starting bluetoothd via systemctl.
-      sudo systemctl bluetooth start
+      sudo systemctl start bluetooth
    fi
 fi
 
@@ -42,7 +42,7 @@ if is_edison && ! ( hciconfig -a hci${adapter} | grep -q "PSCAN" ) ; then
       sudo $EXECUTABLE 2>&1 | tee -a /var/log/openaps/bluetoothd.log &
    else
       echo Bluetooth PSCAN not enabled! Restarting bluetoothd via systemctl...
-      sudo systemctl bluetooth restart
+      sudo systemctl restart bluetooth
    fi
 fi
 


### PR DESCRIPTION
Fixes the newly added systemctl commands, whose start/restart bluetooth commands use an incorrect argument order, resulting in an inability for oref0-bluetoothup to automatically resolve bluetoothd issues.