### PR TITLE
Make sure .bash_profile exists

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1051,6 +1051,8 @@ if prompt_yn "" N; then
     do_openaps_import $HOME/src/oref0/lib/oref0-setup/supermicrobolus.json
 
     echo "Adding OpenAPS log shortcuts"
+    # Make sure that .bash_profile exists first, then call script to add the log shortcuts
+    touch "$HOME/.bash_profile"
     oref0-log-shortcuts --add-to-profile="$HOME/.bash_profile"
 
     # Append NIGHTSCOUT_HOST and API_SECRET to $HOME/.bash_profile so that openaps commands can be executed from the command line


### PR DESCRIPTION
Fixes an issue with new installs where log shortcuts are not added to .bash_profile, because the `oref0-log-shortcuts.sh` script only works on existing files.