### PR TITLE
Call pumphistory_daily_refresh also in the case of a failure.

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -160,6 +160,7 @@ function fail {
         refresh_after_bolus_or_enact
         echo "Incomplete oref0-pump-loop (pump suspended) at $(date)"
     else
+        pumphistory_daily_refresh
         maybe_mmtune
         echo "If pump and rig are close enough, this error usually self-resolves. Stand by for the next loop."
         echo Unsuccessful oref0-pump-loop at $(date)


### PR DESCRIPTION
Needed in order to delete the file if the rig was booted after a long time.