### PR TITLE
maxDelta bg % threshold as hidden preference

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -837,9 +837,17 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         enableSMB = false;
     }
 // Disable SMB for sudden rises (often caused by calibrations or activation/deactivation of Dexcom's noise-filtering algorithm)
-    if ( maxDelta > profile.maxDelta_bg_threshold * bg ) {
-        console.error("maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * profile.maxDelta_bg_threshold+"% of BG "+convert_bg(bg, profile)+" - disabling SMB");
-        rT.reason += "maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * profile.maxDelta_bg_threshold+"% of BG "+convert_bg(bg, profile)+": SMB disabled; ";
+// Added maxDelta_bg_threshold as a hidden preference and included a cap at 0.3 as a safety limit
+var maxDelta_bg_threshold;
+    if (typeof profile.maxDelta_bg_threshold === 'undefined') {
+        maxDelta_bg_threshold = 0.2;
+    }
+	  if (typeof profile.maxDelta_bg_threshold !== 'undefined') {
+		    maxDelta_bg_threshold = Math.min(profile.maxDelta_bg_threshold, 0.3);
+	  }
+    if ( maxDelta > maxDelta_bg_threshold * bg ) {
+        console.error("maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * maxDelta_bg_threshold +"% of BG "+convert_bg(bg, profile)+" - disabling SMB");
+        rT.reason += "maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * maxDelta_bg_threshold +"% of BG "+convert_bg(bg, profile)+": SMB disabled; ";
         enableSMB = false;
     }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -837,9 +837,9 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         enableSMB = false;
     }
 // Disable SMB for sudden rises (often caused by calibrations or activation/deactivation of Dexcom's noise-filtering algorithm)
-    if ( maxDelta > 0.20 * bg ) {
-        console.error("maxDelta",convert_bg(maxDelta, profile),"> 20% of BG",convert_bg(bg, profile),"- disabling SMB");
-        rT.reason += "maxDelta "+convert_bg(maxDelta, profile)+" > 20% of BG "+convert_bg(bg, profile)+": SMB disabled; ";
+    if ( maxDelta > profile.maxDelta_bg_threshold * bg ) {
+        console.error("maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * profile.maxDelta_bg_threshold+"% of BG "+convert_bg(bg, profile)+" - disabling SMB");
+        rT.reason += "maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * profile.maxDelta_bg_threshold+"% of BG "+convert_bg(bg, profile)+": SMB disabled; ";
         enableSMB = false;
     }
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -842,9 +842,9 @@ var maxDelta_bg_threshold;
     if (typeof profile.maxDelta_bg_threshold === 'undefined') {
         maxDelta_bg_threshold = 0.2;
     }
-	  if (typeof profile.maxDelta_bg_threshold !== 'undefined') {
-		    maxDelta_bg_threshold = Math.min(profile.maxDelta_bg_threshold, 0.3);
-	  }
+    if (typeof profile.maxDelta_bg_threshold !== 'undefined') {
+        maxDelta_bg_threshold = Math.min(profile.maxDelta_bg_threshold, 0.3);
+    }
     if ( maxDelta > maxDelta_bg_threshold * bg ) {
         console.error("maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * maxDelta_bg_threshold +"% of BG "+convert_bg(bg, profile)+" - disabling SMB");
         rT.reason += "maxDelta "+convert_bg(maxDelta, profile)+" > "+100 * maxDelta_bg_threshold +"% of BG "+convert_bg(bg, profile)+": SMB disabled; ";

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -51,6 +51,7 @@ function defaults ( ) {
     , maxUAMSMBBasalMinutes: 30 // maximum minutes of basal that can be delivered as a single SMB when IOB exceeds COB
     , SMBInterval: 3 // minimum interval between SMBs, in minutes.
     , bolus_increment: 0.1 // minimum bolus that can be delivered as an SMB
+    , maxDelta_bg_threshold: 0.2 // maximum % change in bg to use SMB, above that will disable SMB
     , curve: "rapid-acting" // change this to "ultra-rapid" for Fiasp, or "bilinear" for old curve
     , useCustomPeakTime: false // allows changing insulinPeakTime
     , insulinPeakTime: 75 // number of minutes after a bolus activity peaks.  defaults to 55m for Fiasp if useCustomPeakTime: false

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -51,7 +51,7 @@ function defaults ( ) {
     , maxUAMSMBBasalMinutes: 30 // maximum minutes of basal that can be delivered as a single SMB when IOB exceeds COB
     , SMBInterval: 3 // minimum interval between SMBs, in minutes.
     , bolus_increment: 0.1 // minimum bolus that can be delivered as an SMB
-    , maxDelta_bg_threshold: 0.2 // maximum % change in bg to use SMB, above that will disable SMB
+    , maxDelta_bg_threshold: 0.2 // maximum change in bg to use SMB, above that will disable SMB
     , curve: "rapid-acting" // change this to "ultra-rapid" for Fiasp, or "bilinear" for old curve
     , useCustomPeakTime: false // allows changing insulinPeakTime
     , insulinPeakTime: 75 // number of minutes after a bolus activity peaks.  defaults to 55m for Fiasp if useCustomPeakTime: false


### PR DESCRIPTION
As per @tynbendad  https://github.com/openaps/oref0/issues/1278#issuecomment-536225039, we also run into this issue regularly with fast carbs and bgs < 6 mmol/L.

So added a hidden optional % threshold to disable SMB.

Tried this out for the past 24hrs and works as normal at 20%, RigToo running updated % threshold, MealsDev2 running Dev.

```
Aug 21 12:48:56 RigToo pump-loop.log maxDelta 1.4 > 20% of BG 5.9 - disabling SMB
Aug 21 12:48:57 RigToo pump-loop.log "minPredBG 11.3, minGuardBG 6.9, IOBpredBG 11.8, UAMpredBG 13.8; maxDelta 1.4 > 20% of BG 5.9: SMB disabled; Eventual BG 13.8 >= 6.0, temp 0.35<1.6U/hr. "
Aug 21 12:51:06 MealsDev2 pump-loop.log maxDelta 1.4 > 20% of BG 5.9 - disabling SMB
Aug 21 12:51:07 MealsDev2 pump-loop.log "minPredBG 11.2, minGuardBG 6.9, IOBpredBG 11.6, UAMpredBG 13.6; maxDelta 1.4 > 20% of BG 5.9: SMB disabled; Eventual BG 13.6 >= 6.0, temp 1.6 >~ req 1.6U/hr. "
```

Then changed the threshold to 10% in preferences on RigToo and got the following result post lunch.
```
Aug 21 12:59:11 RigToo pump-loop.log maxDelta 1.7 > 10% of BG 9.3 - disabling SMB
Aug 21 12:59:12 RigToo pump-loop.log "minPredBG 17.7, minGuardBG 10.9, IOBpredBG 14.5, UAMpredBG 20.9; maxDelta 1.7 > 10% of BG 9.3: SMB disabled; ; Canceling temp at 59m past the hour. "
```

