### PR TITLE
Improve error message on Autotune run without BG-data

### DIFF
--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -104,6 +104,7 @@ if (!module.parent) {
         var glucose_data = JSON.parse(fs.readFileSync(glucose_input, 'utf8'));
     } catch (e) {
         console.error("Warning: could not parse "+glucose_input);
+        return console.error("Warning: could not parse "+glucose_input", e);
     }
 
     var carb_data = { };

--- a/bin/oref0-autotune.sh
+++ b/bin/oref0-autotune.sh
@@ -248,7 +248,7 @@ do
             cp profile.pump.json profile.json
             exit
         else
-            die "Could not run oref0-autotune-core autotune.$i.json profile.json profile.pump.json"
+            die "Could not run oref0-autotune-core autotune.$i.json profile.json profile.pump.json. Make sure Nightscout contains BG-values for the selected date range, Autotune(Web) does not work without BG-values. See documentation on the how-to check http://nightscout.github.io/nightscout/reports/#day-to-day ."
         fi
     else
         # Copy tuned profile produced by autotune to profile.json for use with next day of data


### PR DESCRIPTION
In several Dutch and English Facebook groups, I see a growing number of posts of Autotune(Web) seemingly not working. I thought we can share some insight on this error, help people to resolve this themselves, and reduce support requests by implementing two small fixes. Did my best, see below :)

**Error message**
When using Autotune(Web) some people mention error message "SyntaxError: Unexpected token u in JSON at position 0".

**Analysis**
People do not understand the technical error message. They search and/or start a support request in a Facebook group. I have analyzed several full error messages, most of the time I see BG-data is missing for entered dates (technically: epoch timestamp). For people, Autotune(Web) was always working and suddenly does no anymore, how come? And why would the important BG-data be missing?

**Functional cause**
First, an important message: Autotune(Web) still works perfectly. Thanks, Ben West, Mark Carrington! First I did not understand the growth of errors in Facebook groups...until userX mentioned "I changed from libre 1 to Libre 2" in https://www.facebook.com/groups/AndroidAPSUsers/posts/3048186752069388. Great info for understanding this userX (I will mention you in the private Facebook group...)! 

To make Libre 2 work with xDrip, people are switching to the patched LibreLink-App. Afterward, it is necessary to configure xDrip as described here https://androidaps.readthedocs.io/en/latest/Hardware/Libre2.html.

When the configuration of xDrip is done wrong, it is possible xDrip does not receive values from the patched Libre Link app, hence will not upload to Nightscout, and Autotune(Web) fails with the strange error message (for most non-tech people).

**Future**
In The Netherlands people who are reimbursed for the FSL1 by the insurance already automatically have received the FSL2. My assumption is more people worldwide will switch to Libre 2. Or already have switched to Libre 2 but not yet have used Autotune(Web). And because of it, they will possibly encounter Autotune(Web) errors a few weeks/month later. They also will search/ask for help on Facebooks groups.

**Technical background**
As from line 200 in https://github.com/openaps/oref0/blob/master/bin/oref0-autotune.sh Autotune(Web) requests Nightscout entries day by day. Autotune(Web) receives Nightscout data in JSON format.

When Nightscout does not have BG-data for the requested date, it returns [] (two characters) and saves the file. Because it saves the file, line 209 does not return error message "No ns-entries.$i.json downloaded" and continues the script. Line 239 starts oref0-autotune-prep with near-empty ns-entries.$i.json files. Near empty because of the [].

Code continues in https://github.com/openaps/oref0/blob/master/bin/oref0-autotune-prep.js line 57 points variable glucose_input to the near-empty file. Line 103-107 tries to parse the JSON format but this will fail because of the [] content.

**Solutions**
- Add text "Make sure Nightscout contains BG-values for the selected date range, Autotune(Web) does not work without BG-values. See documentation on the how-to check http://nightscout.github.io/nightscout/reports/#day-to-day ." in line 200 of file https://github.com/openaps/oref0/blob/master/bin/oref0-autotune.sh. This will help people to resolve this themselves and probably will reduce support requests.
- Better error handling for Autotune without BG-data. Prevent the technical error on the logging which users of Autotune(Web) see (example in https://www.facebook.com/groups/AndroidAPSUsers/posts/3048186752069388). File https://github.com/openaps/oref0/blob/master/bin/oref0-autotune-prep.js below line 106 "return console.error("Warning: could not parse "+glucose_input", e);".

**Try for yourself**
It is possible to See the parsing error for yourself on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse by changing
const json = '{"result":true, "count":42}';
in
const json = '[]';
...and click [Run >] --> you will see '> undefined'.

All the best,
Peter