### PR TITLE
Replace git with https for install and setup scripts

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -73,7 +73,7 @@ sed -i "s/daily/hourly/g" /etc/logrotate.conf
 sed -i "s/#compress/compress/g" /etc/logrotate.conf
 
 curl -s https://raw.githubusercontent.com/openaps/oref0/$BRANCH/bin/openaps-packages.sh | bash -
-mkdir -p ~/src; cd ~/src && ls -d oref0 && (cd oref0 && git checkout $BRANCH && git pull) || git clone git://github.com/openaps/oref0.git
+mkdir -p ~/src; cd ~/src && ls -d oref0 && (cd oref0 && git checkout $BRANCH && git pull) || git clone https://github.com/openaps/oref0.git
 echo "Press Enter to run oref0-setup with the current release ($BRANCH branch) of oref0,"
 read -p "or press ctrl-c to cancel. " -r
 cd && ~/src/oref0/bin/oref0-setup.sh

--- a/bin/oref0-log-shortcuts.sh
+++ b/bin/oref0-log-shortcuts.sh
@@ -33,7 +33,7 @@ function do_aliases ()
     alias cat-pref="cd ${myopenaps} && cat preferences.json"
     alias edit-pref="cd ${myopenaps} && nano preferences.json"
     alias cat-wifi="cat /etc/wpa_supplicant/wpa_supplicant.conf"
-    alias edit-wifi="vi /etc/wpa_supplicant/wpa_supplicant.conf"
+    alias edit-wifi="nano /etc/wpa_supplicant/wpa_supplicant.conf"
     alias cat-runagain="cd ${myopenaps} && cat oref0-runagain.sh"
     alias edit-runagain="cd ${myopenaps} && nano oref0-runagain.sh"
     alias cat-autotune="cd ${myopenaps}/autotune && cat autotune_recommendations.log"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -745,7 +745,7 @@ if prompt_yn "" N; then
         (cd $HOME/src/oref0 && git fetch && git pull) || die "Couldn't pull latest oref0"
     else
         echo -n "Cloning oref0: "
-        (cd $HOME/src && git clone git://github.com/openaps/oref0.git) || die "Couldn't clone oref0"
+        (cd $HOME/src && git clone https://github.com/openaps/oref0.git) || die "Couldn't clone oref0"
     fi
 
     # Make sure jq version >1.5 is installed

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -498,6 +498,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     // remainingCIpeak (mg/dL/5m) = remainingCarbs (g) * CSF (mg/dL/g) * 5 (m/5m) * 1h/60m / (remainingCATime/2) (h)
     var remainingCIpeak = remainingCarbs * csf * 5 / 60 / (remainingCATime/2);
     //console.error(profile.min_5m_carbimpact,ci,totalCI,totalCA,remainingCarbs,remainingCI,remainingCATime);
+    console.error("profile.min_5m_carbimpact:",profile.min_5m_carbimpact,"ci:",ci,"totalCI:",round(totalCI,2),"totalCA:",round(totalCA,2),"remainingCarbs:",remainingCarbs,"remainingCIpeak:",remainingCIpeak,"remainingCATime:",remainingCATime);
 
     // calculate peak deviation in last hour, and slope from that to current deviation
     var slopeFromMaxDeviation = round(meal_data.slopeFromMaxDeviation,2);

--- a/www/app.py
+++ b/www/app.py
@@ -59,7 +59,7 @@ def enacted():
 
 @app.route("/glucose")
 def glucose():
-    if os.path.getmtime(myopenaps_dir + "xdrip/glucose.json") > os.path.getmtime(myopenaps_dir + "monitor/glucose.json"):
+    if os.path.getmtime(myopenaps_dir + "xdrip/glucose.json") > os.path.getmtime(myopenaps_dir + "monitor/glucose.json") and os.path.getsize(myopenaps_dir + "xdrip/glucose.json") > 0:
         json_url = os.path.join(myopenaps_dir + "xdrip/glucose.json")
     else:
         json_url = os.path.join(myopenaps_dir + "monitor/glucose.json")


### PR DESCRIPTION
openaps-install.sh and oref0-setup.sh installation bug due to git:// instead of https://

Line 74 of openaps-install.sh calls the git clone via `git://` instead of `https://` for some reason my PC doesn't like it an always fails.

Suggested change, replacing with `git clone https://github.com/openaps/oref0.git`

https://github.com/openaps/oref0/blob/ee154b044948c76f064d59db93cc3f7b7691a679/bin/openaps-install.sh#L74

After this line 74 call, i get the following:

`Cloning into 'oref0'...
fatal: unable to connect to github.com:`

Work around is simply to use `cd src && git clone git://github.com/openaps/oref0.git`


Checking the code i found the following git call too, so requrest both changed at the same time.

https://github.com/openaps/oref0/blob/ee154b044948c76f064d59db93cc3f7b7691a679/bin/oref0-setup.sh#L736

Thanks.




