### PR TITLE
fix wrong interface choose

### DIFF
--- a/bin/oref0-cron-every-minute.sh
+++ b/bin/oref0-cron-every-minute.sh
@@ -42,7 +42,7 @@ if ! is_bash_process_running_named "oref0-online $BT_MAC"; then
     oref0-online "$BT_MAC" 2>&1 >> /var/log/openaps/network.log &
 fi
 
-sudo wpa_cli scan &
+sudo wpa_cli -i wlan0 scan &
 
 (
     killall -g --older-than 30m openaps


### PR DESCRIPTION
By default, choose the first interface found with a control socket in the socket path.