### PR TITLE
Correct NS Query

### DIFF
--- a/bin/nightscout.sh
+++ b/bin/nightscout.sh
@@ -237,7 +237,7 @@ ns)
         |  openaps use ${ZONE} select --date dateString --current now --gaps - ${FILE}  | jq .
     ;;
     latest-entries-time)
-      PREVIOUS_TIME=$(ns-get host $NIGHTSCOUT_HOST entries.json 'find[type]=sgv'  | jq .[0])
+      PREVIOUS_TIME=$(ns-get host $NIGHTSCOUT_HOST entries.json 'find[type][$eq]=sgv'  | jq .[0])
       test -z "${PREVIOUS_TIME}" && echo -n 0 || echo $PREVIOUS_TIME | jq .dateString
       exit 0
     ;;


### PR DESCRIPTION
I don't see anywhere this is used, so it should have no impact.  However, for consistency, this corrects the latest-entries-time section of nightscout.sh.