### PR TITLE
Upload preferences.json and oref0 version to devicestatus

### DIFF
--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -64,7 +64,7 @@ if (!module.parent) {
             nargs: 1,
             describe: "OpenAPS preferences file",
             default: false
-        },
+        })
         .option('uploader', {
             alias: 'u',
             nargs: 1,

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -39,6 +39,11 @@ function preferencesStatus (status) {
     var preferences = requireWithTimestamp(cwd + preferences_input);
     if (preferences) {
       status.preferences = preferences;
+      if (preferences.nightscout_host) { status.preferences.nightscout_host = "redacted"; }
+      if (preferences.bt_mac) { status.preferences.bt_mac = "redacted"; }
+      if (preferences.pushover_token) { status.preferences.pushover_token = "redacted"; }
+      if (preferences.pushover_user) { status.preferences.pushover_user = "redacted"; }
+      if (preferences.pump_serial) { status.preferences.pump_serial = "redacted"; }
     }
 }
 

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -59,6 +59,12 @@ if (!module.parent) {
 
     var argv = require('yargs')
         .usage("$0 <clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [--uploader uploader.json] [mmtune.json] [--preferences preferences.json]")
+        .option('preferences', {
+            alias: 'p',
+            nargs: 1,
+            describe: "OpenAPS preferences file",
+            default: false
+        },
         .option('uploader', {
             alias: 'u',
             nargs: 1,

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -58,7 +58,7 @@ function uploaderStatus (status) {
 if (!module.parent) {
 
     var argv = require('yargs')
-        .usage("$0 <clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [--uploader uploader.json] [mmtune.json] [preferences.json]")
+        .usage("$0 <clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [--uploader uploader.json] [mmtune.json] [--preferences preferences.json]")
         .option('uploader', {
             alias: 'u',
             nargs: 1,
@@ -78,7 +78,7 @@ if (!module.parent) {
     var reservoir_input = inputs[5];
     var status_input = inputs[6];
     var mmtune_input = inputs[7];
-    var preferences_input = inputs[8];
+    var preferences_input = params.uploader;
     var uploader_input = params.uploader;
 
     if (inputs.length < 7 || inputs.length > 8) {

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -84,7 +84,7 @@ if (!module.parent) {
     var reservoir_input = inputs[5];
     var status_input = inputs[6];
     var mmtune_input = inputs[7];
-    var preferences_input = params.uploader;
+    var preferences_input = params.preferences;
     var uploader_input = params.uploader;
 
     if (inputs.length < 7 || inputs.length > 8) {

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -98,7 +98,6 @@ if (!module.parent) {
     }
 
     var pjson = require('../package.json');
-    console.error(pjson.version);
 
     var cwd = process.cwd() + '/';
 

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -92,6 +92,9 @@ if (!module.parent) {
         process.exit(1);
     }
 
+    var pjson = require('../package.json');
+    console.error(pjson.version);
+
     var cwd = process.cwd() + '/';
 
     var hostname = 'unknown';
@@ -127,7 +130,8 @@ if (!module.parent) {
             openaps: {
                 iob: iob,
                 suggested: suggested,
-                enacted: enacted
+                enacted: enacted,
+                version: pjson.version
             },
             pump: {
                 clock: safeRequire(cwd + clock_input),

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -35,6 +35,13 @@ function mmtuneStatus (status) {
     }
 }
 
+function preferencesStatus (status) {
+    var preferences = requireWithTimestamp(cwd + preferences_input);
+    if (preferences) {
+      status.preferences = preferences;
+    }
+}
+
 function uploaderStatus (status) {
     var uploader = require(cwd + uploader_input);
     if (uploader) {
@@ -51,7 +58,7 @@ function uploaderStatus (status) {
 if (!module.parent) {
 
     var argv = require('yargs')
-        .usage("$0 <clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [--uploader uploader.json] [mmtune.json]")
+        .usage("$0 <clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [--uploader uploader.json] [mmtune.json] [preferences.json]")
         .option('uploader', {
             alias: 'u',
             nargs: 1,
@@ -71,6 +78,7 @@ if (!module.parent) {
     var reservoir_input = inputs[5];
     var status_input = inputs[6];
     var mmtune_input = inputs[7];
+    var preferences_input = inputs[8];
     var uploader_input = params.uploader;
 
     if (inputs.length < 7 || inputs.length > 8) {
@@ -125,6 +133,10 @@ if (!module.parent) {
 
         if (mmtune_input) {
             mmtuneStatus(status);
+        }
+
+        if (preferences_input) {
+            preferencesStatus(status);
         }
 
         if (uploader_input) {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -184,9 +184,9 @@ function upload_ns_status {
 # ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --uploader monitor/edison-battery.json > upload/ns-status.json
 function format_ns_status {
     if [ -s monitor/edison-battery.json ]; then
-        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json preferences.json --uploader monitor/edison-battery.json > upload/ns-status.json
+        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --preferences preferences.json --uploader monitor/edison-battery.json > upload/ns-status.json
     else
-        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json preferences.json > upload/ns-status.json
+        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --preferences preferences.json > upload/ns-status.json
     fi
 }
 

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -184,9 +184,9 @@ function upload_ns_status {
 # ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --uploader monitor/edison-battery.json > upload/ns-status.json
 function format_ns_status {
     if [ -s monitor/edison-battery.json ]; then
-        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --uploader monitor/edison-battery.json > upload/ns-status.json
+        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json preferences.json --uploader monitor/edison-battery.json > upload/ns-status.json
     else
-        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json
+        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json preferences.json > upload/ns-status.json
     fi
 }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -764,8 +764,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             // if blendedMinPredBG > minCOBPredBG, use that instead
             minPredBG = round(Math.max(minIOBPredBG, minCOBPredBG, blendedMinPredBG));
         // if carbs have been entered, but have expired, use minUAMPredBG
-        } else {
+        } else if ( enableUAM ) {
             minPredBG = minZTUAMPredBG;
+        } else {
+            minPredBG = minGuardBG;
         }
     // in pure UAM mode, use the higher of minIOBPredBG,minUAMPredBG
     } else if ( enableUAM ) {

--- a/logrotate.openaps
+++ b/logrotate.openaps
@@ -17,7 +17,7 @@
 /var/log/openaps/*.log {
   rotate 30
   daily
-  size 10M
+  size 5M
   compress
   delaycompress
   missingok


### PR DESCRIPTION
One repeated request from researchers is to be able to tell what preferences a user has enabled, and what version of oref0 they're running.  This uploads such information to the Nightscout devicestatus collection, so it can be included if the user chooses to donate their data to the OpenAPS Data Commons or similar. Sensitive PII from preferences.json is redacted prior to upload.