### PR TITLE
Tzachi share node2

### DIFF
--- a/bin/mm-format-ns-treatments.sh
+++ b/bin/mm-format-ns-treatments.sh
@@ -18,7 +18,7 @@ EOT
 # | json -e "this.type = 'mm://openaps/$self'" \
 model=$(jq -r . $MODEL)
 
-oref0-normalize-temps $HISTORY \
+run_remote_command "oref0-normalize-temps $HISTORY" \
   | jq '[ .[]
     | .medtronic = ( [ "mm://openaps/'$self'/", ( . | if ._type then ._type else .eventType end ) ] | join("") )
     | .created_at = if .created_at then .created_at else .timestamp end

--- a/bin/mm-format-ns-treatments.sh
+++ b/bin/mm-format-ns-treatments.sh
@@ -18,6 +18,10 @@ EOT
 # | json -e "this.type = 'mm://openaps/$self'" \
 model=$(jq -r . $MODEL)
 
+
+dir_name=~/test_data/normalize-temps$(date +"%Y-%m-%d-%T")
+mkdir -p $dir_name
+cp  $HISTORY  $dir_name
 run_remote_command "oref0-normalize-temps $HISTORY" \
   | jq '[ .[]
     | .medtronic = ( [ "mm://openaps/'$self'/", ( . | if ._type then ._type else .eventType end ) ] | join("") )

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var os = require("os");
+var fs = require('fs');
 
 var requireUtils = require('../lib/require-utils');
 var requireWithTimestamp = requireUtils.requireWithTimestamp;
