### PR TITLE
Refactor enable smb in determine-basal.js

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -28,10 +28,9 @@ DIR=""
 directory=""
 EXTRAS=""
 radio_locale="US"
-buildgofromsource=false
+radiotags="cc111x"
 ecc1medtronicversion="latest"
 ecc1dexcomversion="latest"
-radiotags="cc111x"
 hardwaretype=explorer-board
 
 # Echo text, but in bright-blue. Used for confirmation echo text. This takes
@@ -345,65 +344,48 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
         echocolor "Configuring for Explorer Board HAT. "
         ttyport=/dev/spidev0.0
         hardwaretype=explorer-hat
+	radiotags="cc111x"
     elif is_edison; then # Options for Edison (Explorer Board is default)
         echo "What kind of hardware setup do you have? Options are:"
         echo "1) Explorer Board"
-        echo "2) TI stick (DIY: SPI)"
+        echo "2) TI stick (SPI-connected)"
         echo "3) Other Radio (DIY: rfm69, cc11xx)"
         read -p "Please enter the number for your hardware configuration: [1] " -r
         case $REPLY in
-          2) echocolor "Configuring for SPI-connected TI stick. "; ttyport=/dev/spidev0.0; hardwaretype=386-spi;;
+          2) echocolor "Configuring for SPI-connected TI stick. "; ttyport=/dev/spidev0.0; hardwaretype=386-spi; radiotags="cc111x";;
           3)
              prompt_and_validate ttyport "What is your TTY port? (/dev/ttySOMETHING)" validate_ttyport
-             echocolor "Ok, we'll try TTY $ttyport then. "; echocolor "You will need to build Go binaries from source. "; buildgofromsource=true; hardwaretype=diy;;
-          *) echocolor "Yay! Configuring for Edison with Explorer Board. "; ttyport=/dev/spidev5.1; hardwaretype=edison-explorer;;
+             echocolor "Ok, we'll try TTY $ttyport then. "; echocolor "You will need to pick your radio type. "; hardwaretype=diy;;
+          *) echocolor "Yay! Configuring for Edison with Explorer Board. "; ttyport=/dev/spidev5.1; hardwaretype=edison-explorer; radiotags="cc111x";;
         esac
     elif is_pi; then # Options for raspberry pi, including Explorer HAT (default) if it's not auto-detected
 	echo "What kind of hardware setup do you have? Options are:"
 	echo "1) Explorer HAT"
 	echo "2) Radiofruit RFM69HCW Bonnet"
         echo "3) RFM69HCW (DIY: SPI)"
-        echo "4) TI Stick (DIY: SPI)"
+        echo "4) TI Stick (SPI-connected)"
 	echo "5) Other radio (DIY: rfm69, cc11xx)"
 	read -p "Please enter the number for your hardware configuration: [1] " -r
         case $REPLY in
-          2) echocolor "Configuring Radiofruit RFM69HCW Bonnet. "; ttyport=/dev/spidev0.1; hardwaretype=radiofruit;;
-          3) echocolor "Configuring RFM69HCW. "; ttyport=/dev/spidev0.1; hardwaretype=rfm69hcw;;
-          4) echocolor "Configuring for SPI-connected TI stick. "; ttyport=/dev/spidev0.0; hardwaretype=arm-spi;;
+          2) echocolor "Configuring Radiofruit RFM69HCW Bonnet. "; ttyport=/dev/spidev0.1; hardwaretype=radiofruit; radiotags="rfm69";;
+          3) echocolor "Configuring RFM69HCW. "; hardwaretype=diy;;
+          4) echocolor "Configuring for SPI-connected TI stick. "; ttyport=/dev/spidev0.0; hardwaretype=arm-spi; radiotags="cc111x";;
           5)
              prompt_and_validate ttyport "What is your TTY port? (/dev/ttySOMETHING)" validate_ttyport
