### PR TITLE
Fix issue 1377, install correct version of py-parsedatetime

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -702,7 +702,8 @@ if prompt_yn "" N; then
     echo Removing any existing git in $directory/.git
     rm -rf $directory/.git
     echo Removed any existing git
-
+    echo "Uninstalling parsedatetime, reinstalling correct version"
+    pip uninstall -y parsedatetime && pip install -I parsedatetime===2.5
     # TODO: delete this after openaps 0.2.2 release
     echo Checking openaps 0.2.2 installation with --nogit support
     if ! openaps --version 2>&1 | egrep "0.[2-9].[2-9]"; then


### PR DESCRIPTION
Quick fix for a dependency issue.
There is probably a bit cleaner solution, but this works for the moment.