@@ -48,7 +49,7 @@ function preferencesStatus (status, cwd ,preferences_input) {
 }
 
 function uploaderStatus (status, cwd, uploader_input) {
-    var uploader = require(cwd + uploader_input);
+    var uploader = JSON.parse(fs.readFileSync(cwd + uploader_input, 'utf8'));
     if (uploader) {
         if (typeof uploader === 'number') {
             status.uploader = {
@@ -80,7 +81,6 @@ var ns_status = function ns_status(argv_params) {
             default: false
         })
         .strict(true)
-        //.exitProcess(false)
         .fail(function (msg, err, yargs) {
             if (err) {
                 return console.error('Error found', err);
@@ -107,6 +107,7 @@ var ns_status = function ns_status(argv_params) {
         return;
     }
 
+    //var pjson = JSON.parse(fs.readFileSync('../package.json', 'utf8'));
     var pjson = require('../package.json');
 
     var cwd = process.cwd() + '/';
@@ -174,12 +175,14 @@ var ns_status = function ns_status(argv_params) {
 }
 
 if (!module.parent) {
-   // remove the first parameter.
-   var command = process.argv;
-   command.shift();
-   command.shift();
-   var result = ns_status(command)
-   console.log(result);
+    // remove the first parameter.
+    var command = process.argv;
+    command.shift();
+    command.shift();
+    var result = ns_status(command);
+    if(result !== undefined) {
+        console.log(result);
+    }
 }
 
 exports = module.exports = ns_status

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -107,6 +107,7 @@ var ns_status = function ns_status(argv_params) {
         return;
     }
 
+    // TODO: For some reason the following line does not work (../package.json ia not found).
     //var pjson = JSON.parse(fs.readFileSync('../package.json', 'utf8'));
     var pjson = require('../package.json');
 

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -92,11 +92,6 @@ var ns_status = function ns_status(argv_params) {
     var params = argv.argv;
     var inputs = params._;
  
-
-console.error('input length = ', inputs.length , inputs[1]);	
-
-    
-
     var clock_input = inputs[0];
     var iob_input = inputs[1];
     var suggested_input = inputs[2];

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -152,8 +152,7 @@ var ns_status = function ns_status(argv_params) {
                 battery: safeLoadFile(cwd + battery_input),
                 reservoir: safeLoadFile(cwd + reservoir_input),
                 status: requireWithTimestamp(cwd + status_input)
-            },
-            created_at: new Date()
+            }
         };
 
         if (mmtune_input) {

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -6,6 +6,7 @@ var os = require("os");
 var requireUtils = require('../lib/require-utils');
 var safeRequire = requireUtils.safeRequire;
 var requireWithTimestamp = requireUtils.requireWithTimestamp;
+var safeLoadFile = requireUtils.safeLoadFile;
 
 /*
   Prepare Status info to for upload to Nightscout
@@ -23,7 +24,7 @@ var requireWithTimestamp = requireUtils.requireWithTimestamp;
 
 */
 
-function mmtuneStatus (status) {
+function mmtuneStatus (status, cwd, mmtune_input) {
     var mmtune = requireWithTimestamp(cwd + mmtune_input);
     if (mmtune) {
         if (mmtune.scanDetails && mmtune.scanDetails.length) {
@@ -35,7 +36,7 @@ function mmtuneStatus (status) {
     }
 }
 
-function preferencesStatus (status) {
+function preferencesStatus (status, cwd ,preferences_input) {
     var preferences = requireWithTimestamp(cwd + preferences_input);
     if (preferences) {
       status.preferences = preferences;
@@ -47,7 +48,7 @@ function preferencesStatus (status) {
     }
 }
 
-function uploaderStatus (status) {
+function uploaderStatus (status, cwd, uploader_input) {
     var uploader = require(cwd + uploader_input);
     if (uploader) {
         if (typeof uploader === 'number') {
@@ -60,9 +61,12 @@ function uploaderStatus (status) {
     }
 }
 
-if (!module.parent) {
 
-    var argv = require('yargs')
+
+
+var ns_status = function ns_status(argv_params) {
+
+    var argv = require('yargs')(argv_params)
         .usage("$0 <clock.json> <iob.json> <suggested.json> <enacted.json> <battery.json> <reservoir.json> <status.json> [--uploader uploader.json] [mmtune.json] [--preferences preferences.json]")
         .option('preferences', {
             alias: 'p',
@@ -77,10 +81,22 @@ if (!module.parent) {
             default: false
         })
         .strict(true)
+        //.exitProcess(false)
+        .fail(function (msg, err, yargs) {
+            if (err) {
+                return console.error('Error found', err);
+            }
+            return console.error('Parsing of command arguments failed', msg)
+            })
         .help('help');
-
     var params = argv.argv;
     var inputs = params._;
+ 
+
+console.error('input length = ', inputs.length , inputs[1]);	
+
+    
+
     var clock_input = inputs[0];
     var iob_input = inputs[1];
     var suggested_input = inputs[2];
@@ -94,7 +110,7 @@ if (!module.parent) {
 
     if (inputs.length < 7 || inputs.length > 8) {
         argv.showHelp();
-        process.exit(1);
+        return;
     }
 
     var pjson = require('../package.json');
@@ -138,27 +154,39 @@ if (!module.parent) {
                 version: pjson.version
             },
             pump: {
-                clock: safeRequire(cwd + clock_input),
-                battery: safeRequire(cwd + battery_input),
-                reservoir: safeRequire(cwd + reservoir_input),
+                clock: safeLoadFile(cwd + clock_input),
+                battery: safeLoadFile(cwd + battery_input),
+                reservoir: safeLoadFile(cwd + reservoir_input),
                 status: requireWithTimestamp(cwd + status_input)
-            }
+            },
+            created_at: new Date()
         };
 
         if (mmtune_input) {
-            mmtuneStatus(status);
+            mmtuneStatus(status, cwd, mmtune_input);
         }
 
         if (preferences_input) {
-            preferencesStatus(status);
+            preferencesStatus(status, cwd ,preferences_input);
         }
 
         if (uploader_input) {
-            uploaderStatus(status);
+            uploaderStatus(status, cwd, uploader_input);
         }
 
-        console.log(JSON.stringify(status));
+        return JSON.stringify(status);
     } catch (e) {
         return console.error("Could not parse input data: ", e);
     }
 }
+
+if (!module.parent) {
+   // remove the first parameter.
+   var command = process.argv;
+   command.shift();
+   command.shift();
+   var result = ns_status(command)
+   console.log(result);
+}
+
+exports = module.exports = ns_status

--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -4,7 +4,6 @@
 var os = require("os");
 
 var requireUtils = require('../lib/require-utils');
-var safeRequire = requireUtils.safeRequire;
 var requireWithTimestamp = requireUtils.requireWithTimestamp;
 var safeLoadFile = requireUtils.safeLoadFile;
 

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -13,7 +13,7 @@ function run_remote_command () {
 	#echo $out_file
 	echo -n $1 |socat -t90 - UNIX-CONNECT:/tmp/unixSocket > $out_file
 	#cat $out_file
-	jq -r .err $out_file >2
+	jq -r .err $out_file 2>
 	jq -r .stdout $out_file 
 	return_val=$( jq -r .return_val $out_file) 
 	return $(( return_val ))

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -14,8 +14,8 @@ function run_remote_command () {
 	#echo $out_file
 	echo -n $1 |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node > $out_file || return 1
 	#cat $out_file
-	jq -r .err $out_file >&2
-	jq -r .stdout $out_file 
+	jq -j .err $out_file >&2
+	jq -j .stdout $out_file 
 	return_val=$( jq -r .return_val $out_file) 
 	return $(( return_val ))
 }

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -9,40 +9,40 @@ self=$(basename $0)
 PREFERENCES_FILE="preferences.json"
 
 function run_remote_command () {
-	set -o pipefail
-	out_file=$( mktemp /tmp/shared_node.XXXXXXXXXXXX)
-	#echo $out_file
-	echo -n $1 |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node > $out_file || return 1
-	#cat $out_file
-	jq -j .err $out_file >&2
-	jq -j .stdout $out_file 
-	return_val=$( jq -r .return_val $out_file) 
-	return $(( return_val ))
+    set -o pipefail
+    out_file=$( mktemp /tmp/shared_node.XXXXXXXXXXXX)
+    #echo $out_file
+    echo -n $1 |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node > $out_file || return 1
+    #cat $out_file
+    jq -j .err $out_file >&2
+    jq -j .stdout $out_file 
+    return_val=$( jq -r .return_val $out_file) 
+    return $(( return_val ))
 }
 
 function start_share_node_if_needed() {
-	# First check if node is alive
-	output="$(echo ping |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node)"
-	echo $output
-	if [ "$output" = '{"err":"","stdout":"pong","return_val":0}' ]; then
-		echo shared node is alive
-		return 0
-	fi
-	echo 'killing node so it will restart later'
+    # First check if node is alive
+    output="$(echo ping |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node)"
+    echo $output
+    if [ "$output" = '{"err":"","stdout":"pong","return_val":0}' ]; then
+        echo shared node is alive
+        return 0
+    fi
+    echo 'killing node so it will restart later'
         node_pid="$(ps -ef | grep node | grep oref0-shared-node.js | grep -v grep | awk '{print $2 }')"
-	echo $node_pid
-	kill -9 $node_pid
-	# Node should start automaticly by oref0-shared-node-loop
-	# Waiting 90 seconds for it to start
-	for i in {1..90}
+    echo $node_pid
+    kill -9 $node_pid
+    # Node should start automaticly by oref0-shared-node-loop
+    # Waiting 90 seconds for it to start
+    for i in {1..90}
     do
        sleep 1
        output="$(echo ping |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node)"
-	   echo $output
-	   if [ "$output" = '{"err":"","stdout":"pong","return_val":0}' ]; then
+       echo $output
+       if [ "$output" = '{"err":"","stdout":"pong","return_val":0}' ]; then
            echo shared node is alive
-		   return 0
-	   fi
+           return 0
+       fi
     done
     die Waiting for shared node failed 
 }

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -8,6 +8,16 @@ self=$(basename $0)
 
 PREFERENCES_FILE="preferences.json"
 
+function run_remote_command () {
+	out_file=$( mktemp /tmp/shared_node.XXXXXXXXXXXX)
+	#echo $out_file
+	echo -n $1 |socat -t90 - UNIX-CONNECT:/tmp/unixSocket > $out_file
+	#cat $out_file
+	jq -r .err $out_file >2
+	jq -r .stdout $out_file 
+	return_val=$( jq -r .return_val $out_file) 
+	return $(( return_val ))
+}
 
 function overtemp {
     # check for CPU temperature above 85°C

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -13,7 +13,7 @@ function run_remote_command () {
 	#echo $out_file
 	echo -n $1 |socat -t90 - UNIX-CONNECT:/tmp/unixSocket > $out_file
 	#cat $out_file
-	jq -r .err $out_file 2>
+	jq -r .err $out_file >&2
 	jq -r .stdout $out_file 
 	return_val=$( jq -r .return_val $out_file) 
 	return $(( return_val ))

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -9,14 +9,43 @@ self=$(basename $0)
 PREFERENCES_FILE="preferences.json"
 
 function run_remote_command () {
+	set -o pipefail
 	out_file=$( mktemp /tmp/shared_node.XXXXXXXXXXXX)
 	#echo $out_file
-	echo -n $1 |socat -t90 - UNIX-CONNECT:/tmp/unixSocket > $out_file
+	echo -n $1 |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node > $out_file || return 1
 	#cat $out_file
 	jq -r .err $out_file >&2
 	jq -r .stdout $out_file 
 	return_val=$( jq -r .return_val $out_file) 
 	return $(( return_val ))
+}
+
+function start_share_node_if_needed() {
+	# First check if node is alive
+	output="$(echo ping |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node)"
+	echo $output
+	if [ "$output" = '{"err":"","stdout":"pong","return_val":0}' ]; then
+		echo shared node is alive
+		return 0
+	fi
+	echo 'killing node so it will restart later'
+	node_pid="$(ps -ef | grep 'node oref0-shared-node.js' | grep -v grep | awk '{print $2 }')"
+	echo $node_pid
+	kill -9 $node_pid
+	# Node should start automaticly by oref0-shared-node-loop
+	# Waiting 90 seconds for it to start
+	for i in {1..90}
+    do
+       sleep 1
+       echo "Welcome $i times"
+       output="$(echo ping |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node)"
+	   echo $output
+	   if [ "$output" = '{"err":"","stdout":"pong","return_val":0}' ]; then
+           echo shared node is alive
+		   return 0
+	   fi
+    done
+    die Waiting for shared node failed 
 }
 
 function overtemp {

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -29,7 +29,7 @@ function start_share_node_if_needed() {
 		return 0
 	fi
 	echo 'killing node so it will restart later'
-	node_pid="$(ps -ef | grep 'node oref0-shared-node.js' | grep -v grep | awk '{print $2 }')"
+        node_pid="$(ps -ef | grep node | grep oref0-shared-node.js | grep -v grep | awk '{print $2 }')"
 	echo $node_pid
 	kill -9 $node_pid
 	# Node should start automaticly by oref0-shared-node-loop
@@ -37,7 +37,6 @@ function start_share_node_if_needed() {
 	for i in {1..90}
     do
        sleep 1
-       echo "Welcome $i times"
        output="$(echo ping |socat -t90 - UNIX-CONNECT:/tmp/oaps_shared_node)"
 	   echo $output
 	   if [ "$output" = '{"err":"","stdout":"pong","return_val":0}' ]; then

--- a/bin/oref0-cron-every-minute.sh
+++ b/bin/oref0-cron-every-minute.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#exit 1
+
 source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 
 usage "$@" <<EOT
@@ -113,7 +113,7 @@ if ! is_bash_process_running_named oref0-pump-loop; then
 fi
 
 if ! is_bash_process_running_named oref0-shared-node-loop; then
-    oref0-shared-node-loop | tee -a /var/log/openaps/oref0-shared-node.log | adddate openaps.shared-node | uncolor |tee -a /var/log/openaps/openaps-date.log &
+    oref0-shared-node-loop | tee -a /var/log/openaps/shared-node.log | adddate openaps.shared-node | uncolor |tee -a /var/log/openaps/openaps-date.log &
 fi
 
 if [[ ! -z "$BT_PEB" ]]; then
@@ -142,6 +142,7 @@ done | while read file; do
     # attempt a logrotate
     logrotate /etc/logrotate.conf -f
 done
+start_share_node_if_needed
 
 # check if 5 minutes have passed, and if yes, turn of the screen to save power
 ttyport="$(get_pref_string .ttyport)"

--- a/bin/oref0-cron-every-minute.sh
+++ b/bin/oref0-cron-every-minute.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+#exit 1
 source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 
 usage "$@" <<EOT
@@ -110,6 +110,10 @@ fi
 
 if ! is_bash_process_running_named oref0-pump-loop; then
     oref0-pump-loop 2>&1 | tee -a /var/log/openaps/pump-loop.log | adddate openaps.pump-loop | uncolor |tee -a /var/log/openaps/openaps-date.log &
+fi
+
+if ! is_bash_process_running_named oref0-shared-node-loop; then
+    oref0-shared-node-loop | tee -a /var/log/openaps/oref0-shared-node.log | adddate openaps.shared-node | uncolor |tee -a /var/log/openaps/openaps-date.log &
 fi
 
 if [[ ! -z "$BT_PEB" ]]; then

--- a/bin/oref0-cron-every-minute.sh
+++ b/bin/oref0-cron-every-minute.sh
@@ -113,7 +113,7 @@ if ! is_bash_process_running_named oref0-pump-loop; then
 fi
 
 if ! is_bash_process_running_named oref0-shared-node-loop; then
-    oref0-shared-node-loop | tee -a /var/log/openaps/shared-node.log | adddate openaps.shared-node | uncolor |tee -a /var/log/openaps/openaps-date.log &
+    oref0-shared-node-loop 2>&1 | tee -a /var/log/openaps/shared-node.log | adddate openaps.shared-node | uncolor |tee -a /var/log/openaps/openaps-date.log &
 fi
 
 if [[ ! -z "$BT_PEB" ]]; then

--- a/bin/oref0-get-ns-entries.js
+++ b/bin/oref0-get-ns-entries.js
@@ -49,7 +49,6 @@ if (!module.parent) {
   }
 
   var nsurl = params._.slice(1, 2).pop();
-  if (nsurl && nsurl.charAt(nsurl.length - 1) == "/") nsurl = nsurl.substr(0, nsurl.length - 1); // remove trailing slash if it exists
 
   var apisecret = params._.slice(2, 3).pop();
   var hours = Number(params._.slice(3, 4).pop());
@@ -63,6 +62,7 @@ if (!module.parent) {
     usage();
     process.exit(1);
   }
+  if (nsurl && nsurl.charAt(nsurl.length - 1) == "/") nsurl = nsurl.substr(0, nsurl.length - 1); // remove trailing slash if it exists
 
   if (apisecret != null && !apisecret.startsWith("token=") && apisecret.length != 40) {
     var shasum = crypto.createHash('sha1');

--- a/bin/oref0-get-ns-entries.js
+++ b/bin/oref0-get-ns-entries.js
@@ -62,7 +62,8 @@ if (!module.parent) {
     usage();
     process.exit(1);
   }
-  if (nsurl && nsurl.charAt(nsurl.length - 1) == "/") nsurl = nsurl.substr(0, nsurl.length - 1); // remove trailing slash if it exists
+  // remove trailing slash if it exists
+  if (nsurl && nsurl.charAt(nsurl.length - 1) == "/") nsurl = nsurl.substr(0, nsurl.length - 1);
 
   if (apisecret != null && !apisecret.startsWith("token=") && apisecret.length != 40) {
     var shasum = crypto.createHash('sha1');

--- a/bin/oref0-normalize-temps.js
+++ b/bin/oref0-normalize-temps.js
@@ -61,7 +61,7 @@ if (!module.parent) {
    var command = process.argv;
    command.shift();
    command.shift();
-   var result = oref0-normalize-temps(command)
+   var result = oref0_normalize_temps(command)
    console.log(result);
 }
 

--- a/bin/oref0-normalize-temps.js
+++ b/bin/oref0-normalize-temps.js
@@ -17,9 +17,12 @@
 var find_insulin = require('../lib/temps');
 var find_bolus = require('../lib/bolus');
 var describe_pump = require('../lib/pump');
+var fs = require('fs');
 
-if (!module.parent) {
-  var argv = require('yargs')
+
+  
+var oref0_normalize_temps = function oref0_normalize_temps(argv_params) {  
+  var argv = require('yargs')(argv_params)
     .usage('$0 <pumphistory.json>')
     .demand(1)
     // error and show help if some other args given
@@ -37,7 +40,7 @@ if (!module.parent) {
 
   var cwd = process.cwd()
   try {
-    var all_data = require(cwd + '/' + iob_input);
+    var all_data = JSON.parse(fs.readFileSync(cwd + '/' + iob_input));
   } catch (e) {
     return console.error("Could not parse pumphistory: ", e);
   }
@@ -50,6 +53,16 @@ if (!module.parent) {
   // treatments.sort(function (a, b) { return a.date > b.date });
 
 
-  console.log(JSON.stringify(treatments));
+  return JSON.stringify(treatments);
 }
 
+if (!module.parent) {
+   // remove the first parameter.
+   var command = process.argv;
+   command.shift();
+   command.shift();
+   var result = oref0-normalize-temps(command)
+   console.log(result);
+}
+
+exports = module.exports = oref0_normalize_temps

--- a/bin/oref0-normalize-temps.js
+++ b/bin/oref0-normalize-temps.js
@@ -34,8 +34,7 @@ var oref0_normalize_temps = function oref0_normalize_temps(argv_params) {
 
   if (params._.length > 1) {
     argv.showHelp();
-    console.error('Too many arguments');
-    process.exit(1);
+    return console.error('Too many arguments');
   }
 
   var cwd = process.cwd()
@@ -62,7 +61,9 @@ if (!module.parent) {
    command.shift();
    command.shift();
    var result = oref0_normalize_temps(command)
-   console.log(result);
+   if(result !== undefined) {
+       console.log(result);
+   }
 }
 
 exports = module.exports = oref0_normalize_temps

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -188,9 +188,9 @@ function upload_ns_status {
 # ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --uploader monitor/edison-battery.json > upload/ns-status.json
 function format_ns_status {
     if [ -s monitor/edison-battery.json ]; then
-        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --preferences preferences.json --uploader monitor/edison-battery.json > upload/ns-status.json
+        run_remote_command 'ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --preferences preferences.json --uploader monitor/edison-battery.json' > upload/ns-status.json
     else
-        ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --preferences preferences.json > upload/ns-status.json
+        run_remote_command 'ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --preferences preferences.json' > upload/ns-status.json
     fi
 }
 
@@ -224,6 +224,7 @@ function format_latest_nightscout_treatments {
 
     echo "Latest NS treatment: $latest_ns_treatment_time"
     nightscout cull-latest-openaps-treatments $historyfile settings/model.json $latest_ns_treatment_time > upload/latest-treatments.json
+    cat upload/latest-treatments.json
 }
 
 function check_mdt_upload {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -187,6 +187,11 @@ function upload_ns_status {
 #ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json > upload/ns-status.json
 # ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --uploader monitor/edison-battery.json > upload/ns-status.json
 function format_ns_status {
+    dir_name=~/test_data/ns-status$(date +"%Y-%m-%d-%T")
+    echo dir_name = $dir_name
+    mkdir -p $dir_name
+    cp  monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json preferences.json   monitor/edison-battery.json $dir_name
+    
     if [ -s monitor/edison-battery.json ]; then
         run_remote_command 'ns-status monitor/clock-zoned.json monitor/iob.json enact/suggested.json enact/enacted.json monitor/battery.json monitor/reservoir.json monitor/status.json --preferences preferences.json --uploader monitor/edison-battery.json' > upload/ns-status.json
     else

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -101,7 +101,6 @@ function find_valid_ns_glucose {
     run_remote_command 'json -f cgm/ns-glucose.json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38"'
 }
 
-
 function ns_temptargets {
     #openaps report invoke settings/temptargets.json settings/profile.json >/dev/null
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET temp_targets > settings/ns-temptargets.json.new
@@ -240,7 +239,6 @@ function format_latest_nightscout_treatments {
 
     echo "Latest NS treatment: $latest_ns_treatment_time"
     nightscout cull-latest-openaps-treatments $historyfile settings/model.json $latest_ns_treatment_time > upload/latest-treatments.json
-    cat upload/latest-treatments.json
 }
 
 function check_mdt_upload {

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -92,9 +92,9 @@ function glucose_fresh {
 }
 
 function find_valid_ns_glucose {
-    # TODO: use jq for this if possible
-    cat cgm/ns-glucose.json | json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38"
+    run_remote_command 'json -f cgm/ns-glucose.json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38"'
 }
+
 
 function ns_temptargets {
     #openaps report invoke settings/temptargets.json settings/profile.json >/dev/null
@@ -203,7 +203,7 @@ function format_ns_status {
 function upload_recent_treatments {
     #echo Uploading treatments
     format_latest_nightscout_treatments || die "Couldn't format latest NS treatments"
-    if test $(json -f upload/latest-treatments.json -a created_at eventType | wc -l ) -gt 0; then
+    if test $(jq -r '.[] |.created_at + " " + .eventType' upload/latest-treatments.json | wc -l ) -gt 0; then
         ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json | colorize_json || die "Couldn't upload latest treatments to NS"
     else
         echo "No new treatments to upload"

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -92,6 +92,12 @@ function glucose_fresh {
 }
 
 function find_valid_ns_glucose {
+    dir_name=~/test_data/find-glucose$(date +"%Y-%m-%d-%T")
+    echo dir_name = $dir_name
+    mkdir -p $dir_name
+    cp cgm/ns-glucose.json  $dir_name
+    date --iso-8601=seconds >  $dir_name/date_string
+
     run_remote_command 'json -f cgm/ns-glucose.json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38"'
 }
 
@@ -203,6 +209,11 @@ function format_ns_status {
 function upload_recent_treatments {
     #echo Uploading treatments
     format_latest_nightscout_treatments || die "Couldn't format latest NS treatments"
+
+    dir_name=~/test_data/json_jq$(date +"%Y-%m-%d-%T")
+    mkdir -p $dir_name
+    cp upload/latest-treatments.json  $dir_name
+
     if test $(jq -r '.[] |.created_at + " " + .eventType' upload/latest-treatments.json | wc -l ) -gt 0; then
         ns-upload $NIGHTSCOUT_HOST $API_SECRET treatments.json upload/latest-treatments.json | colorize_json || die "Couldn't upload latest treatments to NS"
     else

--- a/bin/oref0-shared-node-loop.sh
+++ b/bin/oref0-shared-node-loop.sh
@@ -18,6 +18,4 @@ Usage: $self
 Sync data with Nightscout. Typically runs from crontab.
 EOT
 
-
-
 main "$@"

--- a/bin/oref0-shared-node-loop.sh
+++ b/bin/oref0-shared-node-loop.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
+
+# Shared node loop.
+main() {
+    echo
+    echo Starting Shared-Node-loop at $(date):
+    while true; do
+
+        node ../src/oref0/bin/oref0-shared-node.js
+        echo Tough luck, shared node crashed. Starting it againg at  $(date)
+    done
+}
+
+usage "$@" <<EOT
+Usage: $self
+Sync data with Nightscout. Typically runs from crontab.
+EOT
+
+
+
+main "$@"

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -85,8 +85,8 @@ function serverListen() {
                 // remove the first parameter.
                 command.shift();
                 try {
-                    result = ns_status(command) + "\n";
-                    //sleepFor(2000);
+                    result = ns_status(command);
+                    result = addNewlToResult(result);
                 } catch (err) {
                     return_val = 1;
                     console.log('exception when parsing ns_status ', err);
@@ -95,12 +95,7 @@ function serverListen() {
                 command.shift();
                 try {
                     result = oref0_normalize_temps(command);
-                    if (typeof result === 'undefined') {
-                        // This preserves the oref0_normalize_temps behavior.
-                        result = ""
-                    } else {
-                        result += "\n";
-                    }
+                    result = addNewlToResult(result);
                 } catch (err) {
                     return_val = 1;
                     console.log('exception when parsing oref0-normalize-temps ', err);
@@ -112,7 +107,7 @@ function serverListen() {
                 command.shift();
                 try {
                     [result, return_val] = jsonWrapper(command);
-                    result += "\n";
+                    result = addNewlToResult(result);
                 } catch (err) {
                     return_val = 1;
                     console.log('exception when running json_wrarpper ', err);
@@ -145,6 +140,16 @@ function funcWithReturnFromSnippet(js) {
     return (new Function(js));
 }
 
+
+function addNewlToResult(result) {
+    if (result === undefined) {
+        // This preserves the oref0_normalize_temps behavior.
+        result = ""
+    } else {
+        result += "\n";
+    }
+    return result;
+}
 
 // The goal is to run something like:
 // json -f monitor/status.1.json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38"

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var os = require("os");
+var ns_status = require("./ns-status");	
+var oref0_normalize_temps = require("./oref0-normalize-temps");	
+
+function createRetVal(stdout, return_val) {
+    var returnObj = {
+	err: "",
+	stdout: stdout,
+	return_val: return_val
+    }
+    return returnObj;
+}
+
+function serverListen() {
+
+    const net = require('net');
+    const fs = require('fs');
+    const unixSocketServer = net.createServer({allowHalfOpen:true});
+
+    var socketPath = '/tmp/unixSocket';
+    try {
+        fs.unlinkSync(socketPath);
+    } catch (err) {
+	    if (err.code == 'ENOENT') {
+                // Intentionly ignored.
+            } else {
+                throw err;
+	    }
+    }
+    unixSocketServer.listen(socketPath, () => {
+        console.log('now listening');
+    });
+
+    unixSocketServer.on('end', function() {
+        console.log("server 2 disconnected from port");
+    });
+
+    unixSocketServer.on('connection', (s) => {
+        console.log('got connection!');
+	s.allowHalfOpen = true;
+        s.on('end', function() {
+            console.log("server 2 disconnected from port");
+        });
+	
+	s.on('error', function(err) {
+            console.log("there was an error in the client and the error is: " + err.code);
+        });
+	
+        s.on("data", function(data) {
+            //... do stuff with the data ...
+            console.log('read data', data.toString());
+            var command = data.toString().split(' ');
+	    command = command.map(s => s.trim());
+
+            var result = 'unknown command';
+
+	    console.log('command = ' , command);
+
+            if (command[0] == 'ns-status') {
+		// remove the first parameter.
+		command.shift();
+		try {
+		    result = ns_status(command);
+		    //sleepFor(2000);
+		} catch (err) {
+		    console.log('exception when parsing ns_status ' , err);
+		}
+            } else if (command [0] == 'oref0-normalize-temps') {
+		command.shift();
+		try {
+		    
+		    result = oref0_normalize_temps(command);
+		} catch (err) {
+		    console.log('exception when parsing oref0-normalize-temps ' , err);
+		}
+	    } else {
+	        console.error('Unknown command = ' , command);
+	    }
+
+	    s.write(JSON.stringify(createRetVal(result, 0)));
+            s.end();
+        });
+    });
+}
+
+
+
+
+if (!module.parent) {
+    serverListen();
+}
+
+// Functions needed to simulate a stack node.
+const util = require('util');
+const vm = require('vm');
+
+function sleepFor( sleepDuration ){
+    var now = new Date().getTime();
+    while(new Date().getTime() < now + sleepDuration){ /* do nothing */ } 
+}
+
+
+
+
+

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -3,14 +3,18 @@
 'use strict';
 
 var os = require("os");
-var ns_status = require("./ns-status");	
-var oref0_normalize_temps = require("./oref0-normalize-temps");	
+var ns_status = require("./ns-status");
+var oref0_normalize_temps = require("./oref0-normalize-temps");
+var json = require("json");
+var uniqueFilename = require('unique-filename')
+var fs = require('fs');
+var requireUtils = require('../lib/require-utils');
 
 function createRetVal(stdout, return_val) {
     var returnObj = {
-	err: "",
-	stdout: stdout,
-	return_val: return_val
+        err: "",
+        stdout: stdout,
+        return_val: return_val
     }
     return returnObj;
 }
@@ -19,17 +23,19 @@ function serverListen() {
 
     const net = require('net');
     const fs = require('fs');
-    const unixSocketServer = net.createServer({allowHalfOpen:true});
+    const unixSocketServer = net.createServer({
+        allowHalfOpen: true
+    });
 
     var socketPath = '/tmp/oaps_shared_node';
     try {
         fs.unlinkSync(socketPath);
     } catch (err) {
-	    if (err.code == 'ENOENT') {
-                // Intentionly ignored.
-            } else {
-                throw err;
-	    }
+        if (err.code == 'ENOENT') {
+            // Intentionly ignored.
+        } else {
+            throw err;
+        }
     }
     unixSocketServer.listen(socketPath, () => {
         console.log('now listening');
@@ -41,55 +47,130 @@ function serverListen() {
 
     unixSocketServer.on('connection', (s) => {
         console.log('got connection!');
-	s.allowHalfOpen = true;
+        s.allowHalfOpen = true;
         s.on('end', function() {
             console.log("server 2 disconnected from port");
         });
-	
-	s.on('error', function(err) {
+
+        s.on('error', function(err) {
             console.log("there was an error in the client and the error is: " + err.code);
         });
-	
+
         s.on("data", function(data) {
             //... do stuff with the data ...
             console.log('read data', data.toString());
             var command = data.toString().split(' ');
-	    command = command.map(s => s.trim());
+
+            // Split by space except for inside quotes 
+            // (https://stackoverflow.com/questions/16261635/javascript-split-string-by-space-but-ignore-space-in-quotes-notice-not-to-spli)
+            var command = data.toString().match(/\\?.|^$/g).reduce((p, c) => {
+                if (c === '"') {
+                    p.quote ^= 1;
+                } else if (!p.quote && c === ' ') {
+                    p.a.push('');
+                } else {
+                    p.a[p.a.length - 1] += c.replace(/\\(.)/, "$1");
+                }
+                return p;
+            }, {
+                a: ['']
+            }).a;
+
+            command = command.map(s => s.trim());
 
             var result = 'unknown command';
+            var return_val = 0;
 
-	    console.log('command = ' , command);
+            console.log('command = ', command);
 
             if (command[0] == 'ns-status') {
-		// remove the first parameter.
-		command.shift();
-		try {
-		    result = ns_status(command);
-		    //sleepFor(2000);
-		} catch (err) {
-		    console.log('exception when parsing ns_status ' , err);
-		}
-            } else if (command [0] == 'oref0-normalize-temps') {
-		command.shift();
-		try {
-		    
-		    result = oref0_normalize_temps(command);
-		} catch (err) {
-		    console.log('exception when parsing oref0-normalize-temps ' , err);
-		}
-	    } else if (command [0] == 'ping') {
-		    result = 'pong';
-	    } else {
-	        console.error('Unknown command = ' , command);
-	    }
+                // remove the first parameter.
+                command.shift();
+                try {
+                    result = ns_status(command);
+                    //sleepFor(2000);
+                } catch (err) {
+                    return_val = 1;
+                    console.log('exception when parsing ns_status ', err);
+                }
+            } else if (command[0] == 'oref0-normalize-temps') {
+                command.shift();
+                try {
 
-	    s.write(JSON.stringify(createRetVal(result, 0)));
+                    result = oref0_normalize_temps(command);
+                } catch (err) {
+                    return_val = 1;
+                    console.log('exception when parsing oref0-normalize-temps ', err);
+                }
+            } else if (command[0] == 'ping') {
+                result = 'pong';
+            } else if (command[0] == 'json') {
+                // remove the first parameter.
+                command.shift();
+                try {
+                    result = jsonWrapper(command);
+                } catch (err) {
+                    return_val = 1;
+                    console.log('exception when running json_wrarpper ', err);
+                }
+            } else {
+                console.error('Unknown command = ', command);
+                return_val = 1;
+            }
+            s.write(JSON.stringify(createRetVal(result, return_val)));
             s.end();
         });
     });
 }
 
+// The goal is to run something like:
+// json -f monitor/status.1.json -c "minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38"
+function jsonWrapper(argv_params) {
+    var argv = require('yargs')(argv_params)
+        .usage('$0 json -f monitor/status.1.json -c \"minAgo=(new Date()-new Date(this.dateString))/60/1000; return minAgo < 10 && minAgo > -5 && this.glucose > 38\"')
+        .option('input_file', {
+            alias: 'f',
+            nargs: 1,
+            describe: "Input/Output file",
+            default: false
+        })
+        .option('filtering_code', {
+            alias: 'c',
+            nargs: 1,
+            describe: "Conditional filtering",
+            default: false
+        })
+        .strict(true)
+        .fail(function(msg, err, yargs) {
+            if (err) {
+                return console.error('Error found', err);
+            }
+            return console.error('Parsing of command arguments failed', msg)
+        })
+        .help('help');
+    var params = argv.argv;
+    var inputs = params._;
+    if (inputs.length > 0) {
+        return console.error('Error: too many input parameters.');
+    }
+    if (!params.input_file) {
+        return console.error('Error: No input file.');
+    }
+    if (!params.filtering_code) {
+        return console.error('Error: No filtering_code');
+    }
+    // Copy the input file to a temp one (we must work inplace).
+    var jsonTmpfile = uniqueFilename(os.tmpdir(), 'json_input')
+    fs.copyFileSync(params.input_file, jsonTmpfile);
+    console.log("Coppied file to ", jsonTmpfile);
 
+    var newCommand = ['node', '/home/pi/lib/json', '-I', '-f', jsonTmpfile, '-c', params.filtering_code];
+    json.main(newCommand);
+    // output should be in the temp file.
+    var output = requireUtils.safeLoadFile(jsonTmpfile);
+    // Shoud we check for errors here?
+    return output;
+}
 
 
 if (!module.parent) {
@@ -100,12 +181,8 @@ if (!module.parent) {
 const util = require('util');
 const vm = require('vm');
 
-function sleepFor( sleepDuration ){
+function sleepFor(sleepDuration) {
     var now = new Date().getTime();
-    while(new Date().getTime() < now + sleepDuration){ /* do nothing */ } 
+    while (new Date().getTime() < now + sleepDuration) {
+        /* do nothing */ }
 }
-
-
-
-
-

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -21,7 +21,7 @@ function serverListen() {
     const fs = require('fs');
     const unixSocketServer = net.createServer({allowHalfOpen:true});
 
-    var socketPath = '/tmp/unixSocket';
+    var socketPath = '/tmp/oaps_shared_node';
     try {
         fs.unlinkSync(socketPath);
     } catch (err) {
@@ -77,6 +77,8 @@ function serverListen() {
 		} catch (err) {
 		    console.log('exception when parsing oref0-normalize-temps ' , err);
 		}
+	    } else if (command [0] == 'ping') {
+		    result = 'pong';
 	    } else {
 	        console.error('Unknown command = ' , command);
 	    }

--- a/lib/require-utils.js
+++ b/lib/require-utils.js
@@ -14,18 +14,68 @@ function safeRequire (path) {
   return resolved;
 }
 
+function safeLoadFile(path) {
+  
+  var resolved;
+
+  try {
+    resolved = JSON.parse(fs.readFileSync(path, 'utf8'));
+    //console.log('content = ' , resolved);
+  } catch (e) {
+    console.error("Could not require: " + path, e);
+  }
+  return resolved;
+}
+
 function requireWithTimestamp (path) {
-  var resolved = safeRequire(path);
+  var resolved = safeLoadFile(path);
 
   if (resolved) {
     resolved.timestamp = fs.statSync(path).mtime;
   }
-
   return resolved;
 }
 
+// Functions that are needed in order to test the module. Can be removed in the future.
+
+function compareMethods(path) {
+  var new_data = safeLoadFile(path);
+  var old_data = safeRequire(path);
+  if (JSON.stringify(new_data) === JSON.stringify(old_data) ) {
+    console.log("test passed", new_data, old_data); 
+  } else {
+    console.log("test failed"); 
+  }
+}
+
+// Module tests.
+if (!module.parent) {
+ // Write the first file: and test it.
+ var obj = {x: "x", y: 1}
+ fs.writeFileSync('/tmp/file1.json', JSON.stringify(obj));
+ compareMethods('/tmp/file1.json');
+
+  // Check a non existing object.
+  compareMethods('/tmp/not_exist.json');
+  
+  // check a file that is not formated well.
+  fs.writeFileSync('/tmp/bad.json', '{"x":"x","y":1');
+  compareMethods('/tmp/bad.json');
+
+  // Rewrite the file and reread it.
+  var new_obj = {x: "x", y: 2}
+  fs.writeFileSync('/tmp/file1.json', JSON.stringify(new_obj));
+  var obj_read = safeLoadFile('/tmp/file1.json');
+  if (JSON.stringify(new_obj) === JSON.stringify(obj_read) ) {
+    console.log("test passed"); 
+  } else {
+    console.log("test failed"); 
+  }
+
+}
 
 module.exports = {
   safeRequire: safeRequire
   , requireWithTimestamp: requireWithTimestamp
+  , safeLoadFile: safeLoadFile
 };

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "oref0-upload-profile": "./bin/oref0-upload-profile.js",
     "oref0-version": "./bin/oref0-version.sh",
     "oref0-get-ns-entries": "./bin/oref0-get-ns-entries.js",
+    "oref0-shared-node-loop": "./bin/oref0-shared-node-loop.sh",
     "peb-urchin-status": "./bin/peb-urchin-status.sh",
     "wifi": "./bin/oref0-tail-wifi.sh"
   },


### PR DESCRIPTION
This pr adds code to run on shared node.

Solution overview:
1) A shared node is created to accept different requests.
2) js modules have been changed to return their values based on a function call.
3) "Clients" use a unix socket to talk with shared node.
More details:
Keeping shared node alive:
1) Shared node is started every time that it is killed.
2) Every minute, ping is sent to the shared node. If it does not answer it, it is killed.
3) On my testing, I did not see it never failing.

Return value of shared node:
The result of the node consist of 3 things:
1) The exit code of the function.
2) The output to stdout of the js code.
3) The output to stderr of the js code (was not still used).

Testing:
Test rig has been looping for a long time without any problem. It was able to complete pump loops within 5 minutes except where communication with pump was problematic.
All input to the shared node is captured, and copied to a shared directory.
Later, the old code and the new code have been running on this input. No difference was found between the two runs.
With this change the rigs become much less loaded (and very likely this is also a needed step in reducing battery consumption).
