### PR TITLE
per #1288, only use minZTUAMPredBG if enableUAM

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -764,8 +764,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // if blendedMinPredBG > minCOBPredBG, use that instead
             minPredBG = round(Math.max(minIOBPredBG, minCOBPredBG, blendedMinPredBG));
         // if carbs have been entered, but have expired, use minUAMPredBG
-        } else {
+        } else if ( enableUAM ) {
             minPredBG = minZTUAMPredBG;
+        } else {
+            minPredBG = minGuardBG;
         }
     // in pure UAM mode, use the higher of minIOBPredBG,minUAMPredBG
     } else if ( enableUAM ) {


### PR DESCRIPTION
and use minGuardBG otherwise

This is intended to address the problem posed in #1288, and I'm hoping simplifies the solution proposed there and makes it easier to validate.