-             echocolor "Ok, we'll try TTY $ttyport then. "; echocolor "You will need to build Go binaries from source. "; buildgofromsource=true; hardwaretype=diy;;
-          *) echocolor "Configuring Explorer Board HAT. "; ttyport=/dev/spidev0.0; hardwaretype=explorer-hat;;
+             echocolor "Ok, we'll try TTY $ttyport then. "; echocolor "You will need to pick your radio type. "; hardwaretype=diy;;
+          *) echocolor "Configuring Explorer Board HAT. "; ttyport=/dev/spidev0.0; hardwaretype=explorer-hat; radiotags="cc111x";;
         esac
-    else # If Edison or raspberry pi aren't detected, ask the user for their tty port and force Go binaries to be built from source
+    else # If Edison or raspberry pi aren't detected, ask the user for their tty port
         echo "Cannot auto-detect a supported platform (Edison or Raspberry Pi). Please make sure user 'edison' or 'pi' exists, or continue setup with manual configuration. "
         prompt_and_validate ttyport "What is your TTY port? (/dev/ttySOMETHING)" validate_ttyport
         echocolor "Ok, we'll try TTY $ttyport then. "
-        echocolor "You will need to build Go binaries from source."
-        buildgofromsource=true
+        echocolor "You will need to pick your radio type."
+        hardwaretype=diy
     fi
 
-    # Ask about downloading binaries, but only if hardware choices allow binaries to be used.
-    if [ $buildgofromsource = false ]; then
-      read -p "Would you like to [D]ownload released precompiled Go pump communication library or install an [U]nofficial (possibly untested) version.[D]/U " -r
-      if [[ $REPLY =~ ^[Uu]$ ]]; then
-        read -p "You could either build the Medtronic library from [S]ource, or type the version tag you would like to use, example 'v2019.01.21' [S]/<version> " -r
-        if [[ $REPLY =~ ^[Ss]$ ]]; then
-          buildgofromsource=true
-        else
-          ecc1medtronicversion="tags/$REPLY"
-          echo "Will use https://github.com/ecc1/medtronic/releases/$REPLY."
-          read -p "Also enter the ecc1/dexcom version, example 'v2018.12.05' <version> " -r
-          ecc1dexcomversion="tags/$REPLY"
-          echo "Will use https://github.com/ecc1/dexcom/$REPLY if Go-dexcom is needed."
-        fi
-      fi
-    fi
-
-    # Get details from the user about how binaries should be built from source, otherwise have setup download binaries. Default is cc111x.
-    if [ $buildgofromsource = true ]; then
-        echo "Building Go pump binaries from source"
-        echo "What type of radio do you use? Options are:"
+    # Get details from the user about how binaries should be built. Default is cc111x.
+    if [ $hardwaretype = diy ]; then
+        echo "What type of radio are you using? Options are:"
         echo "1) cc1110 or cc1111"
         echo "2) cc1101"
         echo "3) RFM69HCW on /dev/spidev0.0 (walrus)"
@@ -412,17 +394,29 @@ if [[ -z "$DIR" || -z "$serial" ]]; then
         read -p "Please enter the number for your radio configuration: [1] " -r
         case $REPLY in
           2) radiotags="cc1101";;
-          3) radiotags="rfm69 walrus";;
-          4) radiotags="rfm69";;
+          3) radiotags="rfm69 walrus"; ttyport=/dev/spidev0.0;;
+          4) radiotags="rfm69"; ttyport=/dev/spidev0.1;;
           5) read -p "Enter your radiotags: " -r; radiotags=$REPLY;;
           *) radiotags="cc111x";;
         esac
-        echo "Building Go pump binaries from source with " + "$radiotags" + " tags."
+        echo "Building Go pump binaries with " + "$radiotags" + " tags."
     else
-      echo "Downloading latest precompiled Go pump binaries."
-      ecc1medtronicversion="latest"
-      ecc1dexcomversion="latest"
+      echo "Building Go pump binaries with " + "$radiotags" + " tags."
+#      ecc1medtronicversion="latest"
+#      ecc1dexcomversion="latest"
     fi
