### PR TITLE
per #1401 set highest sensitivity on low TT and halfBasal

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -206,7 +206,15 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         // e.g.: Sensitivity ratio set to 0.8 based on temp target of 120; Adjusting basal from 1.65 to 1.35; ISF from 58.9 to 73.6
         //sensitivityRatio = 2/(2+(target_bg-normalTarget)/40);
         var c = halfBasalTarget - normalTarget;
-        sensitivityRatio = c/(c+target_bg-normalTarget);
+        // getting multiplication less or equal to 0 means that we have a really low target with a really low halfBasalTarget
+        // with low TT and lowTTlowersSensitivity we need autosens_max as a value
+        // we use multiplication instead of the division to avoid "division by zero error"
+        if (c * (c + target_bg-normalTarget) <= 0.0) {
+          sensitivityRatio = profile.autosens_max;
+        }
+        else {
+          sensitivityRatio = c/(c+target_bg-normalTarget);
+        }
         // limit sensitivityRatio to profile.autosens_max (1.2x by default)
         sensitivityRatio = Math.min(sensitivityRatio, profile.autosens_max);
         sensitivityRatio = round(sensitivityRatio,2);


### PR DESCRIPTION
as described in #1401 we have a possibility of zero or negative ratio on low TT and halfBasalTarget.
This ensures that we don't get over the autosens_max even in these situations

getting multiplication less or equal to 0 means that we have a really low target with a really low halfBasalTarget
with low TT and lowTTlowersSensitivity we need autosens_max as a value
we use multiplication instead of the division to avoid "division by zero error"