### PR TITLE
Fix oref0-ns-loop.sh pushover_snooze NS authorization

### DIFF
--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -41,7 +41,13 @@ EOT
 
 function pushover_snooze {
     URL=$NIGHTSCOUT_HOST/api/v1/devicestatus.json?count=100
-    if snooze=$(curl -s $URL | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes); then
+    if [[ "${API_SECRET}" =~ "token=" ]]; then
+        URL="${URL}&${API_SECRET}"
+    else
+        CURL_AUTH='-H api-secret:'${API_SECRET}
+    fi
+
+    if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes); then
         #echo $snooze
         #echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) monitor/pushover-sent


### PR DESCRIPTION
This adds the logic to handle Nightscout instances with default denied read permissions.