### PR TITLE
Fix cgm with share2 via nightscout with tokenbased authentication with oref 0.7.x (regression)

### DIFF
--- a/bin/oref0-get-ns-entries.js
+++ b/bin/oref0-get-ns-entries.js
@@ -158,7 +158,7 @@ if (!module.parent) {
     // append the token secret to the end of the ns url, or add it to the headers if token based authentication is not used
     var headers = {} ;
     var tokenAuth = "";
-    if apisecret.startsWith("token=") {
+    if (apisecret.startsWith("token=")) {
       tokenAuth = "&" + apisecret;
     } else { 
       headers = { 'api-secret': apisecret };

--- a/bin/oref0-get-ns-entries.js
+++ b/bin/oref0-get-ns-entries.js
@@ -64,7 +64,7 @@ if (!module.parent) {
     process.exit(1);
   }
 
-  if (apisecret.length != 40) {
+  if (apisecret != null && !apisecret.startsWith("token=") && apisecret.length != 40) {
     var shasum = crypto.createHash('sha1');
     shasum.update(apisecret);
     apisecret = shasum.digest('hex');
@@ -155,15 +155,20 @@ if (!module.parent) {
 
   function loadFromNightscoutWithDate(lastDate, glucosedata) {
 
-    var headers = {
-      'api-secret': apisecret
-    };
+    // append the token secret to the end of the ns url, or add it to the headers if token based authentication is not used
+    var headers = {} ;
+    var tokenAuth = "";
+    if apisecret.startsWith("token=") {
+      tokenAuth = "&" + apisecret;
+    } else { 
+      headers = { 'api-secret': apisecret };
+    }
 
     if (!_.isNil(lastDate)) {
       headers["If-Modified-Since"] = lastDate.toISOString();
     }
 
-    var uri = nsurl + '/api/v1/entries/sgv.json?count=' + records;
+    var uri = nsurl + '/api/v1/entries/sgv.json?count=' + records + tokenAuth;
     var options = {
       uri: uri
       , json: true


### PR DESCRIPTION
As far as I can tell the PR https://github.com/openaps/oref0/pull/1248 introduced a regression for users with Dexcom G6 with share2 and Nightscout that use token based authentication for authenticating their rig to Nightscout.

Example logfile:
```
Starting oref0-ns-loop at Mon Dec 30 11:39:02 CET 2019:
Connected to 192.168.1.1, testing for xDrip API availability
Load from local xDrip timed out, likely not connected to xDrip hotspot
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at /root/src/oref0/bin/oref0-get-ns-entries.js:136:30
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:511:3)
Loading CGM data from Nightscout failed null
Connected to 192.168.1.1, testing for xDrip API availability
Load from local xDrip timed out, likely not connected to xDrip hotspot
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at /root/src/oref0/bin/oref0-get-ns-entries.js:136:30
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:511:3)
Loading CGM data from Nightscout failed null
No recent valid BG found. Most recent:
(NOT VALID JSON: empty)
(NOT VALID JSON: empty)
Latest NS temptargets: (NOT VALID JSON: empty)
Merging local temptargets: (NOT VALID JSON: empty)
Temptargets merged: (NOT VALID JSON: empty)
meal.json.new not found
ns_meal_carbs failed
{"batteryVoltage":3804,"battery":62}
IOB not found

```


TODO: untested (too late now)