### PR TITLE
Replace expensive node json calls by jq

### DIFF
--- a/bin/monitor-xdrip.sh
+++ b/bin/monitor-xdrip.sh
@@ -11,11 +11,11 @@ date
 cp -rf xdrip/glucose.json xdrip/last-glucose.json
 curl --compressed -s http://localhost:5000/api/v1/entries?count=288 | jq '[ .[] | .glucose = .sgv ]' > xdrip/glucose.json
 if ! cmp --silent xdrip/glucose.json xdrip/last-glucose.json; then
-    if cat xdrip/glucose.json
+    if cat xdrip/glucose.json \
     	|  jq \
 	        --arg AT_LATEST   "`date -u +'%Y-%m-%dT%H:%M:%S.000Z' --date '5 minutes'`"\
 	        --arg AT_EARLIEST "`date -u +'%Y-%m-%dT%H:%M:%S.000Z' --date '-10 minutes'`"\
-	        '[.[] | (select (.dateString >= $AT_EARLIEST)) | (select (.dateString <= $AT_LATEST)) | (select (.glucose > 38))]'
+	        '[.[] | (select (.dateString >= $AT_EARLIEST)) | (select (.dateString <= $AT_LATEST)) | (select (.glucose > 38))]' \
     	| grep -q glucose; then
         cp -up xdrip/glucose.json monitor/glucose.json
     else

--- a/bin/monitor-xdrip.sh
+++ b/bin/monitor-xdrip.sh
@@ -11,7 +11,12 @@ date
 cp -rf xdrip/glucose.json xdrip/last-glucose.json
 curl --compressed -s http://localhost:5000/api/v1/entries?count=288 | jq '[ .[] | .glucose = .sgv ]' > xdrip/glucose.json
 if ! cmp --silent xdrip/glucose.json xdrip/last-glucose.json; then
