### PR TITLE
Fix pancreabble config paths

### DIFF
--- a/lib/oref0-setup/pancreabble.json
+++ b/lib/oref0-setup/pancreabble.json
@@ -24,10 +24,10 @@
     "upload/urchin-data.json": {
       "use": "format_urchin_data",
       "reporter": "JSON",
-      "cgm_clock": "monitor/clock.json",
+      "cgm_clock": "monitor/clock-zoned.json",
       "action": "add",
       "device": "pbbl",
-      "glucose_history": "monitor/glucose-unzoned.json",
+      "glucose_history": "monitor/glucose.json",
       "status_text": "",
       "status_json": "upload/urchin-status.json"
     }


### PR DESCRIPTION
Pancreabble can't find clock.json and glucose-unzoned.json files.