+
+#TODO: add versioning support
+#    read -p "You could either build the Medtronic library from latest version, or type the version tag you would like to use, example 'v2019.01.21' [S]/<version> " -r
+#    if [[ $REPLY =~ ^[Vv]$ ]]; then
+#      ecc1medtronicversion="tags/$REPLY"
+#      echo "Will use https://github.com/ecc1/medtronic/releases/$REPLY."
+#      read -p "Also enter the ecc1/dexcom version, example 'v2018.12.05' <version> " -r
+#      ecc1dexcomversion="tags/$REPLY"
+#      echo "Will use https://github.com/ecc1/dexcom/$REPLY if Go-dexcom is needed."
+#    else 
+#      echo "Okay, building Medtronic library from latest version."
+#    fi
 
     if [[ ! -z "${ttyport}" ]]; then
       echo -e "\e[1mMedtronic pumps come in two types: WW (Worldwide) pumps, and NA (North America) pumps.\e[0m"
@@ -629,6 +623,9 @@ if [[ ! -z "$PUSHOVER_USER" ]]; then
 fi
 if [[ ! -z "$hardwaretype" ]]; then
     echo -n " --hardwaretype='$hardwaretype'" | tee -a $OREF0_RUNAGAIN
+fi
+if [[ ! -z "$radiotags" ]]; then
+    echo -n " --radiotags='$radiotags'" | tee -a $OREF0_RUNAGAIN
 fi
 echo; echo | tee -a $OREF0_RUNAGAIN
 chmod 755 $OREF0_RUNAGAIN
@@ -1261,40 +1258,32 @@ if prompt_yn "" N; then
     echo "Clearing retrieved apt packages to free space."
     apt-get autoclean && apt-get clean
 
-    # Install Go if needed, or set up paths
-    if [ $buildgofromsource = true ]; then
-      source $HOME/.bash_profile
-      if go version | grep go1.11.; then
-          echo Go already installed
-      else
-          echo "Installing Golang..."
-          if uname -m | grep armv; then
-              cd /tmp && wget -c https://storage.googleapis.com/golang/go1.11.linux-armv6l.tar.gz && tar -C /usr/local -xzvf /tmp/go1.11.linux-armv6l.tar.gz
-          elif uname -m | grep i686; then
-              cd /tmp && wget -c https://dl.google.com/go/go1.11.linux-386.tar.gz && tar -C /usr/local -xzvf /tmp/go1.11.linux-386.tar.gz
-          fi
-      fi
-      if ! grep GOROOT $HOME/.bash_profile; then
-          sed --in-place '/.*GOROOT*/d' $HOME/.bash_profile
-          echo 'GOROOT=/usr/local/go' >> $HOME/.bash_profile
-          echo 'export GOROOT' >> $HOME/.bash_profile
-      fi
-      if ! grep GOPATH $HOME/.bash_profile; then
-          sed --in-place '/.*GOPATH*/d' $HOME/.bash_profile
-          echo 'GOPATH=$HOME/go' >> $HOME/.bash_profile
-          echo 'export GOPATH' >> $HOME/.bash_profile
-          echo 'PATH=$PATH:/usr/local/go/bin:$GOROOT/bin:$GOPATH/bin' >> $HOME/.bash_profile
-          sed --in-place '/.*export PATH*/d' $HOME/.bash_profile
-          echo 'export PATH' >> $HOME/.bash_profile
-      fi
-    else
-      sed --in-place '/.*GOPATH*/d' $HOME/.bash_profile
-      echo 'PATH=$PATH:/usr/local/go/bin:$GOROOT/bin:$GOPATH/bin' >> $HOME/.bash_profile
-      sed --in-place '/.*export PATH*/d' $HOME/.bash_profile
-      echo 'export PATH' >> $HOME/.bash_profile
-    fi
-
+    # Install Golang
     mkdir -p $HOME/go
