### PR TITLE
remove deprecated support for max_bg and wide_bg_target_range

### DIFF
--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -25,9 +25,6 @@ function defaults ( ) {
     // (If someone enters more carbs or stacks more; OpenAPS will just truncate dosing based on 120.
     // Essentially, this just limits AMA/SMB as a safety cap against excessive COB entry)
     , maxCOB: 120
-    , wide_bg_target_range: false // by default use only the low end of the pump's BG target range as OpenAPS target
-    // by default the higher end of the target range is used only for avoiding bolus wizard overcorrections
-    // use wide_bg_target_range: true to force neutral temps over a wider range of eventualBGs
     , skip_neutral_temps: false // if true, don't set neutral temps
     , unsuspend_if_no_temp: false // if true, pump will un-suspend after a zero temp finishes
     , bolussnooze_dia_divisor: 2 // bolus snooze decays after 1/2 of DIA
@@ -83,7 +80,6 @@ function displayedDefaults () {
     profile.rewind_resets_autosens = allDefaults.rewind_resets_autosens;
     profile.adv_target_adjustments = allDefaults.adv_target_adjustments;
     profile.exercise_mode = allDefaults.exercise_mode;
-    profile.wide_bg_target_range = allDefaults.wide_bg_target_range;
     profile.sensitivity_raises_target = allDefaults.sensitivity_raises_target;
     profile.unsuspend_if_no_temp = allDefaults.unsuspend_if_no_temp;
     profile.enableSMB_with_COB = allDefaults.enableSMB_with_COB;

--- a/lib/profile/targets.js
+++ b/lib/profile/targets.js
@@ -21,11 +21,7 @@ function lookup (inputs, profile) {
         }
     }
 
-    if (profile.wide_bg_target_range === true) {
-        console.error('Allowing wide eventualBG target range: ' + bgTargets.low + ' - ' + bgTargets.high );
-    } else {
-        bgTargets.high = bgTargets.low;
-    }
+    bgTargets.high = bgTargets.low;
 
     var tempTargets = bgTargets;
 

--- a/tests/command-behavior.tests.sh
+++ b/tests/command-behavior.tests.sh
@@ -570,8 +570,7 @@ EOT
    "sensitivity_raises_target": true,
    "suspend_zeros_iob": true,
    "unsuspend_if_no_temp": false,
-   "useCustomPeakTime": true,
-   "wide_bg_target_range": false
+   "useCustomPeakTime": true
 }
 EOT
 
@@ -675,8 +674,7 @@ EOT
    "sensitivity_raises_target": true,
    "suspend_zeros_iob": true,
    "unsuspend_if_no_temp": false,
-   "useCustomPeakTime": true,
-   "wide_bg_target_range": false
+   "useCustomPeakTime": true
 }
 EOT
 

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -43,17 +43,6 @@ describe('Profile', function ( ) {
         profile.carb_ratio.should.equal(20);
     });
 
-    it('should should honour wide_bg_target_range', function () {
-        var profile = require('../lib/profile')(_.merge({}, baseInputs, {wide_bg_target_range: true}));
-        profile.max_iob.should.equal(0);
-        profile.dia.should.equal(3);
-        profile.sens.should.equal(100);
-        profile.current_basal.should.equal(1);
-        profile.max_bg.should.equal(100);
-        profile.min_bg.should.equal(100);
-        profile.carb_ratio.should.equal(20);
-    });
-
 
     var currentTime = new Date();
     var creationDate = new Date(currentTime.getTime() - (5 * 60 * 1000));


### PR DESCRIPTION
Wide BG target ranges result in worse outcomes than a single BG target (at a preferred point within the wider range), as they prevent OpenAPS from taking earlier action to correct high and/or low BG.

In order to simplify code paths, allow for easier testing, and make room for future improvements, this PR removes support for wide_bg_target_range and max_bg, and instead sets target to min_bg (which has been the default behavior for some time).

This PR does not (yet) deprecate separate high and low temporary targets, but that would be an obvious next step.