### PR TITLE
update too-flat language

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -146,7 +146,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if ( glucose_status.last_cal && glucose_status.last_cal < 3 ) {
             rT.reason = "CGM was just calibrated";
         } else {
-            rT.reason = "CGM data is unchanged for 5m w/ <1 mg/dL change for the past ~15m and ~45m";
+            rT.reason = "CGM data is unchanged (+"+glucose_status.delta+") for 5m w/ "+glucose_status.short_avgdelta+" mg/dL ~15m change & "+glucose_status.long_avgdelta+" mg/dL ~45m change";
         }
     }
     if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( bg > 60 && glucose_status.delta == 0 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -146,7 +146,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if ( glucose_status.last_cal && glucose_status.last_cal < 3 ) {
             rT.reason = "CGM was just calibrated";
         } else {
-            rT.reason = "CGM data is unchanged (+"+glucose_status.delta+") for 5m w/ "+glucose_status.short_avgdelta+" mg/dL ~15m change & "+glucose_status.long_avgdelta+" mg/dL ~45m change";
+            rT.reason = "CGM data is unchanged ("+bg+"+"+glucose_status.delta+") for 5m w/ "+glucose_status.short_avgdelta+" mg/dL ~15m change & "+glucose_status.long_avgdelta+" mg/dL ~45m change";
         }
     }
     if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( bg > 60 && glucose_status.delta == 0 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -146,7 +146,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         if ( glucose_status.last_cal && glucose_status.last_cal < 3 ) {
             rT.reason = "CGM was just calibrated";
         } else {
-            rT.reason = "Error: CGM data is unchanged for 5m and too flat for the past ~15m and ~45m";
+            rT.reason = "CGM data is unchanged for 5m w/ <1 mg/dL change for the past ~15m and ~45m";
         }
     }
     if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || ( bg > 60 && glucose_status.delta == 0 && glucose_status.short_avgdelta > -1 && glucose_status.short_avgdelta < 1 && glucose_status.long_avgdelta > -1 && glucose_status.long_avgdelta < 1 ) ) {


### PR DESCRIPTION
flat CGM data isn't really an error, just a reason to dose neutrally