+    source $HOME/.bash_profile
+    if go version | grep go1.11.; then
+        echo Go already installed
+    else
+        echo "Installing Golang..."
+        if uname -m | grep armv; then
+            cd /tmp && wget -c https://storage.googleapis.com/golang/go1.11.linux-armv6l.tar.gz && tar -C /usr/local -xzvf /tmp/go1.11.linux-armv6l.tar.gz
+        elif uname -m | grep i686; then
+            cd /tmp && wget -c https://dl.google.com/go/go1.11.linux-386.tar.gz && tar -C /usr/local -xzvf /tmp/go1.11.linux-386.tar.gz
+        fi
+    fi
+    if ! grep GOROOT $HOME/.bash_profile; then
+        sed --in-place '/.*GOROOT*/d' $HOME/.bash_profile
+        echo 'GOROOT=/usr/local/go' >> $HOME/.bash_profile
+        echo 'export GOROOT' >> $HOME/.bash_profile
+    fi
+    if ! grep GOPATH $HOME/.bash_profile; then
+        sed --in-place '/.*GOPATH*/d' $HOME/.bash_profile
+        echo 'GOPATH=$HOME/go' >> $HOME/.bash_profile
+        echo 'export GOPATH' >> $HOME/.bash_profile
+        echo 'PATH=$PATH:/usr/local/go/bin:$GOROOT/bin:$GOPATH/bin' >> $HOME/.bash_profile
+        sed --in-place '/.*export PATH*/d' $HOME/.bash_profile
+        echo 'export PATH' >> $HOME/.bash_profile
+    fi
     source $HOME/.bash_profile
 
     #Necessary to "bootstrap" Go commands...
@@ -1304,61 +1293,51 @@ if prompt_yn "" N; then
       echo 916.55 > $directory/monitor/medtronic_frequency.ini
     fi
 
+    # Build pump communication binaries
+    # Exit if ttyport is not SPI. TODO: support UART-connected TI stick
     if [[ "$ttyport" =~ "spidev" ]]; then
-        #Turn on SPI for all pi-based setups. Not needed on the Edison
+        #Turn on SPI for all pi-based setups. Not needed on the Edison.
         if is_pi; then
           echo "Making sure SPI is enabled..."
           sed -i.bak -e "s/#dtparam=spi=on/dtparam=spi=on/" /boot/config.txt
         fi
-        #Translate hardware type into arch for Go binary downloads
-        if [[ "$hardwaretype" =~ "explorer-hat" || "$hardwaretype" =~ "arm-spi" ]]; then arch=arm-spi
-        elif [[ "$hardwaretype" =~ "radiofruit" || "$hardwaretype" =~ "rfm69hcw" ]]; then arch=arm-rfm69
-        elif [[ "$hardwaretype" =~ "edison-explorer" || "$hardwaretype" =~ "386-spi" ]]; then arch=386-spi
-        elif [[ "$hardwaretype" =~ "diy" ]]; then gobuildfromsource=true #make sure binaries aren't downloaded for DIY rigs
-        else arch=386-spi
-        fi
-    #TODO: Support non-SPI ports (TI stick over UART)
-    #elif [[ "$ttyport" =~ "tty" ]]; then
-    #    if [[ "$hardwaretype" =~ "386-uart" && is_edison ]]; then arch=386-uart
-    #    elif [[ "$hardwaretype" =~ "arm-uart" && is_pi ]]; then arch=arm-uart
+
+        #Make sure radiotags are set properly for different hardware types
+        #The only necessary one here at the moment is rfm69 (cc111x is the default in oref0-setup)
+        case $hardwaretype in
+          edison-explorer) radiotags="cc111x";;
+          explorer-hat) radiotags="cc111x";;
+          radiofruit) radiotags="rfm69";;
+          arm-spi) radiotags="cc111x";;
+          386-spi) radiotags="cc111x";;
+        esac
+
+        #Build Go binaries
+        go get -u -v -tags "$radiotags" github.com/ecc1/medtronic/... || die "Couldn't go get medtronic"
+        ln -sf $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq $directory/ || die "Couldn't softlink openaps.jq"
     else
         #TODO: write validate_ttyport and support non-SPI ports
         die "Unsupported ttyport. Exiting."
     fi
 
