### PR TITLE
Improved handling of node installation (& miscellaneous improvements)

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -46,13 +46,6 @@ if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /de
     echo "Jubilinux 0.2.0, based on Debian Jessie, is no longer receiving security or software updates!"
 fi
 
-#Workaround for Jubilinux to install nodejs/npm from nodesource
-if getent passwd edison &> /dev/null; then
-    #Use nodesource setup script to add nodesource repository to sources.list.d
-    curl -sL https://deb.nodesource.com/setup_8.x | bash -
-fi
-
-#dpkg -P nodejs nodejs-dev
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim locate ntpdate ntp

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -30,15 +30,17 @@ else
    sudo apt-get -y install jq || die "Couldn't install jq"
 fi
 
-# Install/upgrade to latest version of node (v10) using apt if neither node 8 nor node 10+ LTS are installed
-if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' &> /dev/null ; then
-   if getent passwd edison; then
-     # Only on the Edison, use nodesource setup script to add nodesource repository to sources.list.d, then install nodejs (npm is a part of the package)
-     curl -sL https://deb.nodesource.com/setup_8.x | bash -
-     sudo apt-get install -y nodejs=8.* || die "Couldn't install nodejs"
-   else
-     sudo apt-get install -y nodejs npm || die "Couldn't install nodejs and npm"
-   fi
+# Install node using n if there is not an installed version of node >=8,<=19
+# Edge case: This is not likely to work as expected if there *is* a version of node installed, but it is outside of the specified version constraints
+if ! node --version | grep -e 'v[89]\.' -e 'v1\d\.' &> /dev/null ; then
+   echo "Installing node via n..." # For context why we don't install using apt or nvm, see https://github.com/openaps/oref0/pull/1419
+   curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n
+   # Install the latest compatible version of node
+   sudo bash n current
+   # Delete the local n binary used to boostrap the install
+   rm n
+   # Install n globally
+   sudo npm install -g n
    
    # Upgrade to the latest supported version of npm for the current node version
    sudo npm upgrade -g npm|| die "Couldn't update npm"

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -32,7 +32,7 @@ fi
 
 # Install node using n if there is not an installed version of node >=8,<=19
 # Edge case: This is not likely to work as expected if there *is* a version of node installed, but it is outside of the specified version constraints
-if ! node --version | grep -e 'v[89]\.' -e 'v1\d\.' &> /dev/null ; then
+if ! node --version | grep -q -e 'v[89]\.' -e 'v1[[:digit:]]\.'; then
    echo "Installing node via n..." # For context why we don't install using apt or nvm, see https://github.com/openaps/oref0/pull/1419
    curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n
    # Install the latest compatible version of node

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -40,8 +40,8 @@ if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' &> /dev/null ; then
      sudo apt-get install -y nodejs npm || die "Couldn't install nodejs and npm"
    fi
    
