### PR TITLE
Add timeout to oref0-get-ns-entries request call

### DIFF
--- a/bin/oref0-get-ns-entries.js
+++ b/bin/oref0-get-ns-entries.js
@@ -172,6 +172,7 @@ if (!module.parent) {
     var options = {
       uri: uri
       , json: true
+      , timeout: 90000
       , headers: headers
     };
 


### PR DESCRIPTION
Twice in the last week we have had oref0-get-ns-entries hang in the call to request for an hour or more. 

This puts in a 90 second timeout to the call to request to prevent it from hanging.