-    #Build Go binaries from source, or download prebuilt binaries package
-    if [ $buildgofromsource = true ]; then
-      go get -u -v -tags "$radiotags" github.com/ecc1/medtronic/... || die "Couldn't go get medtronic"
-      ln -sf $HOME/go/src/github.com/ecc1/medtronic/cmd/pumphistory/openaps.jq $directory/ || die "Couldn't softlink openaps.jq"
-    else
-      mkdir -p $HOME/go/bin && \
-      downloadUrl=$(curl -s https://api.github.com/repos/ecc1/medtronic/releases/$ecc1medtronicversion | \
-        jq --raw-output '.assets[] | select(.name | contains("'$arch'")) | .browser_download_url')
-      echo "Downloading Go pump binaries from:" $downloadUrl
-      wget -qO- $downloadUrl | tar xJv -C $HOME/go/bin || die "Couldn't download and extract Go pump binaries"
-      echo "Installing Go pump binaries ..."
-      ln -sf $HOME/go/bin/openaps.jq $directory/ || die "Couldn't softlink openaps.jq"
-    fi
-
     if [[ ${CGM,,} =~ "g4-go" ]]; then
         if [ ! -d $HOME/go/bin ]; then mkdir -p $HOME/go/bin; fi
-        echo "Installing or Compiling Go dexcom binaries ..."
-        if $buildgofromsource; then
-            if is_edison; then
-                go get -u -v -tags nofilter github.com/ecc1/dexcom/...
-            else
-                go get -u -v github.com/ecc1/dexcom/...
-            fi
+        echo "Compiling Go dexcom binaries ..."
+        if is_edison; then
+            go get -u -v -tags nofilter github.com/ecc1/dexcom/...
         else
-            arch=arm
-            if egrep -i "edison" /etc/passwd &>/dev/null; then
-                arch=386
-            fi
-            downloadUrl=$(curl -s https://api.github.com/repos/ecc1/dexcom/releases/$ecc1dexcomversion | \
-            jq --raw-output '.assets[] | select(.name | contains("'$arch'")) | .browser_download_url')
-            echo "Downloading Go dexcom binaries from:" $downloadUrl
-            wget -qO- $downloadUrl | tar xJv -C $HOME/go/bin || die "Couldn't download and extract Go dexcom binaries"
+            go get -u -v github.com/ecc1/dexcom/...
         fi
+#        else
+#            arch=arm
+#            if egrep -i "edison" /etc/passwd &>/dev/null; then
+#                arch=386
+#            fi
+#            downloadUrl=$(curl -s https://api.github.com/repos/ecc1/dexcom/releases/$ecc1dexcomversion | \
+#            jq --raw-output '.assets[] | select(.name | contains("'$arch'")) | .browser_download_url')
+#           echo "Downloading Go dexcom binaries from:" $downloadUrl
+#            wget -qO- $downloadUrl | tar xJv -C $HOME/go/bin || die "Couldn't download and extract Go dexcom binaries"
+#        fi
     fi
 
     copy_go_binaries

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -47,7 +47,7 @@ function convert_bg(value, profile)
     }
 }
 
