### PR TITLE
Installer fixes

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -43,6 +43,7 @@ if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /de
     # Replace apt sources.list with archive.debian.org locations
     echo -e "deb http://security.debian.org/ jessie/updates main\n#deb-src http://security.debian.org/ jessie/updates main\n\ndeb http://archive.debian.org/debian/ jessie-backports main\n#deb-src http://archive.debian.org/debian/ jessie-backports main\n\ndeb http://archive.debian.org/debian/ jessie main contrib non-free\n#deb-src http://archive.debian.org/debian/ jessie main contrib non-free" > /etc/apt/sources.list
     echo "Please consider upgrading your rig to Jubilinux 0.3.0 (Debian Stretch)!"
+    echo "Jubilinux 0.2.0, based on Debian Jessie, is no longer receiving security or software updates!"
 fi
 
 #Workaround for Jubilinux to install nodejs/npm from nodesource

--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -42,6 +42,7 @@ if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /de
     echo "Acquire::Check-Valid-Until false;" | tee -a /etc/apt/apt.conf.d/10-nocheckvalid
     # Replace apt sources.list with archive.debian.org locations
     echo -e "deb http://security.debian.org/ jessie/updates main\n#deb-src http://security.debian.org/ jessie/updates main\n\ndeb http://archive.debian.org/debian/ jessie-backports main\n#deb-src http://archive.debian.org/debian/ jessie-backports main\n\ndeb http://archive.debian.org/debian/ jessie main contrib non-free\n#deb-src http://archive.debian.org/debian/ jessie main contrib non-free" > /etc/apt/sources.list
+    echo "Please consider upgrading your rig to Jubilinux 0.3.0 (Debian Stretch)!"
 fi
 
 #Workaround for Jubilinux to install nodejs/npm from nodesource

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -12,30 +12,35 @@ apt-get install -y sudo
 sudo apt-get update && sudo apt-get -y upgrade
 sudo apt-get install -y git python python-dev software-properties-common python-numpy python-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
 
-# We require jq >= 1.5 for --slurpfile for merging preferences. Debian Jessie ships with 1.4
+# We require jq >= 1.5 for --slurpfile for merging preferences. Debian Jessie ships with 1.4.
 if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /dev/null; then
+   echo "Please consider upgrading your rig to Jubilinux 0.3.0 (Debian Stretch)!"
    sudo apt-get -y -t jessie-backports install jq || die "Couldn't install jq from jessie-backports"
 else
+   # Debian Stretch & Buster ship with jq >= 1.5, so install from apt
    sudo apt-get -y install jq || die "Couldn't install jq"
 fi
 
-# install/upgrade to latest node 8 if neither node 8 nor node 10+ LTS are installed
+# Install/upgrade to latest version of node (v10) using apt if neither node 8 nor node 10+ LTS are installed
 if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' &> /dev/null ; then
-        # nodesource doesn't support armv6
-        if ! arch | grep -e 'armv6' &> /dev/null ; then
-            sudo bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -" || die "Couldn't setup node 8"
-            sudo apt-get install -y nodejs=8.* || die "Couldn't install nodejs"
-        else
-            sudo apt-get install -y nodejs npm || die "Couldn't install nodejs and npm"
-            npm install npm@latest -g || die "Couldn't update npm"
-        fi
-        ## You may also need development tools to build native addons:
-        ##sudo apt-get install gcc g++ make
+   if getent passwd edison; then
+     # Only on the Edison, use nodesource setup script to add nodesource repository to sources.list.d, then install nodejs (npm is a part of the package)
+     curl -sL https://deb.nodesource.com/setup_8.x | bash -
+     sudo apt-get install -y nodejs=8.* || die "Couldn't install nodejs"
+   else
+     sudo apt-get install -y nodejs npm || die "Couldn't install nodejs and npm"
+   fi
+   
+   # Upgrade npm to the latest version using its self-updater
+   sudo npm install npm@latest -g || die "Couldn't update npm"
+
+   ## You may also need development tools to build native addons:
+   ## sudo apt-get install gcc g++ make
 fi
 
 # upgrade setuptools to avoid "'install_requires' must be a string" error
 sudo pip install setuptools -U # no need to die if this fails
-sudo pip install -U openaps || die "Couldn't install openaps toolkit"
+sudo pip install -U --default-timeout=1000 git+https://github.com/openaps/openaps.git || die "Couldn't install openaps toolkit"
 sudo pip install -U openaps-contrib || die "Couldn't install openaps-contrib"
 sudo openaps-install-udev-rules || die "Couldn't run openaps-install-udev-rules"
 sudo activate-global-python-argcomplete || die "Couldn't run activate-global-python-argcomplete"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1089,12 +1089,16 @@ if prompt_yn "" N; then
     if [[ -f $HOME/.profile ]]; then
       sed --in-place '/.*API_SECRET.*/d' $HOME/.profile
       sed --in-place '/.*NIGHTSCOUT_HOST.*/d' $HOME/.profile
+      sed --in-place '/.*MEDTRONIC_PUMP_ID.*/d' $HOME/.profile
+      sed --in-place '/.*MEDTRONIC_FREQUENCY.*/d' $HOME/.profile
     fi
 
     # Delete old copies of variables before replacing them
     sed --in-place '/.*NIGHTSCOUT_HOST.*/d' $HOME/.bash_profile
     sed --in-place '/.*API_SECRET.*/d' $HOME/.bash_profile
     sed --in-place '/.*DEXCOM_CGM_RECV_ID*/d' $HOME/.bash_profile
+    sed --in-place '/.*MEDTRONIC_PUMP_ID.*/d' $HOME/.bash_profile
+    sed --in-place '/.*MEDTRONIC_FREQUENCY.*/d' $HOME/.bash_profile
     #sed --in-place '/.*DEXCOM_CGM_TX_ID*/d' $HOME/.bash_profile
 
     # Then append the variables
@@ -1104,9 +1108,11 @@ if prompt_yn "" N; then
     echo "export API_SECRET" >> $HOME/.bash_profile
     echo DEXCOM_CGM_RECV_ID="$BLE_SERIAL" >> $HOME/.bash_profile
     echo "export DEXCOM_CGM_RECV_ID" >> $HOME/.bash_profile
+    echo MEDTRONIC_PUMP_ID="$serial" >> $HOME/.bash_profile
+    echo MEDTRONIC_FREQUENCY='`cat $HOME/myopenaps/monitor/medtronic_frequency.ini`' >> $HOME/.bash_profile
+    
     #echo DEXCOM_CGM_TX_ID="$DEXCOM_CGM_TX_ID" >> $HOME/.bash_profile
     #echo "export DEXCOM_CGM_TX_ID" >> $HOME/.bash_profile
-    echo
 
     #Turn on i2c, install pi-buttons, and openaps-menu for hardware that has a screen and buttons (so far, only Explorer HAT and Radiofruit Bonnet)
     if grep -qa "Explorer HAT" /proc/device-tree/hat/product &> /dev/null || [[ "$hardwaretype" =~ "explorer-hat" ]] || [[ "$hardwaretype" =~ "radiofruit" ]]; then


### PR DESCRIPTION
- Changes the way nodejs/npm are installed: Edison rigs will get it v8 from nodesource (Jessie/Stretch), Pi rigs will get it from the distro (Raspbian Buster)
- openaps toolchain will be installed from the latest version on git, rather than via pypi.