### PR TITLE
Autotune: Modify test for correct meals announcement

### DIFF
--- a/lib/autotune-prep/categorize.js
+++ b/lib/autotune-prep/categorize.js
@@ -394,8 +394,8 @@ function categorizeBGDatums(opts) {
     if (opts.categorize_uam_as_basal) {
         console.error("--categorize-uam-as-basal=true set: categorizing all UAM data as basal.");
         basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
-    } else if (CSFLength > 12) {
-        console.error("Found at least 1h of carb absorption: assuming all meals were announced, and categorizing UAM data as basal.");
+    } else if (UAMLength < 12) {
+        console.error("Found less than 1h of uam absorption: assuming all meals were announced, and categorizing UAM data as basal.");
         basalGlucoseData = basalGlucoseData.concat(UAMGlucoseData);
     } else {
         if (2*basalLength < UAMLength) {


### PR DESCRIPTION
see https://github.com/openaps/oref0/issues/1383

With current code uam data are always categorized as basal even if categorize-uam-as-basal is false (default setting)

I propose this modification to have autotune works as expected in documentation (there is a security warning in documentation for this setting...)