### PR TITLE
calculate effective temp basal rate for Omnipod Loop

### DIFF
--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -326,6 +326,11 @@ function calcTempTreatments (inputs, zeroTempDuration) {
             var temp = {};
             temp.rate = current.rate;
             temp.duration = current.duration;
+            // Loop reports the amount of insulin actually delivered while the temp basal was running
+            // use that to calculate the effective temp basal rate
+            if (typeof current.amount !== 'undefined') {
+                temp.rate = current.amount / current.duration * 60;
+            }
             temp.timestamp = current.timestamp;
             temp.started_at = new Date(tz(temp.timestamp));
             temp.date = temp.started_at.getTime();


### PR DESCRIPTION
Fix for #1362 to accurately calculate IOB for Omnipod Loop users running Autotune from the `amount` field added to Temp Basal records to record how much insulin was actually delivered while the temp basal was running.

Needs further testing. Side-by-side autotune runs on a single day's worth of Omnipod Loop data show consistent small differences in calculated IOB, resulting in some minor differences in recommendations.