### PR TITLE
Bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ bin/__pycache__
 package-lock.json
 
 *.pyc
+
+bash-unit-test-temp
+

--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -58,7 +58,7 @@ apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true 
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate ntpdate ntp
 #check if edison user exists before trying to add it to groups
 
-grep "PermitRootLogin yes" /etc/ssh/sshd_config || echo "PermitRootLogin yes" > /etc/ssh/sshd_config
+grep "PermitRootLogin yes" /etc/ssh/sshd_config || echo "PermitRootLogin yes" >>/etc/ssh/sshd_config
 
 if  getent passwd edison > /dev/null; then
   echo "Adding edison to sudo users"

--- a/bin/oref0-cron-every-15min.sh
+++ b/bin/oref0-cron-every-15min.sh
@@ -12,12 +12,24 @@ assert_cwd_contains_ini
 
 # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
 if is_edison; then
-    sudo ~/src/EdisonVoltage/voltage json batteryVoltage battery | jq .batteryVoltage | awk '{if ($1<=3050)system("sudo shutdown -h now")}' &
+    BATTERY_VOLTAGE="$(sudo ~/src/EdisonVoltage/voltage json batteryVoltage battery | jq .batteryVoltage)"
+    echo "Battery level is $BATTERY_VOLTAGE."
+    BATTERY_CUTOFF=$(get_pref_float .edison_battery_shutdown_voltage 3050)
+    if (( "$BATTERY_VOLTAGE" <= "$BATTERY_CUTOFF" )); then
+        echo "Critically low battery! Shutting down."
+        sudo shutdown -h now
+    fi
 fi
 
 # proper shutdown of pi rigs once the battery level is below 2 % (should be more than enough to shut down on a standard 18600 ~2Ah cell)
 if is_pi; then
-    sudo ~/src/openaps-menu/scripts/getvoltage.sh | tee ~/myopenaps/monitor/edison-battery.json | jq .battery | awk '{if ($1<2)system("sudo shutdown -h now")}' &
+    BATTERY_PERCENT="$(sudo ~/src/openaps-menu/scripts/getvoltage.sh | tee ~/myopenaps/monitor/edison-battery.json | jq .battery)"
+    BATTERY_CUTOFF=$(get_pref_float .pi_battery_shutdown_percent 2)
+    echo "Battery level is $BATTERY_PERCENT"
+    if (( "$BATTERY_PERCENT" < "$BATTERY_CUTOFF" )); then
+        echo "Critically low battery! Shutting down."
+        sudo shutdown -h now
+    fi
 fi
 
 # temporarily disable hotspot for 1m every 15m to allow it to try to connect via wifi again

--- a/bin/oref0-cron-every-15min.sh
+++ b/bin/oref0-cron-every-15min.sh
@@ -13,7 +13,7 @@ assert_cwd_contains_ini
 # proper shutdown once the EdisonVoltage very low (< 3050mV; 2950 is dead)
 if is_edison; then
     BATTERY_VOLTAGE="$(sudo ~/src/EdisonVoltage/voltage json batteryVoltage battery | jq .batteryVoltage)"
-    echo "Battery level is $BATTERY_VOLTAGE."
+    echo "Battery voltage is $BATTERY_VOLTAGE."
     BATTERY_CUTOFF=$(get_pref_float .edison_battery_shutdown_voltage 3050)
     if (( "$BATTERY_VOLTAGE" <= "$BATTERY_CUTOFF" )); then
         echo "Critically low battery! Shutting down."
@@ -25,7 +25,7 @@ fi
 if is_pi; then
     BATTERY_PERCENT="$(sudo ~/src/openaps-menu/scripts/getvoltage.sh | tee ~/myopenaps/monitor/edison-battery.json | jq .battery)"
     BATTERY_CUTOFF=$(get_pref_float .pi_battery_shutdown_percent 2)
-    echo "Battery level is $BATTERY_PERCENT"
+    echo "Battery level is $BATTERY_PERCENT percent"
     if (( "$BATTERY_PERCENT" < "$BATTERY_CUTOFF" )); then
         echo "Critically low battery! Shutting down."
         sudo shutdown -h now

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -742,7 +742,11 @@ if prompt_yn "" N; then
     mkdir -p $HOME/src/
     if [ -d "$HOME/src/oref0/" ]; then
         echo "$HOME/src/oref0/ already exists; pulling latest"
