### PR TITLE
Tzachi shared node phase2

### DIFF
--- a/bin/oref0-autosens-history.js
+++ b/bin/oref0-autosens-history.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /*
   Determine Basal
@@ -16,10 +17,10 @@
 */
 
 var basal = require('../lib/profile/basal');
-var detect = require('../lib/determine-basal/autosens');
+var detectSensitivity = require('../lib/determine-basal/autosens');
 
 if (!module.parent) {
-    var detectsensitivity = init();
+    //var detectsensitivity = init(); // I don't see where this variable is used, so deleted it.
 
     var argv = require('yargs')
         .usage("$0 <glucose.json> <pumphistory.json> <profile.json> <readings_per_run> [outputfile.json]")
@@ -135,16 +136,16 @@ if (!module.parent) {
     var ratioArray = [];
     do {
         detection_inputs.deviations = 96;
-        detect(detection_inputs);
+        var result = detectSensitivity(detection_inputs);
         for(i=0; i<readings_per_run; i++) {
             detection_inputs.glucose_data.shift();
         }
-        console.error(ratio, newisf, detection_inputs.glucose_data[0].dateString);
+        console.error(result.ratio, result.newisf, detection_inputs.glucose_data[0].dateString);
 
         var obj = {
             "dateString": detection_inputs.glucose_data[0].dateString,
-            "sensitivityRatio": ratio,
-            "ISF": newisf
+            "sensitivityRatio": result.ratio,
+            "ISF": result.newisf
         }
         ratioArray.unshift(obj);
         if (output_file) {

--- a/bin/oref0-calculate-iob.js
+++ b/bin/oref0-calculate-iob.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+'use strict';
 /*
   Insulin On Board (IOB) calculations.
 
@@ -19,13 +19,16 @@
 */
 
 var generate = require('../lib/iob');
+var fs = require('fs');
 function usage ( ) {
     console.log('usage: ', process.argv.slice(0, 2), '<pumphistory-zoned.json> <profile.json> <clock-zoned.json> [autosens.json] [pumphistory-24h-zoned.json]');
 
 }
 
-if (!module.parent) {
-  var argv = require('yargs')
+
+
+var oref0_calculate_iob = function oref0_calculate_iob(argv_params) {  
+  var argv = require('yargs')(argv_params)
     .usage("$0 <pumphistory-zoned.json> <profile.json> <clock-zoned.json> [<autosens.json>] [<pumphistory-24h-zoned.json>]")
     .strict(true)
     .help('help');
@@ -46,21 +49,21 @@ if (!module.parent) {
   var pumphistory_24_input = inputs[4];
 
   var cwd = process.cwd();
-  var pumphistory_data = require(cwd + '/' + pumphistory_input);
-  var profile_data = require(cwd + '/' + profile_input);
-  var clock_data = require(cwd + '/' + clock_input);
+  var pumphistory_data = JSON.parse(fs.readFileSync(cwd + '/' + pumphistory_input));
+  var profile_data = JSON.parse(fs.readFileSync(cwd + '/' + profile_input));
+  var clock_data = JSON.parse(fs.readFileSync(cwd + '/' + clock_input));
 
   var autosens_data = null;
   if (autosens_input) {
     try {
-        autosens_data = require(cwd + '/' + autosens_input);
+        autosens_data = JSON.parse(fs.readFileSync(cwd + '/' + autosens_input));
     } catch (e) {}
     //console.error(autosens_input, JSON.stringify(autosens_data));
   }
   var pumphistory_24_data = null;
   if (pumphistory_24_input) {
     try {
-        pumphistory_24_data = require(cwd + '/' + pumphistory_24_input);
+        pumphistory_24_data = JSON.parse(fs.readFileSync(cwd + '/' + pumphistory_24_input));
     } catch (e) {}
   }
 
@@ -77,6 +80,16 @@ if (!module.parent) {
   }
 
   var iob = generate(inputs);
-  console.log(JSON.stringify(iob));
+  return(JSON.stringify(iob));
 }
 
+if (!module.parent) {
+   // remove the first parameter.
+   var command = process.argv;
+   command.shift();
+   command.shift();
+   var result = oref0_calculate_iob(command)
+   console.log(result);
+}
+
+exports = module.exports = oref0_calculate_iob

--- a/bin/oref0-detect-sensitivity.js
+++ b/bin/oref0-detect-sensitivity.js
@@ -14,7 +14,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-var detect = require('../lib/determine-basal/autosens');
+var detectSensitivity = require('../lib/determine-basal/autosens');
 
 if (!module.parent) {
     var argv = require('yargs')
@@ -112,14 +112,14 @@ if (!module.parent) {
     };
     console.error("Calculating sensitivity using 8h of non-exluded data");
     detection_inputs.deviations = 96;
-    detect(detection_inputs);
-    var ratio8h = ratio;
-    var newisf8h = newisf;
+    var result = detectSensitivity(detection_inputs);
+    var ratio8h = result.ratio;
+    var newisf8h = result.newisf;
     console.error("Calculating sensitivity using all non-exluded data (up to 24h)");
     detection_inputs.deviations = 288;
-    detect(detection_inputs);
-    var ratio24h = ratio;
-    var newisf24h = newisf;
+    result = detectSensitivity(detection_inputs);
+    var ratio24h = result.ratio;
+    var newisf24h = result.newisf;
     if ( ratio8h < ratio24h ) {
         console.error("Using 8h autosens ratio of",ratio8h,"(ISF",newisf8h+")");
     } else {

--- a/bin/oref0-get-ns-entries.js
+++ b/bin/oref0-get-ns-entries.js
@@ -26,6 +26,10 @@ var request = require('request');
 var _ = require('lodash');
 var fs = require('fs');
 var network = require('network');
+var shared_node = require('./oref0-shared-node-utils');
+var console_error = shared_node.console_error;
+var console_log = shared_node.console_log;
+var initFinalResults = shared_node.initFinalResults;
 
 var oref0_get_ns_engtires = function oref0_get_ns_engtires(argv_params, print_callback, final_result) {  
   var safe_errors = ['ECONNREFUSED', 'ESOCKETTIMEDOUT', 'ETIMEDOUT'];
@@ -224,26 +228,9 @@ function print_callback(final_result) {
     console.error(final_result.err);
 }
 
-function console_error(final_result, ...theArgs) {
-    if(final_result.err.length > 0) {
-        final_result.err += '\n';
-    }
-    final_result.err += theArgs.join(' ');
-}
-
-function console_log(final_result, ...theArgs) {
-    if(final_result.stdout.length > 0) {
-        final_result.stdout += '\n';
-    }
-    final_result.stdout += theArgs.join(' ');
-}
 
 if (!module.parent) {
-    var final_result = {
-        stdout: ''
-        , err: ''
-        , return_val : 0
-    };
+    var final_result = initFinalResults();
     
     // remove the first parameter.
     var command = process.argv;

--- a/bin/oref0-get-profile.js
+++ b/bin/oref0-get-profile.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /*
   Get Basal Information
@@ -16,6 +17,7 @@
 
 */
 
+var fs = require('fs');
 var generate = require('../lib/profile/');
 
 function exportDefaults () {
@@ -37,9 +39,8 @@ function updatePreferences (prefs) {
 	console.log(JSON.stringify(prefs, null, '\t'));
 }
 
-if (!module.parent) {
-    
-    var argv = require('yargs')
+var oref0_get_profile = function oref0_get_profile(argv_params) {  
+    var argv = require('yargs')(argv_params)
       .usage("$0 <pump_settings.json> <bg_targets.json> <insulin_sensitivities.json> <basal_profile.json> [<preferences.json>] [<carb_ratios.json>] [<temptargets.json>] [--model <model.json>] [--autotune <autotune.json>] [--exportDefaults] [--updatePreferences <preferences.json>]")
       .option('model', {
         alias: 'm',
@@ -84,7 +85,7 @@ if (!module.parent) {
     if (params.updatePreferences) {
         var preferences = {};
         var cwd = process.cwd()
-        preferences = require(cwd + '/' + params.updatePreferences);
+        preferences = JSON.parse(fs.readFileSync(cwd + '/' + params.updatePreferences));
         updatePreferences(preferences);
         process.exit(0);
     }
@@ -99,8 +100,8 @@ if (!module.parent) {
     var autotune_input = params.autotune;
 
     cwd = process.cwd()
-    var pumpsettings_data = require(cwd + '/' + pumpsettings_input);
-    var bgtargets_data = require(cwd + '/' + bgtargets_input);
+    var pumpsettings_data = JSON.parse(fs.readFileSync(cwd + '/' + pumpsettings_input));
+    var bgtargets_data = JSON.parse(fs.readFileSync(cwd + '/' + bgtargets_input));
     if (bgtargets_data.units !== 'mg/dL') {
         if (bgtargets_data.units === 'mmol/L') {
             for (var i = 0, len = bgtargets_data.targets.length; i < len; i++) {
@@ -115,7 +116,7 @@ if (!module.parent) {
         }
     }
     
-    var isf_data = require(cwd + '/' + isf_input);
+    var isf_data = JSON.parse(fs.readFileSync(cwd + '/' + isf_input));
     if (isf_data.units !== 'mg/dL') {
         if (isf_data.units === 'mmol/L') {
             for (i = 0, len = isf_data.sensitivities.length; i < len; i++) {
@@ -128,13 +129,12 @@ if (!module.parent) {
             process.exit(2);
         }
     }
-    var basalprofile_data = require(cwd + '/' + basalprofile_input);
+    var basalprofile_data = JSON.parse(fs.readFileSync(cwd + '/' + basalprofile_input));
 
     preferences = {};
     if (typeof preferences_input !== 'undefined') {
-        preferences = require(cwd + '/' + preferences_input);
+        preferences = JSON.parse(fs.readFileSync(cwd + '/' + preferences_input));
     }
-    var fs = require('fs');
 
     var model_data = { }
     if (params.model) {
@@ -143,9 +143,9 @@ if (!module.parent) {
         model_data = model_string.replace(/"/gi, '');
       } catch (e) {
         var msg = { error: e, msg: "Could not parse model_data", file: model_input};
-        console.error(msg.msg);
-        console.log(JSON.stringify(msg));
-        process.exit(1);
+        console.error(msg.msg);              //??????????
+        console.log(JSON.stringify(msg));    //??????
+        process.exit(1);                     //?????
       }
     }
     var autotune_data = { }
@@ -231,6 +231,17 @@ if (!module.parent) {
     }
     var profile = generate(inputs);
 
-    console.log(JSON.stringify(profile));
+    return JSON.stringify(profile);
 
 }
+
+if (!module.parent) {
+    // remove the first parameter.
+    var command = process.argv;
+    command.shift();
+    command.shift();
+    var result = oref0_get_profile(command)
+    console.log(result);
+}
+
+exports = module.exports = oref0_get_profile;

--- a/bin/oref0-meal.js
+++ b/bin/oref0-meal.js
@@ -22,7 +22,7 @@
 
 var generate = require('../lib/meal');
 
-var oref0_meal = function oref0_calculate_iob(argv_params) {  
+var oref0_meal = function oref0_meal(argv_params) {  
 	var argv = require('yargs')(argv_params)
       .usage('$0 <pumphistory.json> <profile.json> <clock.json> <glucose.json> <basalprofile.json> [<carbhistory.json>]')
       // error and show help if some other args given

--- a/bin/oref0-meal.js
+++ b/bin/oref0-meal.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /*
   oref0 meal data tool
@@ -21,8 +22,8 @@
 
 var generate = require('../lib/meal');
 
-if (!module.parent) {
-    var argv = require('yargs')
+var oref0_meal = function oref0_calculate_iob(argv_params) {  
+	var argv = require('yargs')(argv_params)
       .usage('$0 <pumphistory.json> <profile.json> <clock.json> <glucose.json> <basalprofile.json> [<carbhistory.json>]')
       // error and show help if some other args given
       .strict(true)
@@ -53,8 +54,8 @@ if (!module.parent) {
     try {
         pumphistory_data = JSON.parse(fs.readFileSync(pumphistory_input, 'utf8'));
     } catch (e) {
-        console.log('{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse pumphistory data" }');
-        return console.error("Could not parse pumphistory data: ", e);
+        console.log('{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse pumphistory data" }'); //??
+        return console.error("Could not parse pumphistory data: ", e); //???
     }
 
     try {
@@ -127,6 +128,16 @@ if (!module.parent) {
         recentCarbs.reason = "not enough glucose data to calculate carb absorption";
     }
 
-    console.log(JSON.stringify(recentCarbs));
+    return JSON.stringify(recentCarbs);
 }
 
+if (!module.parent) {
+   // remove the first parameter.
+   var command = process.argv;
+   command.shift();
+   command.shift();
+   var result = oref0_meal(command)
+   console.log(result);
+}
+
+exports = module.exports = oref0_meal

--- a/bin/oref0-meal.js
+++ b/bin/oref0-meal.js
@@ -21,8 +21,13 @@
 */
 
 var generate = require('../lib/meal');
+var shared_node_utils = require('./oref0-shared-node-utils');
+var console_error = shared_node_utils.console_error;
+var console_log = shared_node_utils.console_log;
+var process_exit = shared_node_utils.process_exit;
+var initFinalResults = shared_node_utils.initFinalResults;
 
-var oref0_meal = function oref0_meal(argv_params) {  
+var oref0_meal = function oref0_meal(final_result, argv_params) {  
 	var argv = require('yargs')(argv_params)
       .usage('$0 <pumphistory.json> <profile.json> <clock.json> <glucose.json> <basalprofile.json> [<carbhistory.json>]')
       // error and show help if some other args given
@@ -41,8 +46,9 @@ var oref0_meal = function oref0_meal(argv_params) {
 
     if (inputs.length < 5 || inputs.length > 6) {
         argv.showHelp();
-        console.log('{ "carbs": 0, "reason": "Insufficient arguments" }');
-        process.exit(1);
+        console_log(final_result, '{ "carbs": 0, "reason": "Insufficient arguments" }');
+        process_exit(1);
+        return;
     }
 
     var fs = require('fs');
@@ -54,41 +60,41 @@ var oref0_meal = function oref0_meal(argv_params) {
     try {
         pumphistory_data = JSON.parse(fs.readFileSync(pumphistory_input, 'utf8'));
     } catch (e) {
-        console.log('{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse pumphistory data" }'); //??
-        return console.error("Could not parse pumphistory data: ", e); //???
+        console_log(final_result, '{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse pumphistory data" }'); //??
+        return console_error(final_result, "Could not parse pumphistory data: ", e);
     }
 
     try {
         profile_data = JSON.parse(fs.readFileSync(profile_input, 'utf8'));
     } catch (e) {
-        console.log('{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse profile data" }');
-        return console.error("Could not parse profile data: ", e);
+        console_log(final_result, '{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse profile data" }');
+        return console_error(final_result, "Could not parse profile data: ", e);
     }
 
     try {
         clock_data = JSON.parse(fs.readFileSync(clock_input, 'utf8'));
     } catch (e) {
-        console.log('{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse clock data" }');
-        return console.error("Could not parse clock data: ", e);
+        console_log(final_result, '{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse clock data" }');
+        return console_error(final_result, "Could not parse clock data: ", e);
     }
 
     try {
         basalprofile_data = JSON.parse(fs.readFileSync(basalprofile_input, 'utf8'));
     } catch (e) {
-        console.log('{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse basalprofile data" }');
-        return console.error("Could not parse basalprofile data: ", e);
+        console_log(final_result, '{ "carbs": 0, "mealCOB": 0, "reason": "Could not parse basalprofile data" }');
+        return console_error(final_result, "Could not parse basalprofile data: ", e);
     }
 
     // disallow impossibly low carbRatios due to bad decoding
     if ( typeof(profile_data.carb_ratio) === 'undefined' || profile_data.carb_ratio < 3 ) {
-        console.log('{ "carbs": 0, "mealCOB": 0, "reason": "carb_ratio ' + profile_data.carb_ratio + ' out of bounds" }');
-        return console.error("Error: carb_ratio " + profile_data.carb_ratio + " out of bounds");
+        console_log(final_result, '{ "carbs": 0, "mealCOB": 0, "reason": "carb_ratio ' + profile_data.carb_ratio + ' out of bounds" }');
+        return console_error(final_result, "Error: carb_ratio " + profile_data.carb_ratio + " out of bounds");
     }
 
     try {
         var glucose_data = JSON.parse(fs.readFileSync(glucose_input, 'utf8'));
     } catch (e) {
-        console.error("Warning: could not parse "+glucose_input);
+        console_error(final_result, "Warning: could not parse "+glucose_input);
     }
 
     var carb_data = { };
@@ -96,19 +102,19 @@ var oref0_meal = function oref0_meal(argv_params) {
         try {
             carb_data = JSON.parse(fs.readFileSync(carb_input, 'utf8'));
         } catch (e) {
-            console.error("Warning: could not parse "+carb_input);
+            console_error(final_result, "Warning: could not parse "+carb_input);
         }
     }
 
     if (typeof basalprofile_data[0] === 'undefined') {
-        return console.error("Error: bad basalprofile_data:" + basalprofile_data);
+        return console_error(final_result, "Error: bad basalprofile_data:" + basalprofile_data);
     }
     if (typeof basalprofile_data[0].glucose !== 'undefined') {
-      console.error("Warning: Argument order has changed: please update your oref0-meal device and meal.json report to place carbhistory.json after basalprofile.json");
-      var temp = carb_data;
-      carb_data = glucose_data;
-      glucose_data = basalprofile_data;
-      basalprofile_data = temp;
+        console_error(final_result, "Warning: Argument order has changed: please update your oref0-meal device and meal.json report to place carbhistory.json after basalprofile.json");
+        var temp = carb_data;
+        carb_data = glucose_data;
+        glucose_data = basalprofile_data;
+        basalprofile_data = temp;
     }
 
     inputs = {
@@ -123,21 +129,26 @@ var oref0_meal = function oref0_meal(argv_params) {
     var recentCarbs = generate(inputs);
 
     if (glucose_data.length < 36) {
-        console.error("Not enough glucose data to calculate carb absorption; found:", glucose_data.length);
+        console_error(final_result, "Not enough glucose data to calculate carb absorption; found:", glucose_data.length);
         recentCarbs.mealCOB = 0;
         recentCarbs.reason = "not enough glucose data to calculate carb absorption";
     }
 
-    return JSON.stringify(recentCarbs);
+    console_log(final_result, recentCarbs);
 }
 
 if (!module.parent) {
-   // remove the first parameter.
-   var command = process.argv;
-   command.shift();
-   command.shift();
-   var result = oref0_meal(command)
-   console.log(result);
+    var final_result = initFinalResults();
+    // remove the first parameter.
+    var command = process.argv;
+    command.shift();
+    command.shift();
+    oref0_meal(final_result, command);
+    console.log(final_result.stdout);
+    if(final_result.err.length > 0) {
+        console.error(final_result.err);
+    }
+    process.exit(final_result.return_val);
 }
 
 exports = module.exports = oref0_meal

--- a/bin/oref0-normalize-temps.js
+++ b/bin/oref0-normalize-temps.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /*
   Released under MIT license. See the accompanying LICENSE.txt file for

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -110,7 +110,13 @@ function ns_temptargets {
     jq -s '.[0] + .[1]|unique|sort_by(.created_at)|reverse' settings/ns-temptargets.json settings/local-temptargets.json > settings/temptargets.json
     echo -n "Temptargets merged: "
     cat settings/temptargets.json | colorize_json '.[0] | { target: .targetBottom, duration: .duration, start: .created_at }'
-    oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json | jq . > settings/profile.json.new || die "Couldn't refresh profile"
+
+    dir_name=~/test_data/oref0-get-profile-ns$(date +"%Y-%m-%d-%H%M")
+    echo dir_name = $dir_name
+    mkdir -p $dir_name
+    cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json $dir_name
+
+    run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || die "Couldn't refresh profile"
     if cat settings/profile.json.new | jq . | grep -q basal; then
         mv settings/profile.json.new settings/profile.json
     else

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -118,12 +118,19 @@ function ns_temptargets {
     fi
 }
 
-# openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-merged.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0
+# openaps report invoke monitor/carbhistory.json; oref0-meal monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new; grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json; exit 0
 function ns_meal_carbs {
     #openaps report invoke monitor/carbhistory.json >/dev/null
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET carb_history > monitor/carbhistory.json.new
     cat monitor/carbhistory.json.new | jq .[0].carbs | egrep -q [0-9] && mv monitor/carbhistory.json.new monitor/carbhistory.json
-    oref0-meal monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new
+    
+    dir_name=~/test_data/oref0-meal$(date +"%Y-%m-%d-%H%M")
+    echo dir_name = $dir_name
+    mkdir -p $dir_name
+    cp monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json $dir_name
+    
+    
+    run_remote_command 'oref0-meal monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json' > monitor/meal.json.new
     #grep -q COB monitor/meal.json.new && mv monitor/meal.json.new monitor/meal.json
     check_cp_meal || return 1
     echo -n "Refreshed carbhistory; COB: "

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -56,11 +56,11 @@ function get_ns_bg {
         || ! jq . cgm/ns-glucose-24h.json | grep -c glucose | jq -e '. > 36' >/dev/null; then
         #nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -24hours > cgm/ns-glucose-24h.json
         cp cgm/ns-glucose-24h.json cgm/ns-glucose-24h-temp.json
-        run_remote_command 'oref0-get-ns-entries cgm/ns-glucose-24h-temp.json $NIGHTSCOUT_HOST $API_SECRET 24' 2>&1 >cgm/ns-glucose-24h.json
+        run_remote_command "oref0-get-ns-entries cgm/ns-glucose-24h-temp.json $NIGHTSCOUT_HOST $API_SECRET 24" 2>&1 >cgm/ns-glucose-24h.json
     fi
     #nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -1hour > cgm/ns-glucose-1h.json
     cp cgm/ns-glucose-1h.json cgm/ns-glucose-1h-temp.json
-    run_remote_command 'oref0-get-ns-entries cgm/ns-glucose-1h-temp.json $NIGHTSCOUT_HOST $API_SECRET 1' 2>&1 >cgm/ns-glucose-1h.json
+    run_remote_command "oref0-get-ns-entries cgm/ns-glucose-1h-temp.json $NIGHTSCOUT_HOST $API_SECRET 1" 2>&1 >cgm/ns-glucose-1h.json
 
     jq -s '.[0] + .[1]|unique|sort_by(.date)|reverse' cgm/ns-glucose-24h.json cgm/ns-glucose-1h.json > cgm/ns-glucose.json
     glucose_fresh # update timestamp on cgm/ns-glucose.json
@@ -111,10 +111,10 @@ function ns_temptargets {
     echo -n "Temptargets merged: "
     cat settings/temptargets.json | colorize_json '.[0] | { target: .targetBottom, duration: .duration, start: .created_at }'
 
-    dir_name=~/test_data/oref0-get-profile-ns$(date +"%Y-%m-%d-%H%M")
+    dir_name=~/test_data/oref0-get-profile$(date +"%Y-%m-%d-%H%M")-ns
     echo dir_name = $dir_name
     mkdir -p $dir_name
-    cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json $dir_name
+    cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json settings/autotune.json $dir_name
 
     run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || die "Couldn't refresh profile"
     if cat settings/profile.json.new | jq . | grep -q basal; then

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -56,11 +56,11 @@ function get_ns_bg {
         || ! jq . cgm/ns-glucose-24h.json | grep -c glucose | jq -e '. > 36' >/dev/null; then
         #nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -24hours > cgm/ns-glucose-24h.json
         cp cgm/ns-glucose-24h.json cgm/ns-glucose-24h-temp.json
-        oref0-get-ns-entries cgm/ns-glucose-24h-temp.json $NIGHTSCOUT_HOST $API_SECRET 24 2>&1 >cgm/ns-glucose-24h.json
+        run_remote_command 'oref0-get-ns-entries cgm/ns-glucose-24h-temp.json $NIGHTSCOUT_HOST $API_SECRET 24' 2>&1 >cgm/ns-glucose-24h.json
     fi
     #nightscout ns $NIGHTSCOUT_HOST $API_SECRET oref0_glucose_since -1hour > cgm/ns-glucose-1h.json
     cp cgm/ns-glucose-1h.json cgm/ns-glucose-1h-temp.json
-    oref0-get-ns-entries cgm/ns-glucose-1h-temp.json $NIGHTSCOUT_HOST $API_SECRET 1 2>&1 >cgm/ns-glucose-1h.json
+    run_remote_command 'oref0-get-ns-entries cgm/ns-glucose-1h-temp.json $NIGHTSCOUT_HOST $API_SECRET 1' 2>&1 >cgm/ns-glucose-1h.json
 
     jq -s '.[0] + .[1]|unique|sort_by(.date)|reverse' cgm/ns-glucose-24h.json cgm/ns-glucose-1h.json > cgm/ns-glucose.json
     glucose_fresh # update timestamp on cgm/ns-glucose.json

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -112,7 +112,7 @@ function ns_temptargets {
     cat settings/temptargets.json | colorize_json '.[0] | { target: .targetBottom, duration: .duration, start: .created_at }'
 
     dir_name=~/test_data/oref0-get-profile$(date +"%Y-%m-%d-%H%M")-ns
-    echo dir_name = $dir_name
+    #echo dir_name = $dir_name
     mkdir -p $dir_name
     cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json settings/autotune.json $dir_name
 
@@ -131,7 +131,7 @@ function ns_meal_carbs {
     cat monitor/carbhistory.json.new | jq .[0].carbs | egrep -q [0-9] && mv monitor/carbhistory.json.new monitor/carbhistory.json
     
     dir_name=~/test_data/oref0-meal$(date +"%Y-%m-%d-%H%M")
-    echo dir_name = $dir_name
+    #echo dir_name = $dir_name
     mkdir -p $dir_name
     cp monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json $dir_name
     

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -684,7 +684,13 @@ function get_settings {
     fi
 
     # generate settings/pumpprofile.json without autotune
-    oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json 2>&3 | jq . > settings/pumpprofile.json.new || { echo "Couldn't refresh pumpprofile"; fail "$@"; }
+
+    dir_name=~/test_data/oref0-get-profile-pump$(date +"%Y-%m-%d-%H%M")
+    #echo dir_name = $dir_name
+    mkdir -p $dir_name
+    cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json $dir_name
+    
+    run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json' 2>&3 | jq . > settings/pumpprofile.json.new || { echo "Couldn't refresh pumpprofile"; fail "$@"; }
     if [ -s settings/pumpprofile.json.new ] && jq -e .current_basal settings/pumpprofile.json.new >&4; then
         mv settings/pumpprofile.json.new settings/pumpprofile.json
         echo -n "Pump profile refreshed; "
@@ -693,7 +699,12 @@ function get_settings {
         ls -lart settings/pumpprofile.json.new
     fi
     # generate settings/profile.json.new with autotune
-    oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json | jq . > settings/profile.json.new || { echo "Couldn't refresh profile"; fail "$@"; }
+    dir_name=~/test_data/oref0-get-profile-pump-auto$(date +"%Y-%m-%d-%H%M")
+    #echo dir_name = $dir_name
+    mkdir -p $dir_name
+    cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json settings/autotune.json $dir_name
+
+    run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || { echo "Couldn't refresh profile"; fail "$@"; }
     if [ -s settings/profile.json.new ] && jq -e .current_basal settings/profile.json.new >&4; then
         mv settings/profile.json.new settings/profile.json
         echo -n "Settings refreshed; "

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -685,7 +685,7 @@ function get_settings {
 
     # generate settings/pumpprofile.json without autotune
 
-    dir_name=~/test_data/oref0-get-profile-pump$(date +"%Y-%m-%d-%H%M")
+    dir_name=~/test_data/oref0-get-profile$(date +"%Y-%m-%d-%H%M")-pump
     #echo dir_name = $dir_name
     mkdir -p $dir_name
     cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json $dir_name
@@ -699,7 +699,7 @@ function get_settings {
         ls -lart settings/pumpprofile.json.new
     fi
     # generate settings/profile.json.new with autotune
-    dir_name=~/test_data/oref0-get-profile-pump-auto$(date +"%Y-%m-%d-%H%M")
+    dir_name=~/test_data/oref0-get-profile$(date +"%Y-%m-%d-%H%M")-pump-auto
     #echo dir_name = $dir_name
     mkdir -p $dir_name
     cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json settings/autotune.json $dir_name

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -624,7 +624,12 @@ function check_cp_meal {
 }
 
 function calculate_iob {
-    oref0-calculate-iob monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json settings/autosens.json > monitor/iob.json.new || { echo; echo "Couldn't calculate IOB"; fail "$@"; }
+    dir_name=~/test_data/oref0-calculate-iob$(date +"%Y-%m-%d-%H%M")
+    echo dir_name = $dir_name
+    mkdir -p $dir_name
+    cp  monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json settings/autosens.json $dir_name
+
+    run_remote_command 'oref0-calculate-iob monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json settings/autosens.json' > monitor/iob.json.new || { echo; echo "Couldn't calculate IOB"; fail "$@"; }
     [ -s monitor/iob.json.new ] && jq -e .[0].iob monitor/iob.json.new >&3 && cp monitor/iob.json.new monitor/iob.json || { echo; echo "Couldn't copy IOB"; fail "$@"; }
 }
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -597,7 +597,12 @@ function refresh_pumphistory_and_meal {
     try_return invoke_pumphistory_etc || return 1
     try_return invoke_reservoir_etc || return 1
     echo -n "meal.json "
-    if ! retry_return oref0-meal monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json > monitor/meal.json.new ; then
+    
+    dir_name=~/test_data/oref0-meal$(date +"%Y-%m-%d-%H%M")
+    echo dir_name = $dir_name
+    mkdir -p $dir_name
+    cp monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json $dir_name
+    if ! retry_return run_remote_command 'oref0-meal monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json' > monitor/meal.json.new ; then
         echo; echo "Couldn't calculate COB"
         return 1
     fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -599,7 +599,7 @@ function refresh_pumphistory_and_meal {
     echo -n "meal.json "
     
     dir_name=~/test_data/oref0-meal$(date +"%Y-%m-%d-%H%M")
-    echo dir_name = $dir_name
+    #echo dir_name = $dir_name
     mkdir -p $dir_name
     cp monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json $dir_name
     if ! retry_return run_remote_command 'oref0-meal monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json' > monitor/meal.json.new ; then
@@ -630,7 +630,7 @@ function check_cp_meal {
 
 function calculate_iob {
     dir_name=~/test_data/oref0-calculate-iob$(date +"%Y-%m-%d-%H%M")
-    echo dir_name = $dir_name
+    #echo dir_name = $dir_name
     mkdir -p $dir_name
     cp  monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json settings/autosens.json $dir_name
 

--- a/bin/oref0-shared-node-utils.js
+++ b/bin/oref0-shared-node-utils.js
@@ -9,7 +9,7 @@ function console_both(final_result, theArgs) {
         if (typeof theArgs[i] != 'object') {
             final_result += theArgs[i];
         } else {
-            final_result += JSON.stringify(theArgs[i], null, ' ');
+            final_result += JSON.stringify(theArgs[i]);
         }
         if(i != len -1 ) {
              final_result += ' ';

--- a/bin/oref0-shared-node-utils.js
+++ b/bin/oref0-shared-node-utils.js
@@ -1,0 +1,50 @@
+'use strict';
+
+function console_both(final_result, theArgs) {
+    if(final_result.length > 0) {
+        final_result += '\n';
+    }
+    var len = theArgs.length;
+    for (var i = 0 ; i < len; i++) {
+        if (typeof theArgs[i] != 'object') {
+            final_result += theArgs[i];
+        } else {
+            final_result += JSON.stringify(theArgs[i], null, ' ');
+        }
+        if(i != len -1 ) {
+             final_result += ' ';
+        }
+
+    }
+    return final_result;
+}
+
+var console_error = function console_error(final_result, ...theArgs) {
+    final_result.err = console_both(final_result.err, theArgs);
+}
+
+var console_log = function console_log(final_result, ...theArgs) {
+    final_result.stdout = console_both(final_result.stdout, theArgs);
+}
+
+var process_exit = function process_exit(final_result, ret) {
+    final_result.return_val = ret;
+}
+
+var initFinalResults = function initFinalResults() {
+    var final_result = {
+        stdout: ''
+        , err: ''
+        , return_val : 0
+    };
+    return final_result;
+}
+
+
+
+module.exports = {
+    console_log : console_log,
+    console_error : console_error,
+    process_exit : process_exit,
+    initFinalResults : initFinalResults
+}

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -125,9 +125,9 @@ function serverListen() {
             }  else if (command[0] == 'oref0-meal') {
                 command.shift();
                 try {
-                    result = oref0_meal(command);
-                    result = addNewlToResult(result);
-                    final_result = createRetVal(result, 0);
+                    result = oref0_meal(final_result, command);
+                    final_result.stdout = addNewlToResult(final_result.stdout); // put them both in a new function ????????????
+                    final_result.err = addNewlToResult(final_result.err);
                 } catch (err) {
                     final_result.return_val = 1;
                     console.log('exception when parsing oref0-meal ', err);

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -7,6 +7,7 @@ var ns_status = require("./ns-status");
 var oref0_normalize_temps = require("./oref0-normalize-temps");
 var oref0_calculate_iob = require("./oref0-calculate-iob");
 var oref0_meal = require("./oref0-meal");
+var oref0_get_profile = require("./oref0-get-profile");
 var fs = require('fs');
 var requireUtils = require('../lib/require-utils');
 
@@ -119,6 +120,15 @@ function serverListen() {
                 } catch (err) {
                     return_val = 1;
                     console.log('exception when parsing oref0-meal ', err);
+                }
+            } else if (command[0] == 'oref0-get-profile') {
+                command.shift();
+                try {
+                    result = oref0_get_profile(command);
+                    result = addNewlToResult(result);
+                } catch (err) {
+                    return_val = 1;
+                    console.log('exception when parsing oref0-get-profile ', err);
                 }
             } else if (command[0] == 'ping') {
                 result = 'pong';

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -11,6 +11,10 @@ var oref0_get_profile = require("./oref0-get-profile");
 var oref0_get_ns_entries = require("./oref0-get-ns-entries");
 var fs = require('fs');
 var requireUtils = require('../lib/require-utils');
+var shared_node_utils = require('./oref0-shared-node-utils');
+var console_error = shared_node_utils.console_error;
+var console_log = shared_node_utils.console_log;
+var initFinalResults = shared_node_utils.initFinalResults;
 
 function createRetVal(stdout, return_val) {
     var returnObj = {
@@ -81,10 +85,10 @@ function serverListen() {
             command = command.map(s => s.trim());
 
             var result = 'unknown command\n';
-            var return_val = 0;
 
             console.log('command = ', command);
             var async_command = false;
+            var final_result = initFinalResults();
 
             if (command[0] == 'ns-status') {
                 // remove the first parameter.
@@ -92,17 +96,20 @@ function serverListen() {
                 try {
                     result = ns_status(command);
                     result = addNewlToResult(result);
+                    final_result = createRetVal(result, 0);
                 } catch (err) {
-                    return_val = 1;
+                    final_result.return_val = 1;
                     console.log('exception when parsing ns_status ', err);
+                    console_err(final_result, 'exception when parsing ns_status ', err);
                 }
             } else if (command[0] == 'oref0-normalize-temps') {
                 command.shift();
                 try {
                     result = oref0_normalize_temps(command);
                     result = addNewlToResult(result);
+                    final_result = createRetVal(result, 0);
                 } catch (err) {
-                    return_val = 1;
+                    final_result.return_val = 1;
                     console.log('exception when parsing oref0-normalize-temps ', err);
                 }
             } else if (command[0] == 'oref0-calculate-iob') {
@@ -110,8 +117,9 @@ function serverListen() {
                 try {
                     result = oref0_calculate_iob(command);
                     result = addNewlToResult(result);
+                    final_result = createRetVal(result, 0);
                 } catch (err) {
-                    return_val = 1;
+                    final_result.return_val = 1;
                     console.log('exception when parsing oref0-calculate-iob ', err);
                 }
             }  else if (command[0] == 'oref0-meal') {
@@ -119,31 +127,33 @@ function serverListen() {
                 try {
                     result = oref0_meal(command);
                     result = addNewlToResult(result);
+                    final_result = createRetVal(result, 0);
                 } catch (err) {
-                    return_val = 1;
+                    final_result.return_val = 1;
                     console.log('exception when parsing oref0-meal ', err);
                 }
             } else if (command[0] == 'oref0-get-profile') {
                 command.shift();
                 try {
-                    result = oref0_get_profile(command);
-                    result = addNewlToResult(result);
+                    oref0_get_profile(final_result, command);
+                    final_result.stdout = addNewlToResult(final_result.stdout); // put them both in a new function ????????????
+                    final_result.err = addNewlToResult(final_result.err);
                 } catch (err) {
-                    return_val = 1;
+                    final_result.return_val = 1;
                     console.log('exception when parsing oref0-get-profile ', err);
                 }
             } else if (command[0] == 'oref0-get-ns-entries') {
                 async_command = true;
 
-                var final_result = createRetVal('', 0);
+                var final_result = initFinalResults();
                 function print_callback(final_result) {
                     try {
-                        final_result.stdout = addNewlToResult(final_result.stdout);
+                        final_result.stdout = addNewlToResult(final_result.stdout); // put them both in a new function ????????????
                         final_result.err = addNewlToResult(final_result.err);
                         s.write(JSON.stringify(final_result));
                         s.end();
                     } catch (err) {
-                        return_val = 1;
+                        // I assume here that error happens when handeling the socket, so not trying to close it
                         console.log('exception in print_callback ', err);
                     }
                 }
@@ -152,28 +162,32 @@ function serverListen() {
                     result = oref0_get_ns_entries(command, print_callback, final_result);
                     result = addNewlToResult(result);
                 } catch (err) {
-                    return_val = 1;
+                    final_result.return_val = 1;
                     console.log('exception when parsing oref0-get-profile ', err);
                 }
             } else if (command[0] == 'ping') {
                 result = 'pong';
+                final_result = createRetVal(result, 0);
             } else if (command[0] == 'json') {
                 // remove the first parameter.
                 command.shift();
                 try {
+                    var return_val;
                     [result, return_val] = jsonWrapper(command);
                     result = addNewlToResult(result);
+                    final_result = createRetVal(result, return_val);
                 } catch (err) {
-                    return_val = 1;
+                    final_result.return_val = 1;
                     console.log('exception when running json_wrarpper ', err);
                 }
             } else {
                 console.error('Unknown command = ', command);
-                return_val = 1;
+                console_error(final_result, 'Unknown command = ', command);
+                final_result.return_val = 1;
             }
             if(!async_command) {
-            	s.write(JSON.stringify(createRetVal(result, return_val)));
-            	s.end();
+                s.write(JSON.stringify(final_result));
+                s.end();
             }
         });
     });
@@ -202,7 +216,7 @@ function addNewlToResult(result) {
     if (result === undefined) {
         // This preserves the oref0_normalize_temps behavior.
         result = ""
-    } else {
+    } else if (result.length != 0) {
         result += "\n";
     }
     return result;

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -5,6 +5,7 @@
 var os = require("os");
 var ns_status = require("./ns-status");
 var oref0_normalize_temps = require("./oref0-normalize-temps");
+var oref0_calculate_iob = require("./oref0-calculate-iob");
 var fs = require('fs');
 var requireUtils = require('../lib/require-utils');
 
@@ -76,7 +77,7 @@ function serverListen() {
 
             command = command.map(s => s.trim());
 
-            var result = 'unknown command';
+            var result = 'unknown command\n';
             var return_val = 0;
 
             console.log('command = ', command);
@@ -100,7 +101,17 @@ function serverListen() {
                     return_val = 1;
                     console.log('exception when parsing oref0-normalize-temps ', err);
                 }
-            } else if (command[0] == 'ping') {
+            } else if (command[0] == 'oref0-calculate-iob') {
+                command.shift();
+                try {
+                    result = oref0_calculate_iob(command);
+                    result = addNewlToResult(result);
+                } catch (err) {
+                    return_val = 1;
+                    console.log('exception when parsing oref0-normalize-temps ', err);
+                }
+            } 
+            else if (command[0] == 'ping') {
                 result = 'pong';
             } else if (command[0] == 'json') {
                 // remove the first parameter.

--- a/bin/oref0-shared-node.js
+++ b/bin/oref0-shared-node.js
@@ -6,6 +6,7 @@ var os = require("os");
 var ns_status = require("./ns-status");
 var oref0_normalize_temps = require("./oref0-normalize-temps");
 var oref0_calculate_iob = require("./oref0-calculate-iob");
+var oref0_meal = require("./oref0-meal");
 var fs = require('fs');
 var requireUtils = require('../lib/require-utils');
 
@@ -108,10 +109,18 @@ function serverListen() {
                     result = addNewlToResult(result);
                 } catch (err) {
                     return_val = 1;
-                    console.log('exception when parsing oref0-normalize-temps ', err);
+                    console.log('exception when parsing oref0-calculate-iob ', err);
                 }
-            } 
-            else if (command[0] == 'ping') {
+            }  else if (command[0] == 'oref0-meal') {
+                command.shift();
+                try {
+                    result = oref0_meal(command);
+                    result = addNewlToResult(result);
+                } catch (err) {
+                    return_val = 1;
+                    console.log('exception when parsing oref0-meal ', err);
+                }
+            } else if (command[0] == 'ping') {
                 result = 'pong';
             } else if (command[0] == 'json') {
                 // remove the first parameter.

--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var tz = require('moment-timezone');
 var basal = require('../profile/basal');
 var getIOB = require('../iob');
@@ -122,6 +124,7 @@ function categorizeBGDatums(opts) {
     var type="";
     // main for loop
     var fullHistory = IOBInputs.history;
+    var lastIsfResult = null;
     for (i=bucketedData.length-5; i > 0; --i) {
         glucoseDatum = bucketedData[i];
         //console.error(glucoseDatum);
@@ -165,7 +168,8 @@ function categorizeBGDatums(opts) {
         glucoseDatum.avgDelta = avgDelta;
 
         //sens = ISF
-        var sens = ISF.isfLookup(IOBInputs.profile.isfProfile,BGDate);
+        var sens;
+        [sens, lastIsfResult] = ISF.isfLookup(IOBInputs.profile.isfProfile, BGDate, lastIsfResult);
         IOBInputs.clock=BGDate.toISOString();
         // trim down IOBInputs.history to just the data for 6h prior to BGDate
         //console.error(IOBInputs.history[0].created_at);

--- a/lib/bolus.js
+++ b/lib/bolus.js
@@ -1,3 +1,4 @@
+'use strict';
 
 function reduce (treatments) {
 

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var basal = require('../profile/basal');
 var get_iob = require('../iob');
 var find_insulin = require('../iob/history');
@@ -143,11 +145,12 @@ function detectSensitivity(inputs) {
     var mealCarbs = 0;
     var mealStartCounter = 999;
     var type="";
+    var lastIsfResult = null;
     //console.error(bucketed_data);
     for (i=3; i < bucketed_data.length; ++i) {
         bgTime = new Date(bucketed_data[i].date);
-
-        var sens = isf.isfLookup(profile.isfProfile,bgTime);
+        var sens;
+        [sens, lastIsfResult] = isf.isfLookup(profile.isfProfile, bgTime, lastIsfResult);
 
         //console.error(bgTime , bucketed_data[i].glucose);
         var bg;

--- a/lib/determine-basal/autosens.js
+++ b/lib/determine-basal/autosens.js
@@ -401,7 +401,7 @@ function detectSensitivity(inputs) {
     } else {
         console.error("Sensitivity normal.");
     }
-    ratio = 1 + (basalOff / profile.max_daily_basal);
+    var ratio = 1 + (basalOff / profile.max_daily_basal);
     //console.error(basalOff, profile.max_daily_basal, ratio);
 
     // don't adjust more than 1.2x by default (set in preferences.json)
@@ -414,7 +414,7 @@ function detectSensitivity(inputs) {
     }
 
     ratio = Math.round(ratio*100)/100;
-    newisf = Math.round(profile.sens / ratio);
+    var newisf = Math.round(profile.sens / ratio);
     //console.error(profile, newisf, ratio);
     console.error("ISF adjusted from "+profile.sens+" to "+newisf);
     //console.error("Basal adjustment "+basalOff.toFixed(2)+"U/hr");

--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -118,10 +118,12 @@ function detectCarbAbsorption(inputs) {
     var minDeviation = 999;
     var allDeviations = [];
     //console.error(bucketed_data);
+    var lastIsfResult = null;
     for (i=0; i < bucketed_data.length-3; ++i) {
         bgTime = new Date(bucketed_data[i].date);
 
-        var sens = isf.isfLookup(profile.isfProfile,bgTime);
+        var sens;
+        [sens, lastIsfResult] = isf.isfLookup(profile.isfProfile, bgTime, lastIsfResult);
 
         //console.error(bgTime , bucketed_data[i].glucose, bucketed_data[i].date);
         var bg;

--- a/lib/determine-basal/cob.js
+++ b/lib/determine-basal/cob.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var basal = require('../profile/basal');
 var get_iob = require('../iob');
 var find_insulin = require('../iob/history');
@@ -12,7 +14,9 @@ function detectCarbAbsorption(inputs) {
     });
     var iob_inputs = inputs.iob_inputs;
     var basalprofile = inputs.basalprofile;
-    /* TODO why does declaring profile break tests-command-behavior.tests.sh? */ profile = inputs.iob_inputs.profile;
+    /* TODO why does declaring profile break tests-command-behavior.tests.sh? 
+       because it is a global variable used in other places.*/ 
+    var profile = inputs.iob_inputs.profile;
     var mealTime = new Date(inputs.mealTime);
     var ciTime = new Date(inputs.ciTime);
 

--- a/lib/iob/calculate.js
+++ b/lib/iob/calculate.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function iobCalc(treatment, time, curve, dia, peak, profile) {
     // iobCalc returns two variables:
     //   activityContrib = units of treatment.insulin used in previous minute

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var tz = require('moment-timezone');
-var basalprofile = require('../profile/basal.js'); //?????????
+var basalprofile = require('../profile/basal.js');
 var _ = require('lodash');
 var moment = require('moment');
 

--- a/lib/iob/history.js
+++ b/lib/iob/history.js
@@ -1,6 +1,7 @@
+'use strict';
 
 var tz = require('moment-timezone');
-var basalprofile = require('../profile/basal.js');
+var basalprofile = require('../profile/basal.js'); //?????????
 var _ = require('lodash');
 var moment = require('moment');
 
@@ -509,6 +510,7 @@ function calcTempTreatments (inputs, zeroTempDuration) {
         var currentItem = splitHistory[i];
 
         if (currentItem.duration > 0) {
+            var target_bg;
 
             var currentRate = profile_data.current_basal;
             if (!_.isEmpty(profile_data.basalprofile)) {

--- a/lib/iob/index.js
+++ b/lib/iob/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var tz = require('moment-timezone');
 var find_insulin = require('./history');
@@ -65,7 +66,7 @@ function generate (inputs, currentIOBOnly, treatments) {
         iStop=4*60;
     }
     for (var i=0; i<iStop; i+=5){
-        t = new Date(clock.getTime() + i*60000);
+        var t = new Date(clock.getTime() + i*60000);
         //console.error(t);
         var iob = sum(opts, t);
         var iobWithZeroTemp = sum(optsWithZeroTemp, t);

--- a/lib/iob/total.js
+++ b/lib/iob/total.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function iobTotal(opts, time) {
 
     var now = time.getTime();

--- a/lib/meal/history.js
+++ b/lib/meal/history.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function arrayHasElementWithSameTimestampAndProperty(array,t,propname) {
     for (var j=0; j < array.length; j++) {
         var element = array[j];

--- a/lib/meal/index.js
+++ b/lib/meal/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var tz = require('moment-timezone');
 var find_meals = require('./history');

--- a/lib/meal/total.js
+++ b/lib/meal/total.js
@@ -1,5 +1,7 @@
+'use strict';
+
 var tz = require('moment-timezone');
-var calcMealCOB = require('../determine-basal/cob');
+var detectCarbAbsorption = require('../determine-basal/cob');
 
 function recentCarbs(opts, time) {
     var treatments = opts.treatments;
@@ -63,7 +65,7 @@ function recentCarbs(opts, time) {
                 carbs += parseFloat(treatment.carbs);
                 COB_inputs.mealTime = treatmentTime;
                 lastCarbTime = Math.max(lastCarbTime,treatmentTime);
-                var myCarbsAbsorbed = calcMealCOB(COB_inputs).carbsAbsorbed;
+                var myCarbsAbsorbed = detectCarbAbsorption(COB_inputs).carbsAbsorbed; //?????????????????????????????? here prfile was defined
                 var myMealCOB = Math.max(0, carbs - myCarbsAbsorbed);
                 if (typeof(myMealCOB) === 'number' && ! isNaN(myMealCOB)) {
                     mealCOB = Math.max(mealCOB, myMealCOB);
@@ -99,14 +101,14 @@ function recentCarbs(opts, time) {
     COB_inputs.ciTime = time.getTime();
     // set mealTime to 6h ago for Deviation calculations
     COB_inputs.mealTime = time.getTime() - 6 * 60 * 60 * 1000;
-    var c = calcMealCOB(COB_inputs);
+    var c = detectCarbAbsorption(COB_inputs);
     //console.error(c.currentDeviation, c.slopeFromMaxDeviation);
 
     // set a hard upper limit on COB to mitigate impact of erroneous or malicious carb entry
-    if (typeof(profile.maxCOB) === 'number' && ! isNaN(profile.maxCOB)) {
-        mealCOB = Math.min( profile.maxCOB, mealCOB );
+    if (typeof(profile_data.maxCOB) === 'number' && ! isNaN(profile_data.maxCOB)) {
+        mealCOB = Math.min( profile_data.maxCOB, mealCOB );
     } else {
-        console.error("Bad profile.maxCOB:",profile.maxCOB);
+        console.error("Bad profile.maxCOB:",profile_data.maxCOB);
     }
 
     // if currentDeviation is null or maxDeviation is 0, set mealCOB to 0 for zombie-carb safety

--- a/lib/medtronic-clock.js
+++ b/lib/medtronic-clock.js
@@ -1,3 +1,4 @@
+'use strict';
 
 function getTime(minutes) {
     var baseTime = new Date();

--- a/lib/percentile.js
+++ b/lib/percentile.js
@@ -1,3 +1,4 @@
+'use strict';
 // From https://gist.github.com/IceCreamYou/6ffa1b18c4c8f6aeaad2
 // Returns the value at a given percentile in a sorted numeric array.
 // "Linear interpolation between closest ranks" method

--- a/lib/profile/basal.js
+++ b/lib/profile/basal.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var _ = require('lodash');
 

--- a/lib/profile/basal.js
+++ b/lib/profile/basal.js
@@ -14,6 +14,7 @@ function basalLookup (schedules, now) {
     var basalprofile_data = _.sortBy(schedules, function(o) { return o.i; });
     var basalRate = basalprofile_data[basalprofile_data.length-1].rate
     if (basalRate === 0) {
+        // TODO - shared node - move this print to shared object.
         console.error("ERROR: bad basal schedule",schedules);
         return;
     }

--- a/lib/profile/carbs.js
+++ b/lib/profile/carbs.js
@@ -1,8 +1,10 @@
 'use strict';
 
 var getTime = require('../medtronic-clock');
+var shared_node_utils = require('../../bin/oref0-shared-node-utils');
+var console_error = shared_node_utils.console_error;
 
-function carbRatioLookup (inputs, profile) {
+function carbRatioLookup (final_result, inputs, profile) {
     var now = new Date();
     var carbratio_data = inputs.carbratio;
     if (typeof(carbratio_data) !== "undefined" && typeof(carbratio_data.schedule) !== "undefined") {
@@ -16,7 +18,7 @@ function carbRatioLookup (inputs, profile) {
                     carbRatio = carbratio_data.schedule[i];
                     // disallow impossibly high/low carbRatios due to bad decoding
                     if (carbRatio < 3 || carbRatio > 150) {
-                        console.error("Error: carbRatio of " + carbRatio + " out of bounds.");
+                        console_error(final_result, "Error: carbRatio of " + carbRatio + " out of bounds.");
                         return;
                     }
                     break;
@@ -27,7 +29,7 @@ function carbRatioLookup (inputs, profile) {
             }
             return carbRatio.ratio;
         } else {
-            console.error("Error: Unsupported carb_ratio units " + carbratio_data.units);
+            console_error(final_result, "Error: Unsupported carb_ratio units " + carbratio_data.units);
             return;
         }
     //return carbRatio.ratio;

--- a/lib/profile/carbs.js
+++ b/lib/profile/carbs.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var getTime = require('../medtronic-clock');
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -6,7 +6,7 @@ var isf = require('./isf');
 var carb_ratios = require('./carbs');
 var _ = require('lodash');
 
-var shared_node_utils = require('../oref0-shared-node-utils');
+var shared_node_utils = require('../../bin/oref0-shared-node-utils');
 var console_error = shared_node_utils.console_error;
 var console_log = shared_node_utils.console_log;
 

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var basal = require('./basal');
 var targets = require('./targets');
@@ -153,7 +154,8 @@ function generate (inputs, opts) {
   delete profile.bg_targets.raw;
   
   profile.temptargetSet = range.temptargetSet;
-  profile.sens = isf.isfLookup(inputs.isf);
+  var lastResult = null;
+  [profile.sens, lastResult] = isf.isfLookup(inputs.isf, undefined, lastResult);
   profile.isfProfile = inputs.isf;
   if (profile.sens < 5) {
     console.error("ISF of",profile.sens,"is not supported");

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -6,6 +6,10 @@ var isf = require('./isf');
 var carb_ratios = require('./carbs');
 var _ = require('lodash');
 
+var shared_node_utils = require('../oref0-shared-node-utils');
+var console_error = shared_node_utils.console_error;
+var console_log = shared_node_utils.console_log;
+
 function defaults ( ) {
   return /* profile */ {
     max_iob: 0 // if max_iob is not provided, will default to zero 
@@ -69,7 +73,7 @@ function defaults ( ) {
   };
 }
 
-function displayedDefaults () {
+function displayedDefaults (final_result) {
     var allDefaults = defaults();
     var profile = { };
 
@@ -88,11 +92,11 @@ function displayedDefaults () {
     profile.curve = allDefaults.curve;
     profile.offline_hotspot = allDefaults.offline_hotspot;
 
-    console.error(profile);
+    console_error(final_result, profile);
     return profile
 }
 
-function generate (inputs, opts) {
+function generate (final_result, inputs, opts) {
   var profile = opts && opts.type ? opts : defaults( );
 
   // check if inputs has overrides for any of the default prefs
@@ -107,8 +111,8 @@ function generate (inputs, opts) {
   if (inputs.settings.insulin_action_curve > 1) {
     profile.dia =  pumpsettings_data.insulin_action_curve;
   } else {
-    console.error('DIA of', profile.dia, 'is not supported');
-    return -1;
+      console_error(final_result, 'DIA of', profile.dia, 'is not supported');
+      return -1;
   }
 
   if (inputs.model) {
@@ -126,19 +130,19 @@ function generate (inputs, opts) {
   profile.max_daily_basal = basal.maxDailyBasal(inputs);
   profile.max_basal = basal.maxBasalLookup(inputs);
   if (profile.current_basal === 0) {
-    console.error("current_basal of",profile.current_basal,"is not supported");
-    return -1;
+      console_error(final_result, "current_basal of",profile.current_basal,"is not supported");
+      return -1;
   }
   if (profile.max_daily_basal === 0) {
-    console.error("max_daily_basal of",profile.max_daily_basal,"is not supported");
-    return -1;
+      console_error(final_result, "max_daily_basal of",profile.max_daily_basal,"is not supported");
+      return -1;
   }
   if (profile.max_basal < 0.1) {
-    console.error("max_basal of",profile.max_basal,"is not supported");
-    return -1;
+      console_error(final_result, "max_basal of",profile.max_basal,"is not supported");
+      return -1;
   }
 
-  var range = targets.bgTargetsLookup(inputs, profile);
+  var range = targets.bgTargetsLookup(final_result, inputs, profile);
   profile.out_units = inputs.targets.user_preferred_units;
   profile.min_bg = Math.round(range.min_bg);
   profile.max_bg = Math.round(range.max_bg);
@@ -158,14 +162,14 @@ function generate (inputs, opts) {
   [profile.sens, lastResult] = isf.isfLookup(inputs.isf, undefined, lastResult);
   profile.isfProfile = inputs.isf;
   if (profile.sens < 5) {
-    console.error("ISF of",profile.sens,"is not supported");
-    return -1;
+      console_error(final_result, "ISF of",profile.sens,"is not supported");
+      return -1;
   }
   if (typeof(inputs.carbratio) !== "undefined") {
-    profile.carb_ratio = carb_ratios.carbRatioLookup(inputs, profile);
+    profile.carb_ratio = carb_ratios.carbRatioLookup(final_result, inputs, profile);
     profile.carb_ratios = inputs.carbratio;
   } else {
-    console.error("Profile wasn't given carb ratio data, cannot calculate carb_ratio");
+       console_error(final_result, "Profile wasn't given carb ratio data, cannot calculate carb_ratio");
   }
   return profile;
 }

--- a/lib/profile/isf.js
+++ b/lib/profile/isf.js
@@ -2,9 +2,9 @@
 
 var _ = require('lodash');
 
-var lastResult = null;
+//var lastResult = null;
 
-function isfLookup(isf_data, timestamp) {
+function isfLookup(isf_data, timestamp, lastResult) {
 
     var nowDate = timestamp;
 
@@ -15,7 +15,7 @@ function isfLookup(isf_data, timestamp) {
     var nowMinutes = nowDate.getHours() * 60 + nowDate.getMinutes();
 
     if (lastResult && nowMinutes >= lastResult.offset && nowMinutes < lastResult.endOffset) {
-        return lastResult.sensitivity;
+        return [lastResult.sensitivity, lastResult];
     }
 
     isf_data = _.sortBy(isf_data.sensitivities, function(o) { return o.offset; });
@@ -23,7 +23,7 @@ function isfLookup(isf_data, timestamp) {
     var isfSchedule = isf_data[isf_data.length - 1];
 
     if (isf_data[0].offset !== 0) {
-        return -1;
+        return [-1, lastResult];
     }
 
     var endMinutes = 1440;
@@ -41,7 +41,7 @@ function isfLookup(isf_data, timestamp) {
     lastResult = isfSchedule;
     lastResult.endOffset = endMinutes;
 
-    return isfSchedule.sensitivity;
+    return [isfSchedule.sensitivity, lastResult];
 }
 
 isfLookup.isfLookup = isfLookup;

--- a/lib/profile/isf.js
+++ b/lib/profile/isf.js
@@ -2,8 +2,6 @@
 
 var _ = require('lodash');
 
-//var lastResult = null;
-
 function isfLookup(isf_data, timestamp, lastResult) {
 
     var nowDate = timestamp;

--- a/lib/profile/isf.js
+++ b/lib/profile/isf.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var _ = require('lodash');
 

--- a/lib/profile/targets.js
+++ b/lib/profile/targets.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var getTime = require('../medtronic-clock');
 

--- a/lib/profile/targets.js
+++ b/lib/profile/targets.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var getTime = require('../medtronic-clock');
-var shared_node_utils = require('../oref0-shared-node-utils');
+var shared_node_utils = require('../../bin/oref0-shared-node-utils');
 var console_error = shared_node_utils.console_error;
 
 function bgTargetsLookup (final_result, inputs, profile) {

--- a/lib/profile/targets.js
+++ b/lib/profile/targets.js
@@ -1,12 +1,14 @@
 'use strict';
 
 var getTime = require('../medtronic-clock');
+var shared_node_utils = require('../oref0-shared-node-utils');
+var console_error = shared_node_utils.console_error;
 
-function bgTargetsLookup (inputs, profile) {
-  return bound_target_range(lookup(inputs, profile));
+function bgTargetsLookup (final_result, inputs, profile) {
+  return bound_target_range(lookup(final_result, inputs, profile));
 }
 
-function lookup (inputs, profile) {
+function lookup (final_result, inputs, profile) {
     var bgtargets_data = inputs.targets;
     var temptargets_data = inputs.temptargets;
     var now = new Date();
@@ -34,7 +36,7 @@ function lookup (inputs, profile) {
     try {
         temptargets_data.sort(function (a, b) { return new Date(b.created_at) - new Date(a.created_at) });
     } catch (e) {
-        console.error("No temptargets found.");
+        console_error(final_result, "No temptargets found.");
     }
     //console.error(temptargets_data);
     //console.error(now);
@@ -49,7 +51,7 @@ function lookup (inputs, profile) {
             tempTargets = bgTargets;
             break;
         } else if (! temptargets_data[i].targetBottom || ! temptargets_data[i].targetTop) {
-            console.error("eventualBG target range invalid: " + temptargets_data[i].targetBottom + "-" + temptargets_data[i].targetTop);
+            console_error(final_result, "eventualBG target range invalid: " + temptargets_data[i].targetBottom + "-" + temptargets_data[i].targetTop);
             break;
         } else if (now >= start && now < expires ) {
             //console.error(temptargets_data[i]);
@@ -78,8 +80,8 @@ function bound_target_range (target) {
     return target
 }
 
-bgTargetsLookup.bgTargetsLookup = bgTargetsLookup;
-bgTargetsLookup.lookup = lookup;
-bgTargetsLookup.bound_target_range = bound_target_range;
+bgTargetsLookup.bgTargetsLookup = bgTargetsLookup;  // does use log
+bgTargetsLookup.lookup = lookup; // not used outside
+bgTargetsLookup.bound_target_range = bound_target_range; // does not log
 exports = module.exports = bgTargetsLookup;
 

--- a/lib/pump.js
+++ b/lib/pump.js
@@ -1,3 +1,4 @@
+'use strict';
 
 function translate (treatments) {
 

--- a/lib/temps.js
+++ b/lib/temps.js
@@ -1,3 +1,4 @@
+'use strict';
 
 function filter (treatments) {
 


### PR DESCRIPTION
This PR adds 4 more modules to the shared node:
    oref0-calculate-iob
    oref0-meal
    oref0-get-profile
    oref0-get-ns-entries

Technically this changes are not complicated, but looking at the PR it seems to touch a lot of files (many of them only have one line changed).

The main reason for the many changes are this:
1) All files that are touched by this pr (or called from files running by this PR) are moved to strict mode. 
Usually, this only means to add strict to the beginning of the file. Sometimes this meant that variables have to be declared in functions. In a few places variables were shared across files, so I had to make sure they are passed as parameters.

2) There are some functions that have functionality that needs to be moved to the calling function.
This includes the following:
console.log(), console.error() and process.exit()
This 3 functions have been replaced by console_log(), console_error() and process_exit().
The new functions only receive one extra parameter (final_result), that will hold the data to be returned to the calling function. 

There are more printings in the code that I did not move to the new paradigm in order not to make this PR even longer.

Obviously, this PR needs a through code review and more testing.