### PR TITLE
floating carbs

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -545,10 +545,15 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // avoid divide by zero
         cid = 0;
     } else {
-        cid = Math.min(remainingCATime*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
+        if (profile.floating_carbs === true) {
+            // with floating_carbs preference set, use all carbs, not just COB
+            cid = Math.min(remainingCATime*60/5/2,Math.max(0, meal_data.carbs * csf / ci ));
+        } else {
+            cid = Math.min(remainingCATime*60/5/2,Math.max(0, meal_data.mealCOB * csf / ci ));
+        }
     }
     // duration (hours) = duration (5m) * 5 / 60 * 2 (to account for linear decay)
-    console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (",remainingCATime," peak):",round(remainingCIpeak,1),"mg/dL per 5m");
+    console.error("Carb Impact:",ci,"mg/dL per 5m; CI Duration:",round(cid*5/60*2,1),"hours; remaining CI (",remainingCATime/2,"h peak):",round(remainingCIpeak,1),"mg/dL per 5m");
 
     var minIOBPredBG = 999;
     var minCOBPredBG = 999;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -32,6 +32,7 @@ function defaults ( ) {
     , unsuspend_if_no_temp: false // if true, pump will un-suspend after a zero temp finishes
     , bolussnooze_dia_divisor: 2 // bolus snooze decays after 1/2 of DIA
     , min_5m_carbimpact: 8 // mg/dL per 5m (8 mg/dL/5m corresponds to 24g/hr at a CSF of 4 mg/dL/g (x/5*60/4))
+    , floating_carbs: false // if true, use all entered carbs for predBGs: don't decay them as COB
     , autotune_isf_adjustmentFraction: 1.0 // keep autotune ISF closer to pump ISF via a weighted average of fullNewISF and pumpISF.  1.0 allows full adjustment, 0 is no adjustment from pump ISF.
     , remainingCarbsFraction: 1.0 // fraction of carbs we'll assume will absorb over 4h if we don't yet see carb absorption
     , remainingCarbsCap: 90 // max carbs we'll assume will absorb over 4h if we don't yet see carb absorption


### PR DESCRIPTION
If `floating_carbs: true`, then dose slightly more aggressively by using all entered carbs for calculating COBpredBGs. This avoids backing off too quickly as COB decays. Even with this option, oref0 still switches gradually from using COBpredBGs to UAMpredBGs proportionally to how many carbs are left as COB.

In our testing with `floating_carbs: true` and a higher BG target during the day (120 instead of 100), we've so far found that oref0 with SMB and UAM is better able to keep BG in range and avoid high BGs after COB decays.