### PR TITLE
maxDelta bg % threshold as hidden preference

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -52,7 +52,9 @@ function enable_smb(
     profile,
     microBolusAllowed,
     meal_data,
-    target_bg
+    bg,
+    target_bg,
+    high_bg
 ) {
     // disable SMB when a high temptarget is set
     if (! microBolusAllowed) {
@@ -105,7 +107,19 @@ function enable_smb(
             console.error("SMB enabled for temptarget of",convert_bg(target_bg, profile));
         }
         return true;
-    } 
+    }
+
+    // enable SMB if high bg is found
+    if (profile.enableSMB_high_bg === true && high_bg !== null && bg >= high_bg) {
+        console.error("Checking BG to see if High for SMB enablement.");
+        console.error("Current BG", bg, " | High BG ", high_bg);
+        if (meal_data.bwFound) {
+            console.error("Warning: High BG SMB enabled within 6h of using Bolus Wizard: be sure to easy bolus 30s before using Bolus Wizard");
+        } else {
+            console.error("High BG detected. Enabling SMB.");
+        }
+        return true;
+    }
     
     console.error("SMB disabled (no enableSMB preferences active or no condition satisfied)");
     return false;
@@ -215,11 +229,15 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var target_bg;
     var min_bg;
     var max_bg;
+    var high_bg;
     if (typeof profile.min_bg !== 'undefined') {
             min_bg = profile.min_bg;
     }
     if (typeof profile.max_bg !== 'undefined') {
             max_bg = profile.max_bg;
+    }
+    if (typeof profile.enableSMB_high_bg_target !== 'undefined') {
+        high_bg = profile.enableSMB_high_bg_target;
     }
     if (typeof profile.min_bg !== 'undefined' && typeof profile.max_bg !== 'undefined') {
         target_bg = (profile.min_bg + profile.max_bg) / 2;
@@ -426,7 +444,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         profile,
         microBolusAllowed,
         meal_data,
-        target_bg
+        bg,
+        target_bg,
+        high_bg
     );
 
     // enable UAM (if enabled in preferences)
@@ -838,7 +858,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 // Disable SMB for sudden rises (often caused by calibrations or activation/deactivation of Dexcom's noise-filtering algorithm)
     if ( maxDelta > profile.maxDelta_bg_threshold * bg ) {
-        console.error("maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * profile.maxDelta_bg_threshold+"% of BG"+convert_bg(bg, profile)+" - disabling SMB");
+        console.error("maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * profile.maxDelta_bg_threshold+"% of BG "+convert_bg(bg, profile)+" - disabling SMB");
         rT.reason += "maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * profile.maxDelta_bg_threshold+"% of BG "+convert_bg(bg, profile)+": SMB disabled; ";
         enableSMB = false;
     }

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -45,6 +45,8 @@ function defaults ( ) {
     // if the CGM sensor reads falsely high and doesn't come down as actual BG does
     , enableSMB_always: false // always enable supermicrobolus (unless disabled by high temptarget)
     , enableSMB_after_carbs: false // enable supermicrobolus for 6h after carbs, even with 0 COB
+    , enableSMB_high_bg: false // enable SMBs when a high BG is detected, based on the high BG target (adjusted or profile)
+    , enableSMB_high_bg_target: 110 // set the value enableSMB_high_bg will compare against to enable SMB. If BG > than this value, SMBs should enable.
     // *** WARNING *** DO NOT USE enableSMB_always or enableSMB_after_carbs with Libre or similar.
     , allowSMB_with_high_temptarget: false // allow supermicrobolus (if otherwise enabled) even with high temp targets
     , maxSMBBasalMinutes: 30 // maximum minutes of basal that can be delivered as a single SMB with uncovered COB


### PR DESCRIPTION
As per @tynbendad  https://github.com/openaps/oref0/issues/1278#issuecomment-536225039, we run into this issue regularly with fast carbs and bgs < 6 mmol/L.

So added a hidden optional % threshold to disable SMB to Dev.


Tried this out for the past 24hrs and works as normal at 20%, RigToo running updated % threshold, MealsDev2 running Dev:

```
Aug 21 12:48:56 RigToo pump-loop.log maxDelta 1.4 >  20 % of BG 5.9 - disabling SMB
Aug 21 12:48:57 RigToo pump-loop.log "minPredBG 11.3, minGuardBG 6.9, IOBpredBG 11.8, UAMpredBG 13.8; maxDelta 1.4 > 20% of BG 5.9: SMB disabled; Eventual BG 13.8 >= 6.0, temp 0.35<1.6U/hr. "
Aug 21 12:51:06 MealsDev2 pump-loop.log maxDelta 1.4 > 20% of BG 5.9 - disabling SMB
Aug 21 12:51:07 MealsDev2 pump-loop.log "minPredBG 11.2, minGuardBG 6.9, IOBpredBG 11.6, UAMpredBG 13.6; maxDelta 1.4 > 20% of BG 5.9: SMB disabled; Eventual BG 13.6 >= 6.0, temp 1.6 >~ req 1.6U/hr. "
```

Then changed the threshold to 10% in preferences on RigToo and got the following result post lunch:
```
Aug 21 12:59:11 RigToo pump-loop.log maxDelta 1.7 >  10 % of BG 9.3 - disabling SMB
Aug 21 12:59:12 RigToo pump-loop.log "minPredBG 17.7, minGuardBG 10.9, IOBpredBG 14.5, UAMpredBG 20.9; maxDelta 1.7 > 10% of BG 9.3: SMB disabled; ; Canceling temp at 59m past the hour. "
```
