### PR TITLE
Improved rounding of mmol/L units in oref0-upload-profile

### DIFF
--- a/bin/oref0-upload-profile.js
+++ b/bin/oref0-upload-profile.js
@@ -178,11 +178,17 @@ if (!module.parent) {
 
         _.forEach(profiledata.isfProfile.sensitivities, function(isf_entry) {
 
-            var value = Math.round(isf_entry.sensitivity);
+            var value = isf_entry.sensitivity;
+            var conversionFactor = 1;
+            var decimals = new_profile.units === 'mmol' ? 10 : 1;
 
-            if (new_profile.units === 'mmol' && profiledata.isfProfile.units === 'mg/dL') {
-                value = +(Math.round(isf_entry.sensitivity / 18 + 'e+1') + 'e-1');
+            if (profiledata.isfProfile.units && new_profile.units !== profiledata.isfProfile.units) {
+                // if the new profile is using a different unit than our ISF, then set the conversion factor accordingly
+                conversionFactor = (new_profile.units == 'mmol' ? 0.055 : 18);
             }
+
+            value *= conversionFactor;
+            value = Math.round(value * decimals) / decimals;
 
             var new_isf_entry = {
                 time: isf_entry.start.substring(0, 5)

--- a/bin/oref0-upload-profile.js
+++ b/bin/oref0-upload-profile.js
@@ -144,13 +144,21 @@ if (!module.parent) {
 
             var time = target_entry.start.substring(0, 5);
             var seconds = parseInt(time.substring(0, 2)) * 60 * 60 + parseInt(time.substring(3, 5)) * 60;
-            var low_value = Math.round(target_entry.low);
-            var high_value = Math.round(target_entry.high);
+            var low_value = target_entry.low;
+            var high_value = target_entry.high;
+            var conversionFactor = 1;
+            var decimals = new_profile.units === 'mmol' ? 10 : 1;
 
-            if (new_profile.units === 'mmol' && profiledata.bg_targets.units === 'mg/dL') {
-                low_value = +(Math.round(target_entry.low / 18 + 'e+1') + 'e-1');
-                high_value = +(Math.round(target_entry.high / 18 + 'e+1') + 'e-1');
+            if (new_profile.units !== profiledata.bg_targets.units) {
+                // if the new profile is using a different unit than our BG targets, then set the conversion factor accordingly
+                conversionFactor = (new_profile.units == 'mmol' ? 0.055 : 18);
             }
+
+            low_value *= conversionFactor;
+            high_value *= conversionFactor;
+
+            low_value = Math.round(low_value * decimals) / decimals;
+            high_value = Math.round(high_value * decimals) / decimals;
 
             var new_low_entry = {
                 time: '' + time

--- a/bin/oref0-upload-profile.js
+++ b/bin/oref0-upload-profile.js
@@ -149,8 +149,11 @@ if (!module.parent) {
             var conversionFactor = 1;
             var decimals = new_profile.units === 'mmol' ? 10 : 1;
 
+            // Check if the input profile units don't match the Nightscout profile units
             if (new_profile.units !== profiledata.bg_targets.units) {
-                // if the new profile is using a different unit than our BG targets, then set the conversion factor accordingly
+                // Set the conversion factor according to the units wanted
+                // 0.055 = divide by 18 (convert mg/dL to mmol/L)
+                // 18 = multiply by 18 (convert mmol/L to mg/dL)
                 conversionFactor = (new_profile.units == 'mmol' ? 0.055 : 18);
             }
 
@@ -190,8 +193,11 @@ if (!module.parent) {
             var conversionFactor = 1;
             var decimals = new_profile.units === 'mmol' ? 10 : 1;
 
+            // Check if the input profile units don't match the Nightscout profile units
             if (profiledata.isfProfile.units && new_profile.units !== profiledata.isfProfile.units) {
-                // if the new profile is using a different unit than our ISF, then set the conversion factor accordingly
+                // Set the conversion factor according to the units wanted
+                // 0.055 = divide by 18 (convert mg/dL to mmol/L)
+                // 18 = multiply by 18 (convert mmol/L to mg/dL)
                 conversionFactor = (new_profile.units == 'mmol' ? 0.055 : 18);
             }
 


### PR DESCRIPTION
When running `oref0-upload-profile` with an autotune report, the BG targets and ISF values in the report are rounded to the nearest whole number. This is not an issue if your autotune reports are generated in mg/dL units, however when using mmol/L a decimal is necessary to have precise ISF and BG target values. 

This PR solves these issues by changing the math for both ISF and BG targets to round to one decimal place if the profile units are in mmol/L. The rounding for mg/dL units is kept the same.