### PR TITLE
equal sign typo

### DIFF
--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -703,7 +703,7 @@ if prompt_yn "" N; then
     rm -rf $directory/.git
     echo Removed any existing git
     echo "Uninstalling parsedatetime, reinstalling correct version"
-    pip uninstall -y parsedatetime && pip install -I parsedatetime===2.5
+    pip uninstall -y parsedatetime && pip install -I parsedatetime==2.5
     # TODO: delete this after openaps 0.2.2 release
     echo Checking openaps 0.2.2 installation with --nogit support
     if ! openaps --version 2>&1 | egrep "0.[2-9].[2-9]"; then


### PR DESCRIPTION
Recently I re-ran the setup script on DEV and ran into the parsedatetime error. I narrowed it down to what I think is a typo, there is a `===` when I believe `==` is what was meant. I modified this file locally and ran with no issues.