### PR TITLE
Fix bug when parsing most recent date

### DIFF
--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -6,7 +6,7 @@ var getLastGlucose = function (data) {
     });
 
     var now = data[0];
-    var now_date = now.date || Date.parse(now.display_time) || Date.parse(then.dateString);
+    var now_date = now.date || Date.parse(now.display_time) || Date.parse(now.dateString);
     var change;
     var last_deltas = [];
     var short_deltas = [];

--- a/lib/glucose-get-last.js
+++ b/lib/glucose-get-last.js
@@ -1,3 +1,7 @@
+function getDateFromEntry(entry) {
+  return entry.date || Date.parse(entry.display_time) || Date.parse(entry.dateString);
+}
+
 var getLastGlucose = function (data) {
     data = data.map(function prepGlucose (obj) {
         //Support the NS sgv field to avoid having to convert in a custom way
@@ -6,7 +10,7 @@ var getLastGlucose = function (data) {
     });
 
     var now = data[0];
-    var now_date = now.date || Date.parse(now.display_time) || Date.parse(now.dateString);
+    var now_date = getDateFromEntry(now);
     var change;
     var last_deltas = [];
     var short_deltas = [];
@@ -23,7 +27,7 @@ var getLastGlucose = function (data) {
         // only use data from the same device as the most recent BG data point
         if (typeof data[i] !== 'undefined' && data[i].glucose > 38 && data[i].device === now.device) {
             var then = data[i];
-            var then_date = then.date || Date.parse(then.display_time) || Date.parse(then.dateString);
+            var then_date = getDateFromEntry(then);
             var avgdelta = 0;
             var minutesago;
             if (typeof then_date !== 'undefined' && typeof now_date !== 'undefined') {

--- a/tests/get-last-glucose.test.js
+++ b/tests/get-last-glucose.test.js
@@ -30,4 +30,8 @@ describe('getLastGlucose', function ( ) {
       glucose_status.short_avgdelta.should.equal(4.44);
       glucose_status.long_avgdelta.should.equal(2.86);
     });
+    it('should fall back to dateString property', function () {
+      var glucose_status = getLastGlucose([{dateString: "2019-12-04T08:54:19.288-0800", sgv: 100}, {date: 1467942544500, sgv: 95}, {date: 1467942244000, sgv: 85}, {date: 1467941944000, sgv: 70}]);
+      glucose_status.date.should.equal(1575478459288);
+    });
 });


### PR DESCRIPTION
There's a bug when we are looking at the undefined `then` entry when parsing the date for `now`. This PR fixes that bug, does a slight refactor to reduce bugs like this in the future, and adds a test to make sure we're falling back to the correct `dateString` property.