### PR TITLE
Add mills to status upload to reduce NS client workload

### DIFF
--- a/bin/ns-status.js
+++ b/bin/ns-status.js
@@ -3,6 +3,7 @@
 
 var os = require("os");
 var fs = require('fs');
+var moment = require("moment");
 
 var requireUtils = require('../lib/require-utils');
 var requireWithTimestamp = requireUtils.requireWithTimestamp;
@@ -129,6 +130,7 @@ var ns_status = function ns_status(argv_params) {
         if (iobArray && iobArray.length) {
             iob = iobArray[0];
             iob.timestamp = iob.time;
+            iob.mills = moment(iob.time).valueOf();
             delete iob.time;
         }
 
@@ -139,6 +141,14 @@ var ns_status = function ns_status(argv_params) {
           } else {
             delete enacted.predBGs;
           }
+        }
+
+        if (enacted && enacted.timestamp) {
+          enacted.mills = moment(enacted.timestamp).valueOf();
+        }
+
+        if (suggested && suggested.timestamp) {
+          suggested.mills = moment(suggested.timestamp).valueOf();
         }
 
         var status = {


### PR DESCRIPTION
There is a corresponding NS PR to use the mills fields if they are available to drastically reduce the number of times moment has to parse the date strings when scrolling in NS.