### PR TITLE
Ping to default gateways (per network) to see if local connection is …

### DIFF
--- a/bin/oref0-online.sh
+++ b/bin/oref0-online.sh
@@ -43,6 +43,7 @@ main() {
     else
         echo "At $(date) my Bluetooth PAN is not connected"
     fi
+    ping_default_gateways
     echo -n "At $(date) my public IP is: "
     if check_ip; then
         stop_hotspot
@@ -143,6 +144,31 @@ function check_ip {
         echo $PUBLIC_IP
         touch /tmp/hasPublicIp
     fi
+}
+
+# network_name ip metric
+function ping_to_default_gw {
+ping $2 -c 1 > /dev/null
+    if [[ $? == 0 ]] ; then 
+        echo At $(date) ping to default gateway $2 '('$1' metric = '$3')' passed ; 
+    else
+        echo At $(date) ping to default gateway $2 '('$1' metric = '$3')' failed ; 
+    fi
+}
+
+function ping_default_gateways {
+# Here is an example to the output of the netstat command that we parse.
+# route -n
+# Kernel IP routing table
+# Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
+# 0.0.0.0         192.168.44.1    0.0.0.0         UG    0      0        0 bnep0
+# 0.0.0.0         192.168.44.1    0.0.0.0         UG    214    0        0 bnep0
+# 0.0.0.0         192.168.3.1     0.0.0.0         UG    302    0        0 wlan0
+# 192.168.3.0     0.0.0.0         255.255.255.0   U     302    0        0 wlan0
+# 192.168.44.0    0.0.0.0         255.255.255.0   U     214    0        0 bnep0
+route -n | grep ^0.0.0.0 |awk '{print $8 " " $2 " " $5}'| uniq | while read -r line ; do
+    ping_to_default_gw $line 
+done
 }
 
 function has_ip {


### PR DESCRIPTION
…alive.

This helps to distinguish between the case that pi does not have connection to the phone,
and the case that connection to the phone exists but phone has no external IP connection.

Also in the case that both WiFi and BT tethering is enabled one can see which of them is used (the one with the lower metric).

Here is an example to the output (when both WiFi and BT are enabled.):

At Mon 23 Dec 2019 04:50:08 PM IST my local Bluetooth IP is: 192.168.44.226
At Mon 23 Dec 2019 04:50:10 PM IST ping to default gateway 192.168.44.1 (bnep0 metric = 0) passed
At Mon 23 Dec 2019 04:50:10 PM IST ping to default gateway 192.168.44.1 (bnep0 metric = 214) passed
At Mon 23 Dec 2019 04:50:11 PM IST ping to default gateway 192.168.3.1 (wlan0 metric = 302) passed
At Mon 23 Dec 2019 04:50:11 PM IST my public IP is: 37.26.149.235

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>