### PR TITLE
Deprecate and remove support for adv_target_adjustments

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -138,6 +138,20 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var bg = glucose_status.glucose;
     var noise = glucose_status.noise;
 
+// Prep various delta variables.
+    var tick;
+
+    if (glucose_status.delta > -0.5) {
+        tick = "+" + round(glucose_status.delta,0);
+    } else {
+        tick = round(glucose_status.delta,0);
+    }
+    //var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
+    var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta);
+    var minAvgDelta = Math.min(glucose_status.short_avgdelta, glucose_status.long_avgdelta);
+    var maxDelta = Math.max(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
+
+
 // Cancel high temps (and replace with neutral) or shorten long zero temps for various error conditions
 
     // 38 is an xDrip error state that usually indicates sensor failure
@@ -270,38 +284,27 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
+// Raise target for noisy / raw CGM data.
+    if (glucose_status.noise >= 2) {
+        // increase target at least 10% (default 30%) for raw / noisy data
+        var noisyCGMTargetMultiplier = Math.max( 1.1, profile.noisyCGMTargetMultiplier );
+        // don't allow maxRaw above 250
+        var maxRaw = Math.min( 250, profile.maxRaw );
+        var adjustedMinBG = round(Math.min(200, min_bg * noisyCGMTargetMultiplier ));
+        var adjustedTargetBG = round(Math.min(200, target_bg * noisyCGMTargetMultiplier ));
+        var adjustedMaxBG = round(Math.min(200, max_bg * noisyCGMTargetMultiplier ));
+        process.stderr.write("Raising target_bg for noisy / raw CGM data, from "+target_bg+" to "+adjustedTargetBG+"; ");
+        min_bg = adjustedMinBG;
+        target_bg = adjustedTargetBG;
+        max_bg = adjustedMaxBG;
+    }
+
+    // min_bg of 90 -> threshold of 65, 100 -> 70 110 -> 75, and 130 -> 85
+    var threshold = min_bg - 0.5*(min_bg-40);
+
 // If iob_data or its required properties are missing, return.
 // This has to be checked after checking that we're not in one of the CGM-data-related error conditions handled above,
 // and before attempting to use iob_data below.
-// TODO: move this down to be just above // compare currenttemp to iob_data.lastTemp and cancel temp if they don't match
-    if (typeof iob_data === 'undefined' ) {
-        rT.error ='Error: iob_data undefined. ';
-        return rT;
-    }
-
-    var iobArray = iob_data;
-    if (typeof(iob_data.length) && iob_data.length > 1) {
-        iob_data = iobArray[0];
-        //console.error(JSON.stringify(iob_data[0]));
-    }
-
-    if (typeof iob_data.activity === 'undefined' || typeof iob_data.iob === 'undefined' ) {
-        rT.error ='Error: iob_data missing some property. ';
-        return rT;
-    }
-
-// Prep various delta variables. TODO: make this happen earlier along with other variable prep
-    var tick;
-
-    if (glucose_status.delta > -0.5) {
-        tick = "+" + round(glucose_status.delta,0);
-    } else {
-        tick = round(glucose_status.delta,0);
-    }
-    //var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
-    var minDelta = Math.min(glucose_status.delta, glucose_status.short_avgdelta);
-    var minAvgDelta = Math.min(glucose_status.short_avgdelta, glucose_status.long_avgdelta);
-    var maxDelta = Math.max(glucose_status.delta, glucose_status.short_avgdelta, glucose_status.long_avgdelta);
 
 // Adjust ISF based on sensitivityRatio
     var profile_sens = round(profile.sens,1)
@@ -317,6 +320,22 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         //process.stderr.write(" (autosens ratio "+sensitivityRatio+")");
     }
     console.error("; CR:",profile.carb_ratio);
+
+    if (typeof iob_data === 'undefined' ) {
+        rT.error ='Error: iob_data undefined. ';
+        return rT;
+    }
+
+    var iobArray = iob_data;
+    if (typeof(iob_data.length) && iob_data.length > 1) {
+        iob_data = iobArray[0];
+        //console.error(JSON.stringify(iob_data[0]));
+    }
+
+    if (typeof iob_data.activity === 'undefined' || typeof iob_data.iob === 'undefined' ) {
+        rT.error ='Error: iob_data missing some property. ';
+        return rT;
+    }
 
 // Compare currenttemp to iob_data.lastTemp and cancel temp if they don't match, as a safety check
 // This should occur after checking that we're not in one of the CGM-data-related error conditions handled above,
@@ -371,61 +390,11 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // and adjust it for the deviation above
     var eventualBG = naive_eventualBG + deviation;
 
