### PR TITLE
kill ns loop if it is running more than 10 minutes

### DIFF
--- a/bin/oref0-cron-every-minute.sh
+++ b/bin/oref0-cron-every-minute.sh
@@ -49,6 +49,7 @@ sudo wpa_cli -i wlan0 scan &
     killall-g oref0-pump-loop 1800
     killall -g --older-than 30m openaps-report
     killall-g oref0-g4-loop 600
+    killall-g oref0-ns-loop 600
 ) &
 
 # kill pump-loop after 5 minutes of not writing to pump-loop.log


### PR DESCRIPTION
Today, oaps stopped uploading data to NS, therefor I thought that it stopped working.

A small debug showed that ns-loop stopped running, and specifically, the following process got stuck:
root     14207 14063  0 37727 38252   0 16:23 ?        00:00:25 node /usr/local/bin/oref0-get-ns-entries cgm/ns-glucose-1h-temp.json https://snir-dev.herokuapp.com 911eea185f5c758ac275687da8b7eab50ad720e3 1

It seems that on pi-zero this process might be running up to 6-7 minutes (I saw it once running for 20 minutes), so killing it after 10 minutes seems reasonable. 