-var enable_smb = function enable_smb(
+function enableSmb(
     profile,
     microBolusAllowed,
     meal_data,

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -52,8 +52,7 @@ var enable_smb = function enable_smb(
     microBolusAllowed,
     meal_data,
     bg,
-    target_bg,
-    high_bg
+    target_bg
 ) {
     // disable SMB when a high temptarget is set
     if (! microBolusAllowed) {
@@ -431,75 +430,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         microBolusAllowed,
         meal_data,
         bg,
-        target_bg,
-        high_bg
+        target_bg
     );
 
-    // enable SMB whenever we have COB or UAM is enabled
-    // SMB is disabled by default, unless explicitly enabled in preferences.json
-    var enableSMB=false;
-    // disable SMB when a high temptarget is set
-    if (! microBolusAllowed) {
-        console.error("SMB disabled (!microBolusAllowed)")
-    } else if (! profile.allowSMB_with_high_temptarget && profile.temptargetSet && target_bg > 100) {
-        console.error("SMB disabled due to high temptarget of",target_bg);
-        enableSMB=false;
-    // enable SMB/UAM (if enabled in preferences) while we have COB
-    } else if (profile.enableSMB_with_COB === true && meal_data.mealCOB) {
-        if (meal_data.bwCarbs) {
-            if (profile.A52_risk_enable === true) {
-                console.error("Warning: SMB enabled with Bolus Wizard carbs: be sure to easy bolus 30s before using Bolus Wizard")
-                enableSMB=true;
-            } else {
-                console.error("SMB not enabled for Bolus Wizard COB");
-            }
-        } else {
-            console.error("SMB enabled for COB of",meal_data.mealCOB);
-            enableSMB=true;
-        }
-    // enable SMB/UAM (if enabled in preferences) for a full 6 hours after any carb entry
-    // (6 hours is defined in carbWindow in lib/meal/total.js)
-    } else if ((profile.enableSMB_after_carbs === true || profile.enableSMB_with_carbs === true) && meal_data.carbs ) {
-        if (meal_data.bwCarbs) {
-            if (profile.A52_risk_enable === true) {
-            console.error("Warning: SMB enabled with Bolus Wizard carbs: be sure to easy bolus 30s before using Bolus Wizard")
-            enableSMB=true;
-            } else {
-                console.error("SMB not enabled for Bolus Wizard carbs");
-            }
-        } else {
-            console.error("SMB enabled for 6h after carb entry");
-            enableSMB=true;
-        }
-    // enable SMB/UAM (if enabled in preferences) if a low temptarget is set
-    } else if (profile.enableSMB_with_temptarget === true && (profile.temptargetSet && target_bg < 100)) {
-        if (meal_data.bwFound) {
-            if (profile.A52_risk_enable === true) {
-                console.error("Warning: SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard")
-                enableSMB=true;
-            } else {
-                console.error("enableSMB_with_temptarget not supported within 6h of using Bolus Wizard");
-            }
-        } else {
-            console.error("SMB enabled for temptarget of",convert_bg(target_bg, profile));
-            enableSMB=true;
-        }
-    // enable SMB/UAM if always-on (unless previously disabled for high temptarget)
-    } else if (profile.enableSMB_always === true) {
-        if (meal_data.bwFound) {
-            if (profile.A52_risk_enable === true) {
-                console.error("Warning: SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard")
-                enableSMB=true;
-            } else {
-                console.error("enableSMB_always not supported within 6h of using Bolus Wizard");
-            }
-        } else {
-            console.error("SMB enabled due to enableSMB_always");
-            enableSMB=true;
-        }
-    } else {
-        console.error("SMB disabled for this run (no selected enableSMB criteria met)");
-    }
     // enable UAM (if enabled in preferences)
     var enableUAM=(profile.enableUAM);
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -47,11 +47,10 @@ function convert_bg(value, profile)
     }
 }
 
-function enableSmb(
+function enable_smb(
     profile,
     microBolusAllowed,
     meal_data,
-    bg,
     target_bg
 ) {
     // disable SMB when a high temptarget is set
@@ -425,11 +424,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     ZTpredBGs.push(bg);
     UAMpredBGs.push(bg);
 
-    enableSMB = enableSMB(
+    var enableSMB = enable_smb(
         profile,
         microBolusAllowed,
         meal_data,
-        bg,
         target_bg
     );
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -47,6 +47,71 @@ function convert_bg(value, profile)
     }
 }
 
+var enable_smb = function enable_smb(
+    profile,
+    microBolusAllowed,
+    meal_data,
+    bg,
+    target_bg,
+    high_bg
+) {
+    // disable SMB when a high temptarget is set
+    if (! microBolusAllowed) {
+        console.error("SMB disabled (!microBolusAllowed)");
+        return false;
+    } else if (! profile.allowSMB_with_high_temptarget && profile.temptargetSet && target_bg > 100) {
+        console.error("SMB disabled due to high temptarget of",target_bg);
+        return false;
+    } else if (meal_data.bwFound === true && profile.A52_risk_enable === false) {
+        console.error("SMB disabled due to Bolus Wizard activity in the last 6 hours.");
+        return false;
+    }
+
+    // enable SMB/UAM if always-on (unless previously disabled for high temptarget)
+    if (profile.enableSMB_always === true) {
+        if (meal_data.bwFound) {
+            console.error("Warning: SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard");
+        } else {
+            console.error("SMB enabled due to enableSMB_always");
+        }
+        return true;
+    }
+
+    // enable SMB/UAM (if enabled in preferences) while we have COB
+    if (profile.enableSMB_with_COB === true && meal_data.mealCOB) {
+        if (meal_data.bwCarbs) {
+            console.error("Warning: SMB enabled with Bolus Wizard carbs: be sure to easy bolus 30s before using Bolus Wizard");
+        } else {
+            console.error("SMB enabled for COB of",meal_data.mealCOB);
+        }
+        return true;
+    } 
+    
+    // enable SMB/UAM (if enabled in preferences) for a full 6 hours after any carb entry
+    // (6 hours is defined in carbWindow in lib/meal/total.js)
+    if (profile.enableSMB_after_carbs === true && meal_data.carbs ) {
+        if (meal_data.bwCarbs) {
+            console.error("Warning: SMB enabled with Bolus Wizard carbs: be sure to easy bolus 30s before using Bolus Wizard");
+        } else {
+            console.error("SMB enabled for 6h after carb entry");
+        }
+        return true;
+    }
+    
+    // enable SMB/UAM (if enabled in preferences) if a low temptarget is set
+    if (profile.enableSMB_with_temptarget === true && (profile.temptargetSet && target_bg < 100)) {
+        if (meal_data.bwFound) {
+            console.error("Warning: SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard");
+        } else {
+            console.error("SMB enabled for temptarget of",convert_bg(target_bg, profile));
+        }
+        return true;
+    } 
+    
+    console.error("SMB disabled (no enableSMB preferences active or no condition satisfied)");
+    return false;
+}
+
 var determine_basal = function determine_basal(glucose_status, currenttemp, iob_data, profile, autosens_data, meal_data, tempBasalFunctions, microBolusAllowed, reservoir_data, currentTime) {
     var rT = {}; //short for requestedTemp
 
@@ -360,6 +425,15 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     IOBpredBGs.push(bg);
     ZTpredBGs.push(bg);
     UAMpredBGs.push(bg);
+
+    enableSMB = enableSMB(
+        profile,
+        microBolusAllowed,
+        meal_data,
+        bg,
+        target_bg,
+        high_bg
+    );
 
     // enable SMB whenever we have COB or UAM is enabled
     // SMB is disabled by default, unless explicitly enabled in preferences.json


### PR DESCRIPTION
So this is actually a step towards what I'm hoping to implement, but I think the `enable_smb` logic should be refactored to make it easier to read and add additional SMB toggles for more customize-ability in the future. 

Unfortunately my oAPS rigs are broken (radios are dead), so I'm not able to test this in oAPS but I have this running in AAPS and it's running with no issue. Would welcome some testing to make sure I didn't accidentally change some logic.