### PR TITLE
fix glucose-noise lastDelta logic error

### DIFF
--- a/lib/glucose-stats.js
+++ b/lib/glucose-stats.js
@@ -46,7 +46,7 @@ const calcNoise = (sgvArr) => {
 
   // sod = sum of distances
   let sod = 0;
-  const lastDelta = 0;
+  let lastDelta = 0;
 
   for (let i = 1; i < n; i += 1) {
     // y2y1Delta adds a multiplier that gives
@@ -62,6 +62,8 @@ const calcNoise = (sgvArr) => {
       // switched from negative delta to positive, increase noise impact
       y2y1Delta *= 1.2;
     }
+
+    lastDelta = y2y1Delta;
 
     sod += Math.sqrt(Math.pow(x2x1Delta, 2) + Math.pow(y2y1Delta, 2));
   }

--- a/tests/glucose-noise.js
+++ b/tests/glucose-noise.js
@@ -156,7 +156,7 @@ describe('NOISE', function() {
       readDateMills: 1528892189592,
       filtered: 148544,
       unfiltered: 144256,
-      glucose: 158,
+      glucose: 148,
       trend: -6.002474353316756,
     }];
 


### PR DESCRIPTION
This makes the noise calculation a little more sensitive to trend direction changes by inserting a missing lastDelta assignment used to increase the weight of the glucose deltas.