### PR TITLE
raspbian password checking adjustment (also expire correct user)

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -9,16 +9,28 @@ sed -r -i"" "s/localhost( jubilinux)?$/localhost $myrighostname/" /etc/hosts
 sed -r -i"" "s/127.0.1.1.*$/127.0.1.1       $myrighostname/" /etc/hosts
 
 # if passwords are old, force them to be changed at next login
-passwd -S edison 2>/dev/null | grep 20[01][0-6] && passwd -e root
+passwd -S root 2>/dev/null | grep 20[01][0-6] && passwd -e root
 # automatically expire edison account if its password is not changed in 3 days
 passwd -S edison 2>/dev/null | grep 20[01][0-6] && passwd -e edison -i 3
 
-if [ -e /run/sshwarn ] ; then
-    echo Please select a secure password for ssh logins to your rig:
-    echo 'For the "root" account:'
-    passwd root
-    echo 'And for the "pi" account (same password is fine):'
-    passwd pi
+# Password checking for Raspbian
+if test -f /etc/os-release && grep -q Raspbian /etc/os-release && test -f /boot/issue.txt ; then
+    if [[ "$(awk -F'[ -]' '/Raspberry/ {print $5"/"$6"/"$4}' /boot/issue.txt)" == "$(sudo passwd -S root|awk '{print $3}')" ]]; then 
+        # Password of 'root' user has the same date as the reference build date. Change it.
+        passwdPrompt=1
+        echo "Please select a secure password for ssh logins to your rig (same password for multiple accounts is fine):"
+        echo 'For the "root" account:'
+        sudo passwd root 
+    fi
+    if [[ "$(awk -F'[ -]' '/Raspberry/ {print $5"/"$6"/"$4}' /boot/issue.txt)" == "$(sudo passwd -S pi|awk '{print $3}')" ]]; then 
+        # Password of 'pi' user has the same date as the reference build date. Change it.
+        # If we haven't already prompted with the following text, display it.
+        test ${passwdPrompt:-0} -ne 1 && 
+            echo "Please select a secure password for ssh logins to your rig (same password for multiple accounts is fine):"
+        echo 'For the "pi" account:'
+        sudo passwd pi 
+    fi
+    unset passwdPrompt
 fi
 
 # set timezone


### PR DESCRIPTION
old line 12: the existing logic didn't make sense to me check for edison  but expire root so adjusting to check for root, expire root
old line 16-21: If you changed the password for 'pi' before running the script you'd never get to the part about changing root's password as it's disabled and locked by default and therefore `/run/sshwarn` will not exist.
new line 16-32: Check if we are running Raspbian, check the build date against the current password date for both pi and root. If they are the same, we are using default passwords and prompt for change. Checking them independently and only display information message once.

Let me know if you have questions.