### PR TITLE
Reestablish bluetooth connection after failure to set bluetooth hci name

### DIFF
--- a/bin/oref0-bluetoothup.sh
+++ b/bin/oref0-bluetoothup.sh
@@ -56,4 +56,8 @@ if !( hciconfig -a hci${adapter} | grep -q $HOSTNAME ) ; then
       # Not sure that this is needed on Stretch, add an is_debian_jessie check here if something different required.
       echo Bluetooth hci name does not match hostname: $HOSTNAME. Setting bluetooth hci name.
       sudo hciconfig hci${adapter} name $HOSTNAME
+      if !( hciconfig -a hci${adapter} | grep -q $HOSTNAME ) ; then
+         echo Failed to set bluetooth hci name. Reset bluetooth adapter.
+         hciconfig hci${adapter} reset
+      fi
 fi

--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -155,7 +155,12 @@ function bt_connect {
                || (test -f preferences.json \
                 && jq -e .bt_with_wifi < preferences.json > /dev/null); then
             echo; echo "No Internet access detected, attempting to connect BT to $MAC"
-            oref0-bluetoothup
+            if ! is_bash_process_running_named "oref0-bluetoothup"; then
+                oref0-bluetoothup
+            else
+                echo "oref0-bluetoothup already running"
+            fi
+            
             if ! test -f preferences.json \
                 || ! jq -e .bt_offline < preferences.json > /dev/null \
                 || ! ifconfig | egrep -q "bnep0" >/dev/null; then


### PR DESCRIPTION
With this fix, I can maintain my bluetooth connection and continue looping where I otherwise wouldn't 2-3 times per day.  Running this code I get the following logs (and then the subsequent loop will reestablish my bluetooth connection).

```
Bluetooth hci name does not match hostname: sweetbasal. Setting bluetooth hci name.
hci0:	Type: BR/EDR  Bus: UART
	BD Address: 58:A8:39:01:D7:40  ACL MTU: 1021:8  SCO MTU: 64:1
	UP RUNNING PSCAN 
	RX bytes:47078744 acl:91357 sco:0 events:46538 errors:0
	TX bytes:8902971 acl:70445 sco:0 commands:7301 errors:0
	Features: 0xbf 0xfe 0xcf 0xfe 0xdb 0xff 0x7b 0x87
	Packet type: DM1 DM3 DM5 DH1 DH3 DH5 HV1 HV2 HV3 
	Link policy: RSWITCH SNIFF 
	Link mode: SLAVE ACCEPT 
Tue Sep 17 12:49:12 EDT 2019 Failed to set bluetooth hci name. Stop bluetoothd and allow next cycle to handle restart.
Tue Sep 17 12:49:12 EDT 2019 Stopping bluetoothd...
Tue Sep 17 12:49:12 EDT 2019 Stopped bluetoothd
```

