### PR TITLE
minZTUAMPredBG should only be used if UAM is enabled

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -754,18 +754,22 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // if any carbs have been entered recently
     if (meal_data.carbs) {
 
-        // if UAM is disabled, use max of minIOBPredBG, minCOBPredBG
-        if ( ! enableUAM && minCOBPredBG < 999 ) {
-            minPredBG = round(Math.max(minIOBPredBG, minCOBPredBG));
-        // if we have COB, use minCOBPredBG, or blendedMinPredBG if it's higher
-        } else if ( minCOBPredBG < 999 ) {
-            // calculate blendedMinPredBG based on how many carbs remain as COB
-            var blendedMinPredBG = fractionCarbsLeft*minCOBPredBG + (1-fractionCarbsLeft)*minZTUAMPredBG;
-            // if blendedMinPredBG > minCOBPredBG, use that instead
-            minPredBG = round(Math.max(minIOBPredBG, minCOBPredBG, blendedMinPredBG));
-        // if carbs have been entered, but have expired, use minUAMPredBG
+        if (!enableUAM) {
+            // if UAM is disabled, use max of minIOBPredBG, minCOBPredBG
+            if (minCOBPredBG < 999 ) {
+                minPredBG = round(Math.max(minIOBPredBG, minCOBPredBG));
+            }
         } else {
-            minPredBG = minZTUAMPredBG;
+            // if we have COB, use minCOBPredBG, or blendedMinPredBG if it's higher
+            if ( minCOBPredBG < 999 ) {
+                // calculate blendedMinPredBG based on how many carbs remain as COB
+                var blendedMinPredBG = fractionCarbsLeft*minCOBPredBG + (1-fractionCarbsLeft)*minZTUAMPredBG;
+                // if blendedMinPredBG > minCOBPredBG, use that instead
+                minPredBG = round(Math.max(minIOBPredBG, minCOBPredBG, blendedMinPredBG));
+            // if carbs have been entered, but have expired, use minUAMPredBG
+            } else {
+                minPredBG = minZTUAMPredBG;
+            }
         }
     // in pure UAM mode, use the higher of minIOBPredBG,minUAMPredBG
     } else if ( enableUAM ) {


### PR DESCRIPTION
I think this is a bug.

I've observed minPredBG ending up as high as 460 (where the 999 value of minUAMPredBG ends up being used as real data).

The problem is mitigated by the `minPredBG = Math.min( minPredBG, avgPredBG );` line later on but may still cause problems.