-        (cd $HOME/src/oref0 && git fetch && git pull) || die "Couldn't pull latest oref0"
+        (cd $HOME/src/oref0 && git fetch && git pull) || (
+            if ! prompt_yn "Couldn't pull latest oref0. Continue anyways?"; then
+                die "Failed to update oref0."
+            fi
+        )
     else
         echo -n "Cloning oref0: "
         (cd $HOME/src && git clone git://github.com/openaps/oref0.git) || die "Couldn't clone oref0"

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -66,7 +66,9 @@ function defaults ( ) {
     //, maxRaw: 200 // highest raw/noisy CGM value considered safe to use for looping
     , calc_glucose_noise: false
     , target_bg: false // set to an integer value in mg/dL to override pump min_bg
-  };
+    , edison_battery_shutdown_voltage: 3050
+    , pi_battery_shutdown_percent: 2
+  }
 }
 
 function displayedDefaults () {
@@ -87,6 +89,8 @@ function displayedDefaults () {
     profile.enableUAM = allDefaults.enableUAM;
     profile.curve = allDefaults.curve;
     profile.offline_hotspot = allDefaults.offline_hotspot;
+    profile.edison_battery_shutdown_voltage = allDefaults.edison_battery_shutdown_voltage;
+    profile.pi_battery_shutdown_percent = allDefaults.pi_battery_shutdown_percent;
 
     console.error(profile);
     return profile

--- a/tests/check-syntax.test.js
+++ b/tests/check-syntax.test.js
@@ -93,6 +93,7 @@ describe("Syntax checks", function() {
         var type = getFileFormat(file);
         if(type !== "unknown") {
             it(file, function() {
+                this.timeout(4000);
                 checkFile(file, type);
             });
         }

--- a/tests/iob.test.js
+++ b/tests/iob.test.js
@@ -3,6 +3,7 @@
 require('should');
 
 var moment = require('moment');
+var iob = require('../lib/iob');
 
 describe('IOB', function() {
 
@@ -34,13 +35,13 @@ describe('IOB', function() {
 
             };
 
-        var rightAfterBolus = require('../lib/iob')(inputs)[0];
+        var rightAfterBolus = iob(inputs)[0];
         rightAfterBolus.iob.should.equal(2);
         //rightAfterBolus.bolussnooze.should.equal(2);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(1.45);
         //hourLater.bolussnooze.should.be.lessThan(.5);
         hourLater.iob.should.be.greaterThan(0);
@@ -49,7 +50,7 @@ describe('IOB', function() {
 
         var afterDIAInputs = inputs;
         afterDIAInputs.clock = new Date(now + (3 * 60 * 60 * 1000)).toISOString();
-        var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
+        var afterDIA = iob(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
         //afterDIA.bolussnooze.should.equal(0);
@@ -83,14 +84,14 @@ describe('IOB', function() {
                 }
             };
 
-        var rightAfterBolus = require('../lib/iob')(inputs)[0];
+        var rightAfterBolus = iob(inputs)[0];
 
         rightAfterBolus.iob.should.equal(2);
         //rightAfterBolus.bolussnooze.should.equal(2);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(1.6);
         hourLater.iob.should.be.greaterThan(1.3);
 
@@ -101,7 +102,7 @@ describe('IOB', function() {
 
         var afterDIAInputs = inputs;
         afterDIAInputs.clock = new Date(now + (5 * 60 * 60 * 1000)).toISOString();
-        var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
+        var afterDIA = iob(afterDIAInputs)[0];
         afterDIA.iob.should.equal(0);
         //afterDIA.bolussnooze.should.equal(0);
     });
@@ -135,13 +136,13 @@ describe('IOB', function() {
                 }
             };
 
-        var rightAfterBolus = require('../lib/iob')(inputs)[0];
+        var rightAfterBolus = iob(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
         //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.75);
         //hourLater.bolussnooze.should.be.lessThan(0.75);
         hourLater.iob.should.be.greaterThan(0);
@@ -150,7 +151,7 @@ describe('IOB', function() {
 
         var afterDIAInputs = inputs;
         afterDIAInputs.clock = new Date(now + (5 * 60 * 60 * 1000)).toISOString();
-        var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
+        var afterDIA = iob(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
         //afterDIA.bolussnooze.should.equal(0);
@@ -186,13 +187,13 @@ describe('IOB', function() {
                 }
             };
 
-        var rightAfterBolus = require('../lib/iob')(inputs)[0];
+        var rightAfterBolus = iob(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
         //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.77);
         //hourLater.bolussnooze.should.be.lessThan(0.36);
         hourLater.iob.should.be.greaterThan(0.72);
@@ -203,7 +204,7 @@ describe('IOB', function() {
 
         var afterDIAInputs = inputs;
         afterDIAInputs.clock = new Date(now + (5 * 60 * 60 * 1000)).toISOString();
-        var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
+        var afterDIA = iob(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
         //afterDIA.bolussnooze.should.equal(0);
@@ -239,13 +240,13 @@ describe('IOB', function() {
                 }
             };
 
-        var rightAfterBolus = require('../lib/iob')(inputs)[0];
+        var rightAfterBolus = iob(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
         //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.81);
         //hourLater.bolussnooze.should.be.lessThan(0.5);
         hourLater.iob.should.be.greaterThan(0.76);
@@ -257,7 +258,7 @@ describe('IOB', function() {
 
         var afterDIAInputs = inputs;
         afterDIAInputs.clock = new Date(now + (5 * 60 * 60 * 1000)).toISOString();
-        var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
+        var afterDIA = iob(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
         //afterDIA.bolussnooze.should.equal(0);
@@ -293,13 +294,13 @@ describe('IOB', function() {
                 }
             };
 
-        var rightAfterBolus = require('../lib/iob')(inputs)[0];
+        var rightAfterBolus = iob(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
         //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.59);
         //hourLater.bolussnooze.should.be.lessThan(0.23);
 
@@ -311,7 +312,7 @@ describe('IOB', function() {
 
         var afterDIAInputs = inputs;
         afterDIAInputs.clock = new Date(now + (6 * 60 * 60 * 1000)).toISOString();
-        var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
+        var afterDIA = iob(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
         //afterDIA.bolussnooze.should.equal(0);
@@ -345,20 +346,20 @@ describe('IOB', function() {
                 }
             };
 
-        var rightAfterBolus = require('../lib/iob')(inputs)[0];
+        var rightAfterBolus = iob(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
         //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.8);
         //hourLater.bolussnooze.should.be.lessThan(.8);
         hourLater.iob.should.be.greaterThan(0);
 
         var afterDIAInputs = inputs;
         afterDIAInputs.clock = new Date(now + (5 * 60 * 60 * 1000)).toISOString();
-        var afterDIA = require('../lib/iob')(afterDIAInputs)[0];
+        var afterDIA = iob(afterDIAInputs)[0];
 
         afterDIA.iob.should.equal(0);
         //afterDIA.bolussnooze.should.equal(0);
@@ -395,13 +396,13 @@ describe('IOB', function() {
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (4 * 60 * 60 * 1000)).toISOString();
 
-        var hourLaterWith5 = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLaterWith5 = iob(hourLaterInputs)[0];
 
         console.error(hourLaterWith5.iob);
 
         hourLaterInputs.profile.dia = 3;
 
-        var hourLaterWith4 = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLaterWith4 = iob(hourLaterInputs)[0];
 
         console.error(hourLaterWith4.iob);
 
@@ -427,7 +428,7 @@ describe('IOB', function() {
 
         //var snoozeInputs = inputs;
         //snoozeInputs.clock = new Date(now + (20 * 60 * 1000)).toISOString();
-        //var snooze = require('../lib/iob')(snoozeInputs)[0];
+        //var snooze = iob(snoozeInputs)[0];
         //snooze.bolussnooze.should.equal(0);
     //});
 
@@ -476,7 +477,7 @@ describe('IOB', function() {
             };
 
         var iobInputs = inputs;
-        var iobNow = require('../lib/iob')(iobInputs)[0];
+        var iobNow = iob(iobInputs)[0];
 
         //console.log(iobNow);
         iobNow.iob.should.be.lessThan(1);
@@ -535,7 +536,7 @@ describe('IOB', function() {
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = moment('2016-06-13 01:30:00.000');
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(0.5);
         hourLater.iob.should.be.greaterThan(0.4);
     });
@@ -599,7 +600,7 @@ describe('IOB', function() {
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = moment('2016-06-13 00:45:00.000'); //new Date(now + (30 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
 
         hourLater.iob.should.be.lessThan(0.8);
         hourLater.iob.should.be.greaterThan(0.7);
@@ -640,7 +641,7 @@ describe('IOB', function() {
             }
         };
 
-        var hourLater = require('../lib/iob')(inputs)[0];
+        var hourLater = iob(inputs)[0];
 
         var timestampEarly2 = startingPoint.clone().subtract(29, 'minutes');
         var timestampEarly3 = startingPoint.clone().subtract(28, 'minutes');
@@ -669,7 +670,7 @@ describe('IOB', function() {
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = moment('2016-06-13 00:30:00.000');
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
 
         var inputs = {
             clock: timestamp,
@@ -713,7 +714,7 @@ describe('IOB', function() {
             }
         };
 
-        var hourLaterWithOverlap = require('../lib/iob')(inputs)[0];
+        var hourLaterWithOverlap = iob(inputs)[0];
 
         hourLater.iob.should.be.greaterThan(hourLaterWithOverlap.iob - 0.05);
         hourLater.iob.should.be.lessThan(hourLaterWithOverlap.iob + 0.05);
@@ -774,7 +775,7 @@ describe('IOB', function() {
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = moment('2016-06-14 00:45:00.000');
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
 
         hourLater.iob.should.be.lessThan(1);
         hourLater.iob.should.be.greaterThan(0.8);
@@ -832,7 +833,7 @@ describe('IOB', function() {
         var iobInputs = inputs;
 
         // Calculate IOB with inputs that will be the same as
-        var iobNowWithoutSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithoutSuspend = iob(iobInputs)[0];
 
         inputs = {
             clock: timestamp,
@@ -867,7 +868,7 @@ describe('IOB', function() {
 
         iobInputs = inputs;
 
-        var iobNowWithSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithSuspend = iob(iobInputs)[0];
 
         iobNowWithSuspend.iob.should.equal(iobNowWithoutSuspend.iob);
     });
@@ -933,7 +934,7 @@ describe('IOB', function() {
 
         var iobInputs = inputs;
 
-        var iobNowWithoutSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithoutSuspend = iob(iobInputs)[0];
 
         inputs = {
                 clock: timestamp,
@@ -968,7 +969,7 @@ describe('IOB', function() {
 
         iobInputs = inputs;
 
-        var iobNowWithSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithSuspend = iob(iobInputs)[0];
 
         iobNowWithSuspend.iob.should.equal(iobNowWithoutSuspend.iob);
     });
@@ -1035,7 +1036,7 @@ describe('IOB', function() {
 
         var iobInputs = inputs;
 
-        var iobNowWithoutSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithoutSuspend = iob(iobInputs)[0];
 
         inputs = {
             clock: timestamp,
@@ -1090,7 +1091,7 @@ describe('IOB', function() {
 
         iobInputs = inputs;
 
-        var iobNowWithSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithSuspend = iob(iobInputs)[0];
 
         iobNowWithSuspend.iob.should.equal(iobNowWithoutSuspend.iob);
     });
@@ -1146,7 +1147,7 @@ describe('IOB', function() {
 
         var iobInputs = inputs;
 
-        var iobNowWithoutSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithoutSuspend = iob(iobInputs)[0];
 
         inputs = {
             clock: timestamp,
@@ -1180,7 +1181,7 @@ describe('IOB', function() {
 
         var iobInputs = inputs;
 
-        var iobNowWithSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithSuspend = iob(iobInputs)[0];
 
         iobNowWithSuspend.iob.should.equal(iobNowWithoutSuspend.iob);
     });
@@ -1237,7 +1238,7 @@ describe('IOB', function() {
 
         var iobInputs = inputs;
 
-        var iobNowWithoutSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithoutSuspend = iob(iobInputs)[0];
 
         inputs = {
             clock: timestamp,
@@ -1268,7 +1269,7 @@ describe('IOB', function() {
 
         iobInputs = inputs;
 
-        var iobNowWithSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithSuspend = iob(iobInputs)[0];
 
         iobNowWithSuspend.iob.should.equal(iobNowWithoutSuspend.iob);
     });
@@ -1324,7 +1325,7 @@ describe('IOB', function() {
 
         var iobInputs = inputs;
 
-        var iobNowWithoutSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithoutSuspend = iob(iobInputs)[0];
 
             inputs = {
                 clock: timestamp,
@@ -1353,7 +1354,7 @@ describe('IOB', function() {
                 }
             };
 
-        var iobNowWithSuspend = require('../lib/iob')(iobInputs)[0];
+        var iobNowWithSuspend = iob(iobInputs)[0];
 
         iobNowWithSuspend.iob.should.equal(iobNowWithoutSuspend.iob);
     });
@@ -1411,7 +1412,7 @@ describe('IOB', function() {
         };
 
         var hourLaterInputs = inputs;
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.equal(0);
     });
 
@@ -1460,7 +1461,7 @@ describe('IOB', function() {
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
 
         hourLater.iob.should.be.lessThan(1);
         hourLater.iob.should.be.greaterThan(0);
@@ -1512,7 +1513,7 @@ describe('IOB', function() {
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
 
         hourLater.iob.should.be.lessThan(0);
         hourLater.iob.should.be.greaterThan(-1);
@@ -1542,7 +1543,7 @@ describe('IOB', function() {
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
 
         hourLater.iob.should.equal(0);
     });
@@ -1579,7 +1580,7 @@ describe('IOB', function() {
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
 
         hourLater.iob.should.equal(0);
     });
@@ -1612,25 +1613,25 @@ describe('IOB', function() {
 
             };
 
-        var rightAfterBolus = require('../lib/iob')(inputs)[0];
+        var rightAfterBolus = iob(inputs)[0];
         rightAfterBolus.iob.should.equal(1);
         //rightAfterBolus.bolussnooze.should.equal(1);
 
         var hourLaterInputs = inputs;
         hourLaterInputs.clock = new Date(now + (60 * 60 * 1000)).toISOString();
-        var hourLater = require('../lib/iob')(hourLaterInputs)[0];
+        var hourLater = iob(hourLaterInputs)[0];
         hourLater.iob.should.be.lessThan(1);
         //hourLater.bolussnooze.should.be.lessThan(.5);
         hourLater.iob.should.be.greaterThan(0);
 
         var after3hInputs = inputs;
         after3hInputs.clock = new Date(now + (3 * 60 * 60 * 1000)).toISOString();
-        var after3h = require('../lib/iob')(after3hInputs)[0];
+        var after3h = iob(after3hInputs)[0];
         after3h.iob.should.be.greaterThan(0);
 
         var after4hInputs = inputs;
         after4hInputs.clock = new Date(now + (4 * 60 * 60 * 1000)).toISOString();
-        var after4h = require('../lib/iob')(after4hInputs)[0];
+        var after4h = iob(after4hInputs)[0];
         after4h.iob.should.equal(0);
     });
 


### PR DESCRIPTION
Significant changes:
 * Check for bad (super slow) RPi nodejs versions, install nvm version if found. This fixes excessive CPU usage and slow looping interval on Raspberry Pi Zero.
 * Add a pair of config settings, `pi_battery_shutdown_percent` and `edison_battery_shutdown_voltage`, for controlling when the rig shuts down due to low battery. This config setting is needed for USB-powered Pi rigs, where the battery level indicator just returns a random number, which might occasionally be zero.

Minor changes:
 * If unable to update with git pull, prompt before aborting `oref0-runagain.sh`. This is mainly for convenience during development; a checkout in some weird branch doesn't necessarily return success when you "git pull".
 * Fix bug that would clobber sshd_config in some circumstances
 * Extend timeout on JS syntax check unit tests
 * Clean up require() usage in IOB unit test, speeding it up enough to pass without timing out on Pi Zero
 * Add bash-unit-test-temp to gitignore
