### PR TITLE
per #1401 ensure that halfBasalTarget is >=130

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -233,7 +233,8 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     var high_temptarget_raises_sensitivity = profile.exercise_mode || profile.high_temptarget_raises_sensitivity;
     var normalTarget = 100; // evaluate high/low temptarget against 100, not scheduled target (which might change)
     if ( profile.half_basal_exercise_target ) {
-        var halfBasalTarget = profile.half_basal_exercise_target;
+        // per https://github.com/openaps/oref0/issues/1401 half_basal_exercise_target must be >120
+        var halfBasalTarget = Math.max(130, profile.half_basal_exercise_target);
     } else {
         halfBasalTarget = 160; // when temptarget is 160 mg/dL, run 50% basal (120 = 75%; 140 = 60%)
         // 80 mg/dL with low_temptarget_lowers_sensitivity would give 1.5x basal, but is limited to autosens_max (1.2x by default)


### PR DESCRIPTION
As discussed in https://github.com/openaps/oref0/issues/1401 a halfBasalTarget of 120 causes a divide by zero, and halfBasalTarget <120 causes negative sensitivityRatio. Anything 121-129 would IMO cause the system to behave way too strongly to very slight changes in temp target, so I propose we hard-code the minimum halfBasalTarget to 130 mg/dL.