### PR TITLE
Fix values in mg/dl erroneously multiplied by 18 in profile upload to NS

### DIFF
--- a/bin/oref0-upload-profile.js
+++ b/bin/oref0-upload-profile.js
@@ -150,7 +150,7 @@ if (!module.parent) {
             var decimals = new_profile.units === 'mmol' ? 10 : 1;
 
             // Check if the input profile units don't match the Nightscout profile units
-            if (new_profile.units !== profiledata.bg_targets.units) {
+            if (new_profile.units.toUpperCase() !== profiledata.bg_targets.units.toUpperCase()) {
                 // Set the conversion factor according to the units wanted
                 // 0.055 = divide by 18 (convert mg/dL to mmol/L)
                 // 18 = multiply by 18 (convert mmol/L to mg/dL)
@@ -193,8 +193,8 @@ if (!module.parent) {
             var conversionFactor = 1;
             var decimals = new_profile.units === 'mmol' ? 10 : 1;
 
-            // Check if the input profile units don't match the Nightscout profile units
-            if (profiledata.isfProfile.units && new_profile.units !== profiledata.isfProfile.units) {
+            // Check if the input profile units don't match the Nightscout profile units 
+            if (profiledata.isfProfile.units && new_profile.units.toUpperCase() !== profiledata.isfProfile.units.toUpperCase()) {
                 // Set the conversion factor according to the units wanted
                 // 0.055 = divide by 18 (convert mg/dL to mmol/L)
                 // 18 = multiply by 18 (convert mmol/L to mg/dL)


### PR DESCRIPTION
Currently, a case-sensitive comparison of strings 'mg/dl' and 'mg/dL' causes the profile uploader to multiply the values measured in mg/dl by 18.  So an ISF of 50 mg/dl in OpenAPS becomes an ISF of 900 mg/dl in Nightscout.  And similarly, a target of 90 mg/dl in OpenAPS becomes a target of 1620 mg/dl in Nightscout.   This PR fixes that issue.