-    if cat xdrip/glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38" | grep -q glucose; then
+    if cat xdrip/glucose.json
+    	|  jq \
+	        --arg AT_LATEST   "`date -u +'%Y-%m-%dT%H:%M:%S.000Z' --date '5 minutes'`"\
+	        --arg AT_EARLIEST "`date -u +'%Y-%m-%dT%H:%M:%S.000Z' --date '-10 minutes'`"\
+	        '[.[] | (select (.dateString >= $AT_EARLIEST)) | (select (.dateString <= $AT_LATEST)) | (select (.glucose > 38))]'
+    	| grep -q glucose; then
         cp -up xdrip/glucose.json monitor/glucose.json
     else
         echo No recent glucose data downloaded from xDrip.

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -92,8 +92,10 @@ function glucose_fresh {
 }
 
 function find_valid_ns_glucose {
-    # TODO: use jq for this if possible
-    cat cgm/ns-glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38"
+    jq \
+        --arg AT_LATEST   "`date -u +'%Y-%m-%dT%H:%M:%S.000Z' --date '5 minutes'`"\
+        --arg AT_EARLIEST "`date -u +'%Y-%m-%dT%H:%M:%S.000Z' --date '-10 minutes'`"\
+        '[.[] | (select (.dateString >= $AT_EARLIEST)) | (select (.dateString <= $AT_LATEST)) | (select (.glucose > 38))]' cgm/ns-glucose.json
 }
 
 function ns_temptargets {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -196,11 +196,11 @@ function format_ns_status {
     fi
 }
 
-#openaps format-latest-nightscout-treatments && test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0 && (ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json ) || echo \\\"No recent treatments to upload\\\"
+#openaps format-latest-nightscout-treatments && test $(jq -r '.[] |.created_at + " " + .eventType' upload/latest-treatments.json | wc -l ) -gt 0 && (ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json ) || echo \\\"No recent treatments to upload\\\"
 function upload_recent_treatments {
     #echo Uploading treatments
     format_latest_nightscout_treatments || die "Couldn't format latest NS treatments"
-    if test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0; then
+    if test $(jq -r '.[] |.created_at + " " + .eventType' upload/latest-treatments.json | wc -l ) -gt 0; then # this could probably just be a grep
         ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json | colorize_json || die "Couldn't upload latest treatments to NS"
     else
         echo "No new treatments to upload"


### PR DESCRIPTION
Since I'm having CPU load issues on my pi0, I went to check for some expensive calls that could be optimized away. I found this call:
https://github.com/openaps/oref0/blob/acb0150021e7bf284b6741a9510076a13f690747/bin/oref0-ns-loop.sh#L94-L97

`node /usr/local/bin/json --help` takes 14 seconds on my rasp, so I gladly replaced it with a `jq` call. It's quite inexpensive and I did some testing to make sure it outputs the exact same string.

The only caveat is that it assumes that the time in `cgm/ns-glucose.json` is formatted like
```json
"%Y-%M-%DT%H:%M:%S.000Z"
```
which I believe is safe.

Here is some output (with -100 instead of -10):

- with node json (14s user, 30s system):
<details><summary>CLICK ME</summary>
 <p>

```console
pi@pancreas:~/myopenaps $ cat cgm/ns-glucose.json | node /usr/local/bin/json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 100 && minAgo > -5 && this.glucose > 38"
time [
  {
    "_id": "1577798746303128152c1fbb",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:25:46.000Z",
    "dateString": "2019-12-31T13:25:46.000Z",
    "rssi": 100,
    "direction": "Flat",
    "sgv": 96,
    "date": 1577798746196,
    "unfiltered": 105412,
    "filtered": 105412,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 96
  },
  {
    "_id": "157779844630559233724d87",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:20:46.000Z",
    "dateString": "2019-12-31T13:20:46.000Z",
    "rssi": 100,
    "direction": "Flat",
    "sgv": 100,
    "date": 1577798446195,
    "unfiltered": 109647,
    "filtered": 109647,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 100
  },
  {
    "_id": "1577798146394e2f22f3eb02",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:15:46.000Z",
    "dateString": "2019-12-31T13:15:46.000Z",
    "rssi": 100,
    "direction": "FortyFiveDown",
    "sgv": 105,
    "date": 1577798146293,
    "unfiltered": 113882,
    "filtered": 113882,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 105
  },
  {
    "_id": "1577797846461eb0dff039b8",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:10:46.000Z",
    "dateString": "2019-12-31T13:10:46.000Z",
    "rssi": 100,
    "direction": "FortyFiveDown",
    "sgv": 113,
    "date": 1577797846332,
    "unfiltered": 122588,
    "filtered": 122588,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 113
  },
  {
    "_id": "157779754634003dfe489491",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:05:46.000Z",
    "dateString": "2019-12-31T13:05:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 122,
    "date": 1577797546290,
    "unfiltered": 131529,
    "filtered": 131529,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 122
  },
  {
    "_id": "15777972469264b0b85f4d7b",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:00:46.000Z",
    "dateString": "2019-12-31T13:00:46.000Z",
    "rssi": 100,
    "direction": "FortyFiveDown",
    "sgv": 137,
    "date": 1577797246875,
    "unfiltered": 146000,
    "filtered": 146000,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 137
  },
  {
    "_id": "15777969464366d445275b35",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:55:46.000Z",
    "dateString": "2019-12-31T12:55:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 146,
    "date": 1577796946393,
    "unfiltered": 154824,
    "filtered": 154824,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 146
  },
  {
    "_id": "15777966464232dd46a17692",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:50:46.000Z",
    "dateString": "2019-12-31T12:50:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 158,
    "date": 1577796646386,
    "unfiltered": 166706,
    "filtered": 166706,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 158
  },
  {
    "_id": "15777963465338f23c5e0d94",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:45:46.000Z",
    "dateString": "2019-12-31T12:45:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 169,
    "date": 1577796346489,
    "unfiltered": 178118,
    "filtered": 178118,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 169
  },
  {
    "_id": "15777960466311f9ac776c6b",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:40:46.000Z",
    "dateString": "2019-12-31T12:40:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 179,
    "date": 1577796046586,
    "unfiltered": 188235,
    "filtered": 188235,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 179
  },
  {
    "_id": "157779574653386f5c1617cf",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:35:46.000Z",
    "dateString": "2019-12-31T12:35:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 194,
    "date": 1577795746486,
    "unfiltered": 202706,
    "filtered": 202706,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 194
  },
  {
    "_id": "1577795446528bf01ca9a605",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:30:46.000Z",
    "dateString": "2019-12-31T12:30:46.000Z",
    "rssi": 100,
    "direction": "DoubleDown",
    "sgv": 205,
    "date": 1577795446484,
    "unfiltered": 214353,
    "filtered": 214353,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 205
  },
  {
    "_id": "1577795146524be53887f15f",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:25:46.000Z",
    "dateString": "2019-12-31T12:25:46.000Z",
    "rssi": 100,
    "direction": "DoubleDown",
    "sgv": 224,
    "date": 1577795146486,
    "unfiltered": 233412,
    "filtered": 233412,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 224
  }
]
```
</p>
</details>

- with jq (0.1s user, 0.38s system):
<details><summary>CLICK ME</summary>
 <p>

```console

pi@pancreas:~/myopenaps $ time jq \
>         --arg AT_LATEST   "`date -u +'%Y-%m-%dT%H:%M:%S.000Z' --date '5 minutes'`"\
>         --arg AT_EARLIEST "`date -u +'%Y-%m-%dT%H:%M:%S.000Z' --date '-100 minutes'`"\
>         '[.[] | (select (.dateString >= $AT_EARLIEST)) | (select (.dateString <= $AT_LATEST)) | (select (.glucose > 38))]' cgm/ns-glucose.json
[
  {
    "_id": "1577798746303128152c1fbb",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:25:46.000Z",
    "dateString": "2019-12-31T13:25:46.000Z",
    "rssi": 100,
    "direction": "Flat",
    "sgv": 96,
    "date": 1577798746196,
    "unfiltered": 105412,
    "filtered": 105412,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 96
  },
  {
    "_id": "157779844630559233724d87",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:20:46.000Z",
    "dateString": "2019-12-31T13:20:46.000Z",
    "rssi": 100,
    "direction": "Flat",
    "sgv": 100,
    "date": 1577798446195,
    "unfiltered": 109647,
    "filtered": 109647,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 100
  },
  {
    "_id": "1577798146394e2f22f3eb02",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:15:46.000Z",
    "dateString": "2019-12-31T13:15:46.000Z",
    "rssi": 100,
    "direction": "FortyFiveDown",
    "sgv": 105,
    "date": 1577798146293,
    "unfiltered": 113882,
    "filtered": 113882,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 105
  },
  {
    "_id": "1577797846461eb0dff039b8",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:10:46.000Z",
    "dateString": "2019-12-31T13:10:46.000Z",
    "rssi": 100,
    "direction": "FortyFiveDown",
    "sgv": 113,
    "date": 1577797846332,
    "unfiltered": 122588,
    "filtered": 122588,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 113
  },
  {
    "_id": "157779754634003dfe489491",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:05:46.000Z",
    "dateString": "2019-12-31T13:05:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 122,
    "date": 1577797546290,
    "unfiltered": 131529,
    "filtered": 131529,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 122
  },
  {
    "_id": "15777972469264b0b85f4d7b",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T13:00:46.000Z",
    "dateString": "2019-12-31T13:00:46.000Z",
    "rssi": 100,
    "direction": "FortyFiveDown",
    "sgv": 137,
    "date": 1577797246875,
    "unfiltered": 146000,
    "filtered": 146000,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 137
  },
  {
    "_id": "15777969464366d445275b35",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:55:46.000Z",
    "dateString": "2019-12-31T12:55:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 146,
    "date": 1577796946393,
    "unfiltered": 154824,
    "filtered": 154824,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 146
  },
  {
    "_id": "15777966464232dd46a17692",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:50:46.000Z",
    "dateString": "2019-12-31T12:50:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 158,
    "date": 1577796646386,
    "unfiltered": 166706,
    "filtered": 166706,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 158
  },
  {
    "_id": "15777963465338f23c5e0d94",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:45:46.000Z",
    "dateString": "2019-12-31T12:45:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 169,
    "date": 1577796346489,
    "unfiltered": 178118,
    "filtered": 178118,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 169
  },
  {
    "_id": "15777960466311f9ac776c6b",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:40:46.000Z",
    "dateString": "2019-12-31T12:40:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 179,
    "date": 1577796046586,
    "unfiltered": 188235,
    "filtered": 188235,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 179
  },
  {
    "_id": "157779574653386f5c1617cf",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:35:46.000Z",
    "dateString": "2019-12-31T12:35:46.000Z",
    "rssi": 100,
    "direction": "SingleDown",
    "sgv": 194,
    "date": 1577795746486,
    "unfiltered": 202706,
    "filtered": 202706,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 194
  },
  {
    "_id": "1577795446528bf01ca9a605",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:30:46.000Z",
    "dateString": "2019-12-31T12:30:46.000Z",
    "rssi": 100,
    "direction": "DoubleDown",
    "sgv": 205,
    "date": 1577795446484,
    "unfiltered": 214353,
    "filtered": 214353,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 205
  },
  {
    "_id": "1577795146524be53887f15f",
    "noise": 1,
    "device": "MIAOMIAO",
    "sysTime": "2019-12-31T12:25:46.000Z",
    "dateString": "2019-12-31T12:25:46.000Z",
    "rssi": 100,
    "direction": "DoubleDown",
    "sgv": 224,
    "date": 1577795146486,
    "unfiltered": 233412,
    "filtered": 233412,
    "type": "sgv",
    "utcOffset": 0,
    "glucose": 224
  }
]

real	0m0.386s
user	0m0.117s
sys	0m0.057s
```
</p>
</details>

Note: I wanted to use jq's strptime and strftime (https://stackoverflow.com/a/49263320/3660320) but it is not necessary since the dates are formatted in ISO 8601 (https://github.com/stedolan/jq/issues/1056#issuecomment-170714705)

**TODO**: I did not test this in a real loop.