-// Raise target for noisy / raw CGM data.
-// TODO: move this up to immediately after parsing targets above (once adv_target_adjustments is deprecated)
-    if (glucose_status.noise >= 2) {
-        // increase target at least 10% (default 30%) for raw / noisy data
-        var noisyCGMTargetMultiplier = Math.max( 1.1, profile.noisyCGMTargetMultiplier );
-        // don't allow maxRaw above 250
-        var maxRaw = Math.min( 250, profile.maxRaw );
-        var adjustedMinBG = round(Math.min(200, min_bg * noisyCGMTargetMultiplier ));
-        var adjustedTargetBG = round(Math.min(200, target_bg * noisyCGMTargetMultiplier ));
-        var adjustedMaxBG = round(Math.min(200, max_bg * noisyCGMTargetMultiplier ));
-        process.stderr.write("Raising target_bg for noisy / raw CGM data, from "+target_bg+" to "+adjustedTargetBG+"; ");
-        min_bg = adjustedMinBG;
-        target_bg = adjustedTargetBG;
-        max_bg = adjustedMaxBG;
-    // adjust target BG range if configured to bring down high BG faster
-    // TODO: deprecate this
-    } else if ( bg > max_bg && profile.adv_target_adjustments && ! profile.temptargetSet ) {
-        // with target=100, as BG rises from 100 to 160, adjustedTarget drops from 100 to 80
-        adjustedMinBG = round(Math.max(80, min_bg - (bg - min_bg)/3 ),0);
-        adjustedTargetBG =round( Math.max(80, target_bg - (bg - target_bg)/3 ),0);
-        adjustedMaxBG = round(Math.max(80, max_bg - (bg - max_bg)/3 ),0);
-        // if eventualBG, naive_eventualBG, and target_bg aren't all above adjustedMinBG, don’t use it
-        //console.error("naive_eventualBG:",naive_eventualBG+", eventualBG:",eventualBG);
-        if (eventualBG > adjustedMinBG && naive_eventualBG > adjustedMinBG && min_bg > adjustedMinBG) {
-            process.stderr.write("Adjusting targets for high BG: min_bg from "+min_bg+" to "+adjustedMinBG+"; ");
-            min_bg = adjustedMinBG;
-        } else {
-            process.stderr.write("min_bg unchanged: "+min_bg+"; ");
-        }
-        // if eventualBG, naive_eventualBG, and target_bg aren't all above adjustedTargetBG, don’t use it
-        if (eventualBG > adjustedTargetBG && naive_eventualBG > adjustedTargetBG && target_bg > adjustedTargetBG) {
-            process.stderr.write("target_bg from "+target_bg+" to "+adjustedTargetBG+"; ");
-            target_bg = adjustedTargetBG;
-        } else {
-            process.stderr.write("target_bg unchanged: "+target_bg+"; ");
-        }
-        // if eventualBG, naive_eventualBG, and max_bg aren't all above adjustedMaxBG, don’t use it
-        if (eventualBG > adjustedMaxBG && naive_eventualBG > adjustedMaxBG && max_bg > adjustedMaxBG) {
-            console.error("max_bg from "+max_bg+" to "+adjustedMaxBG);
-            max_bg = adjustedMaxBG;
-        } else {
-            console.error("max_bg unchanged: "+max_bg);
-        }
-    }
-
-    // TODO: move this line to be 4 lines down
-    var expectedDelta = calculate_expected_delta(target_bg, eventualBG, bgi);
     if (typeof eventualBG === 'undefined' || isNaN(eventualBG)) {
         rT.error ='Error: could not calculate eventualBG. ';
         return rT;
     }
-
-    // TODO: move this up to immediately after calculating targets
-    // min_bg of 90 -> threshold of 65, 100 -> 70 110 -> 75, and 130 -> 85
-    var threshold = min_bg - 0.5*(min_bg-40);
+    var expectedDelta = calculate_expected_delta(target_bg, eventualBG, bgi);
 
     //console.error(reservoir_data);
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -18,7 +18,6 @@ function defaults ( ) {
     , low_temptarget_lowers_sensitivity: false // lower sensitivity for temptargets <= 99.
     , sensitivity_raises_target: true // raise BG target when autosens detects sensitivity
     , resistance_lowers_target: false // lower BG target when autosens detects resistance
-    , adv_target_adjustments: false // lower target automatically when BG and eventualBG are high
     , exercise_mode: false // when true, > 100 mg/dL high temp target adjusts sensitivityRatio for exercise_mode. This majorly changes the behavior of high temp targets from before. synonmym for high_temptarget_raises_sensitivity
     , half_basal_exercise_target: 160 // when temptarget is 160 mg/dL *and* exercise_mode=true, run 50% basal at this level (120 = 75%; 140 = 60%)
     // create maxCOB and default it to 120 because that's the most a typical body can absorb over 4 hours.
@@ -81,7 +80,6 @@ function displayedDefaults () {
     profile.autosens_max = allDefaults.autosens_max;
     profile.autosens_min = allDefaults.autosens_min;
     profile.rewind_resets_autosens = allDefaults.rewind_resets_autosens;
-    profile.adv_target_adjustments = allDefaults.adv_target_adjustments;
     profile.exercise_mode = allDefaults.exercise_mode;
     profile.wide_bg_target_range = allDefaults.wide_bg_target_range;
     profile.sensitivity_raises_target = allDefaults.sensitivity_raises_target;

--- a/tests/command-behavior.tests.sh
+++ b/tests/command-behavior.tests.sh
@@ -474,7 +474,6 @@ EOT
     cat >profile.json <<EOT
 {
    "A52_risk_enable": false,
-   "adv_target_adjustments": false,
    "allowSMB_with_high_temptarget": false,
    "autosens_max": 1.2,
    "autosens_min": 0.8,
@@ -579,7 +578,6 @@ EOT
     cat >pumpprofile.json <<EOT
 {
    "A52_risk_enable": false,
-   "adv_target_adjustments": false,
    "allowSMB_with_high_temptarget": false,
    "autosens_max": 1.2,
    "autosens_min": 0.8,


### PR DESCRIPTION
adv_target_adjustments was an early experiment, prior to the ZTpredBG changes, attempting to reduce highs. as it exists today, it does not succeed in reducing highs more than it increases lows. For example, in a 7-day oref0-backtest simulator run, it increased % time <70 by 2.6% while only reducing % time >180 by 0.8%.

This PR deprecates and removes adv_target_adjustments to clean up code in preparation for other efforts to accomplish the same thing (for example by extending the ZTpredBG work).

This PR also reorders some code (per earlier TODO comments) to make it more readable.