### PR TITLE
Fix autotune prep error

### DIFF
--- a/bin/oref0-autotune-prep.js
+++ b/bin/oref0-autotune-prep.js
@@ -103,8 +103,7 @@ if (!module.parent) {
     try {
         var glucose_data = JSON.parse(fs.readFileSync(glucose_input, 'utf8'));
     } catch (e) {
-        console.error("Warning: could not parse "+glucose_input);
-        return console.error("Warning: could not parse "+glucose_input", e);
+        return console.error("Warning: could not parse "+glucose_input, e);
     }
 
     var carb_data = { };


### PR DESCRIPTION
I found that my rig wasn't autotuning anymore, and hadn't for a few months. When I tried to run manually, I got:
```
Grabbing NIGHTSCOUT treatments.json and entries/sgv.json for date range...
Query: https://geekygirl-nightscout.herokuapp.com entries/sgv.json find%5Bdate%5D%5B%24gte%5D=1633766400000&find%5Bdate%5D%5B%24lte%5D=1633852800000&count=1500
-rw-r--r-- 1 root root 104010 Oct 16 22:43 ns-entries.2021-10-09.json
Query: https://geekygirl-nightscout.herokuapp.com treatments.json find%5Bcreated_at%5D%5B%24gte%5D=2021-10-08T06:00-04:00&find%5Bcreated_at%5D%5B%24lte%5D=2021-10-10T18:00-04:00
-rw-r--r-- 1 root root 448846 Oct 16 22:43 ns-treatments.2021-10-09.json
oref0-autotune-prep   ns-treatments.2021-10-09.json profile.json ns-entries.2021-10-09.json profile.pump.json > autotune.2021-10-09.json
/root/src/oref0/bin/oref0-autotune-prep.js:107
        return console.error("Warning: could not parse "+glucose_input", e);
                                                                      ^^^^^^

SyntaxError: Invalid or unexpected token
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Function.Module.runMain (module.js:694:10)
    at startup (bootstrap_node.js:204:16)
    at bootstrap_node.js:625:3
Could not run oref0-autotune-prep ns-treatments.2021-10-09.json profile.json ns-entries.2021-10-09.json
```

I noticed there was a console.error line that was right, but one below it that had the unneeded `"` on it. This was the case only on the `dev` branch. This PR takes out the extraneous line and corrects the syntax error.