### PR TITLE
Standalone MRAA installer for OpenAPS v0.7.0

### DIFF
--- a/bin/oref0-mraa-install.sh
+++ b/bin/oref0-mraa-install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Starting MRAA build...Installing dependencies..."
+sudo apt-get -y install git build-essential swig3.0 cmake libjson-c-dev
+echo "Downloading MRAA..."
+mkdir -p ~/src && cd ~/src && wget https://github.com/intel-iot-devkit/mraa/archive/v1.7.0.tar.gz
+echo "Extracting and building MRAA..."
+tar -xvf v1.7.0.tar.gz && mv mraa-1.7.0/ mraa/
+mkdir -p mraa/build && cd mraa/build && cmake .. -DBUILDSWIGNODE=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr && make && sudo make install
+echo "Running ldconfig..."
+bash -c "grep -q i386-linux-gnu /etc/ld.so.conf || echo /usr/local/lib/i386-linux-gnu/ >> /etc/ld.so.conf && ldconfig"
+echo "MRAA installed. Please reboot before using."

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "oref0-mdt-update": "./bin/oref0-mdt-update.sh",
     "oref0-meal": "./bin/oref0-meal.js",
     "oref0-monitor-cgm": "./bin/oref0-monitor-cgm.sh",
+    "oref0-mraa-install": "./bin/oref0-mraa-install.sh",
     "oref0-ns-loop": "./bin/oref0-ns-loop.sh",
     "oref0-normalize-temps": "./bin/oref0-normalize-temps.js",
     "oref0_nightscout_check": "./bin/oref0_nightscout_check.py",


### PR DESCRIPTION
Slightly modified from the 0.6.0 installer, addresses https://github.com/openaps/oref0/issues/1270

Tested on Pi (Debian Buster) + Explorer HAT, could use testing on Edison (jessie & stretch) + Explorer Board.