-   # Upgrade npm to the latest version using its self-updater
-   sudo npm install npm@latest -g || die "Couldn't update npm"
+   # Upgrade to the latest supported version of npm for the current node version
+   sudo npm upgrade -g npm|| die "Couldn't update npm"
 
    ## You may also need development tools to build native addons:
    ## sudo apt-get install gcc g++ make

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -295,7 +295,7 @@ function move_mmtune () {
 function check_nodejs_timing () {
     # Redundant check that node is installed
     # It is installed as part of openaps-packages.sh
-    if ! node --version | grep -e 'v[89]\.' -e 'v1\d\.' &> /dev/null ; then
+    if ! node --version | grep -q -e 'v[89]\.' -e 'v1[[:digit:]]\.'; then
         die "No version of node (>=8,<=19) was found, which is an unexpected error (node installation should have been handled by previous installation steps)"
     fi
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -292,14 +292,11 @@ function move_mmtune () {
     fi
 }
 
-function install_or_upgrade_nodejs () {
-    # install/upgrade to latest node 8 if neither node 8 nor node 10+ LTS are installed
-    if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' >/dev/null; then
-        echo Installing node 8
-        # Use nodesource setup script to add nodesource repository to sources.list.d
-        sudo bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -" || die "Couldn't setup node 8"
-        # Install nodejs and npm from nodesource
-        sudo apt-get install -y nodejs=8.* || die "Couldn't install nodejs"
+function check_nodejs_timing () {
+    # Redundant check that node is installed
+    # It is installed as part of openaps-packages.sh
+    if ! node --version | grep -e 'v[89]\.' -e 'v1\d\.' &> /dev/null ; then
+        die "No version of node (>=8,<=19) was found, which is an unexpected error (node installation should have been handled by previous installation steps)"
     fi
 
     # Check that the nodejs you have installed is not broken. In particular, we're
@@ -314,17 +311,39 @@ function install_or_upgrade_nodejs () {
         echo "Your installed nodejs ($(node --version)) is very slow to start (took ${NODE_EXECUTION_TIME}s)"
         echo "This is a known problem with certain versions of Raspberry Pi OS."
 
-        if prompt_yn "Install a new nodejs version using nvm?" Y; then
-            echo "Installing nvm and using it to replace the system-provided nodejs"
-    
-            # Download nvm
-            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-            # Run nvm, adding its aliases to this shell
-            source ~/.nvm/nvm.sh
-            # Use nvm to install nodejs
-            nvm install 10.24.1
-            # Symlink node into /usr/local/bin, where it will shadow /usr/bin/node
-            ln -s ~/.nvm/versions/node/v10.24.1/bin/node /usr/local/bin/node
+        if prompt_yn "Confirm installation of replacement nodejs/npm versions?" Y; then
+            echo "Attempting to uninstall current nodejs/npm versions (apt-get remove)"
+            sudo apt-get -y remove nodejs npm
+            if [[ -n $NVM_DIR ]]; then
+                echo "Removing nvm ($NVM_DIR)..."
+                echo "(you may wish to optionally remove the nvm-related lines that still exist in ~/.bashrc; this script won't do it for you)"
+                rm -rf "$NVM_DIR"
+            fi
+
+            # Check that there node and npm are no longer available. If they are, warn the user.
+            nodePath=$(command -v node)
+            npmPath=$(command -v npm)
+            if [[ -e "$nodePath" ]]; then
+                echo "Note: A 'node' binary (located at '$nodePath') still exists and may interfere with the new installation of node"
+            fi
+            if [[ -e "$npmPath" ]]; then
+                echo "Note: A 'npm' binary (located at '$npmPath') still exists and may interfere with the new installation of npm"
+            fi
+
+            if [[ ! $(command -v n) ]]; then
+                echo "n already exists on the system, using it to install a new version of node..."
+                sudo n current
+            else
+                echo "Installing n and using it to replace the system-provided nodejs"
+                echo "Installing node via n..."
+                curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n
+                # Install the latest version of node that is supported on this platform
+                sudo bash n current
+                # Delete the local n binary used to boostrap the install
+                rm n
+                # Install n globally
+                sudo npm install -g n
+            fi
 
             NEW_NODE_EXECUTION_TIME="$(\time --format %e node -e 'true' 2>&1)"
             echo "New nodejs took ${NEW_NODE_EXECUTION_TIME}s to start"
@@ -730,7 +749,7 @@ if prompt_yn "" N; then
     echo Running apt-get autoclean
     sudo apt-get autoclean
 
-    install_or_upgrade_nodejs
+    check_nodejs_timing
 
     # Attempting to remove git to make install --nogit by default for existing users
     echo Removing any existing git in $directory/.git


### PR DESCRIPTION
Note: This PR has changed somewhat significantly since inception. The "very minor" changes listed below have been removed to keep the focus on changes to node/npm install improvements. The original text otherwise follows, but please see the comments for relevant context.
---

### Summary

#### Very Minor Changes
- Escape quotes that are themselves in a quoted string. Before, these quotes would not print, but it did not cause any errors or other unexpected behavior.
- Moved a comment to (what I think is) the right place

#### NodeJS Changes
- Remove the nodesource JS installation (in the case of edison boards) from the install script, as it is already done in the openaps-packages script and is not needed until then
- The biggest change of this PR. Instead of Installing `nodejs` and `npm` from the package manager, we instead install [the node version manager n](https://github.com/tj/n) since in my first attempt to install OpenAPS found the scripts failing due to issues with getting JS setup (particularly with getting `npm` to a proper version and keeping it there). There may be an easier fix, but `n` seems like a more robust solution. I chose `n` over `nvm` because of issues with `nvm` in multi-user/root environments. `n` is an actual binary and does a proper global install of `node` that should avoid those issues. I changed the setup script to reflect the preference of `n` over `nvm`. This change also includes a subtle but important modification to the npm self-update command. It now, instead of updating itself to the latest version of npm, it should update itself to the latest version of npm _that is compatible with the installed version of node_. Trying to install the latest version of npm with our relatively ancient version(s?) of `node` does not work.

Copy and pasted code comment that I (re)moved (in a recent commit) but wanted to save for posterity:
```
# Raspbian Buster has (at the time of writing) npm 5.8 in the repo, which is not compatible with the repo nodejs version of 10.24
# An npm self-upgrade (as is attempted below) is successful (bringing npm to major verison 8), but between there and this script trying to `npm install -g json` npm has somehow reverted to the package manager version and become broken (any invocation of npm immediately crashes with a syntax error)
# At this point, the root cause is unclear and I don't want to deal with it, so I'm deferring to `n`
# `n` instead of `nvm` to avoid issues with nvm not being available to all users (see https://stackoverflow.com/questions/21215059/cant-use-nvm-from-root-or-sudo)
```

If you would like me to squash/rebase any of my commits or remove some (perhaps excessive) code comments, I'd be happy to do so.

Please let me know your thoughts/suggestions. I look forward to making future contributions.

### Testing

I used this modified code to conduct my own install and it worked well for me (a lot better than regular `dev` at the moment). Some of these changes are non-functional and could likely be merged separately, but I could understand the desire for some testing around the JS changes. It shouldn't change anything for existing users who re-run `oref0-setup.sh`; their existing version of node is likely fine. 

Perhaps contributors that are doing fresh installs (and just updating their rigs) can do so with these changes included?