### PR TITLE
carbsReq pushover improvements

### DIFF
--- a/bin/oref0-autosens-loop.sh
+++ b/bin/oref0-autosens-loop.sh
@@ -33,9 +33,9 @@ function completed_recently {
 # openaps use detect-sensitivity shell monitor/glucose.json settings/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json
 function autosens {
     # only run autosens if pumphistory-24h is newer than autosens
-    if find monitor/ -newer settings/autosens.json | grep -q pumphistory-24h-zoned.json \
-        || find settings/ -size -5c | grep -q autosens.json \
-        || ! find settings/ | grep -q autosens \
+    if find monitor/ -newer settings/autosens.json | grep pumphistory-24h-zoned.json \
+        || find settings/ -size -5c | grep autosens.json \
+        || ! find settings/ | grep autosens \
         || ! find settings/autosens.json >/dev/null; then
         if oref0-detect-sensitivity monitor/glucose.json monitor/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep "[0-9]"; then
             mv settings/autosens.json.new settings/autosens.json

--- a/bin/oref0-autosens-loop.sh
+++ b/bin/oref0-autosens-loop.sh
@@ -37,7 +37,7 @@ function autosens {
         || find settings/ -size -5c | grep -q autosens.json \
         || ! find settings/ | grep -q autosens \
         || ! find settings/autosens.json >/dev/null; then
-        if oref0-detect-sensitivity monitor/glucose.json monitor/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep -q [0-9]; then
+        if oref0-detect-sensitivity monitor/glucose.json monitor/pumphistory-24h-zoned.json settings/insulin_sensitivities.json settings/basal_profile.json settings/profile.json monitor/carbhistory.json settings/temptargets.json > settings/autosens.json.new && cat settings/autosens.json.new | jq .ratio | grep "[0-9]"; then
             mv settings/autosens.json.new settings/autosens.json
             echo -n "Autosens refreshed: "
         else

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -542,7 +542,7 @@ function wait_for_silence {
         echo -n .
         # returns true if it hears pump comms, false otherwise
         if ! listen -t $waitfor's' 2>&4 ; then
-            echo -n "All clear. "
+            echo " All clear."
             echo -n "Continuing oref0-pump-loop at "; date
             return 0
         else

--- a/bin/oref0-bash-common-functions.sh
+++ b/bin/oref0-bash-common-functions.sh
@@ -542,7 +542,7 @@ function wait_for_silence {
         echo -n .
         # returns true if it hears pump comms, false otherwise
         if ! listen -t $waitfor's' 2>&4 ; then
-            echo "No interfering pump comms detected from other rigs (this is a good thing!)"
+            echo -n "All clear. "
             echo -n "Continuing oref0-pump-loop at "; date
             return 0
         else

--- a/bin/oref0-cron-every-minute.sh
+++ b/bin/oref0-cron-every-minute.sh
@@ -129,7 +129,7 @@ if [[ ! -z "$BT_PEB" || ! -z "$BT_MAC" ]]; then
 fi
 
 if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
-    oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log &
+    #oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log &
 fi
 
 # if disk has less than 10MB free, delete something and logrotate

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -123,12 +123,9 @@ function ns_temptargets {
     #cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json settings/autotune.json $dir_name
 
     run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || die "Couldn't refresh profile"
-    ls -la settings/profile.json.new
-    cat settings/profile.json.new | jq . | grep basal
     if cat settings/profile.json.new | jq . | grep basal > /dev/null; then
         mv settings/profile.json.new settings/profile.json
     else
-        ls -la settings/profile.json.new
         die "Invalid profile.json.new after refresh"
     fi
 }

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -25,7 +25,7 @@ main() {
         fi
     fi
 
-    pushover_snooze
+    #pushover_snooze
     ns_temptargets || die "ns_temptargets failed"
     ns_meal_carbs || echo "ns_meal_carbs failed"
     battery_status

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -127,6 +127,7 @@ function ns_temptargets {
         mv settings/profile.json.new settings/profile.json
     else
         ls -la settings/profile.json.new
+        cat settings/profile.json.new | jq . | grep basal
         die "Invalid profile.json.new after refresh"
     fi
 }

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -134,7 +134,7 @@ function ns_temptargets {
 function ns_meal_carbs {
     #openaps report invoke monitor/carbhistory.json >/dev/null
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET carb_history > monitor/carbhistory.json.new
-    cat monitor/carbhistory.json.new | jq .[0].carbs | egrep -q [0-9] && mv monitor/carbhistory.json.new monitor/carbhistory.json
+    cat monitor/carbhistory.json.new | jq .[0].carbs | egrep -q "[0-9]" && mv monitor/carbhistory.json.new monitor/carbhistory.json
     
     dir_name=~/test_data/oref0-meal$(date +"%Y-%m-%d-%H%M")
     #echo dir_name = $dir_name

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -247,7 +247,7 @@ function format_latest_nightscout_treatments {
     latest_ns_treatment_time=$(latest_ns_treatment_time)
     historyfile=monitor/pumphistory-24h-zoned.json
     # TODO: remove this hack once we actually start parsing pump time change events
-    if [[ $latest_ns_treatment_time > $(date -u +"%Y-%m-%dT%H:%M:%S.000Z") ]]; then
+    if [[ $latest_ns_treatment_time > $(date -Is) ]]; then
         echo "Latest NS treatment time $latest_ns_treatment_time is 'in the future' / from a timezone east of here."
         latest_ns_treatment_time=$(date -Is -d "1 hour ago")
         echo "Uploading the last 10 treatments since $latest_ns_treatment_time"

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -119,7 +119,7 @@ function ns_temptargets {
 
     dir_name=~/test_data/oref0-get-profile$(date +"%Y-%m-%d-%H%M")-ns
     #echo dir_name = $dir_name
-    mkdir -p $dir_name
+    # mkdir -p $dir_name
     #cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json settings/autotune.json $dir_name
 
     run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || die "Couldn't refresh profile"
@@ -138,7 +138,7 @@ function ns_meal_carbs {
     
     dir_name=~/test_data/oref0-meal$(date +"%Y-%m-%d-%H%M")
     #echo dir_name = $dir_name
-    mkdir -p $dir_name
+    # mkdir -p $dir_name
     #cp monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json $dir_name
     
     

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -250,7 +250,7 @@ function format_latest_nightscout_treatments {
     latest_ns_treatment_time=$(latest_ns_treatment_time)
     historyfile=monitor/pumphistory-24h-zoned.json
     # TODO: remove this hack once we actually start parsing pump time change events
-    if [[ $latest_ns_treatment_time > $(date -Is) ]]; then
+    if [[ $latest_ns_treatment_time > $(date -u +"%Y-%m-%dT%H:%M:%S.000Z") ]]; then
         echo "Latest NS treatment time $latest_ns_treatment_time is 'in the future' / from a timezone east of here."
         latest_ns_treatment_time=$(date -Is -d "1 hour ago")
         echo "Uploading the last 10 treatments since $latest_ns_treatment_time"

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -126,6 +126,7 @@ function ns_temptargets {
     if cat settings/profile.json.new | jq . | grep -q basal; then
         mv settings/profile.json.new settings/profile.json
     else
+        ls -la settings/profile.json.new
         die "Invalid profile.json.new after refresh"
     fi
 }

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -123,6 +123,7 @@ function ns_temptargets {
     #cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json settings/autotune.json $dir_name
 
     run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || die "Couldn't refresh profile"
+    ls -la settings/profile.json.new
     if cat settings/profile.json.new | jq . | grep -q basal; then
         mv settings/profile.json.new settings/profile.json
     else

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -239,7 +239,7 @@ function upload_recent_treatments {
 }
 
 function latest_ns_treatment_time {
-    nightscout latest-openaps-treatment $NIGHTSCOUT_HOST $API_SECRET | jq -r .created_at
+    date -Is -d $(nightscout latest-openaps-treatment $NIGHTSCOUT_HOST $API_SECRET | jq -r .created_at)
 }
 
 #nightscout cull-latest-openaps-treatments monitor/pumphistory-zoned.json settings/model.json $(openaps latest-ns-treatment-time) > upload/latest-treatments.json

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -73,7 +73,7 @@ function get_ns_bg {
     # if ns-glucose.json data is <10m old, no more than 5m in the future, and valid (>38),
     # copy cgm/ns-glucose.json over to cgm/glucose.json if it's newer
     valid_glucose=$(find_valid_ns_glucose)
-    if echo $valid_glucose | grep -q glucose; then
+    if echo $valid_glucose | grep glucose >/dev/null; then
         echo Found recent valid BG:
         echo $valid_glucose | colorize_json '.[0] | { glucose: .glucose, dateString: .dateString }'
         cp -pu cgm/ns-glucose.json cgm/glucose.json
@@ -104,7 +104,7 @@ function find_valid_ns_glucose {
 function ns_temptargets {
     #openaps report invoke settings/temptargets.json settings/profile.json >/dev/null
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET temp_targets > settings/ns-temptargets.json.new
-    cat settings/ns-temptargets.json.new | jq .[0].duration | egrep -q [0-9] && mv settings/ns-temptargets.json.new settings/ns-temptargets.json
+    cat settings/ns-temptargets.json.new | jq .[0].duration | egrep "[0-9]" >/dev/null && mv settings/ns-temptargets.json.new settings/ns-temptargets.json
     # TODO: merge local-temptargets.json with ns-temptargets.json
     #openaps report invoke settings/ns-temptargets.json settings/profile.json
     echo -n "Latest NS temptargets: "
@@ -125,7 +125,7 @@ function ns_temptargets {
     run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || die "Couldn't refresh profile"
     ls -la settings/profile.json.new
     cat settings/profile.json.new | jq . | grep basal
-    if cat settings/profile.json.new | jq . | grep -q basal; then
+    if cat settings/profile.json.new | jq . | grep basal > /dev/null; then
         mv settings/profile.json.new settings/profile.json
     else
         ls -la settings/profile.json.new
@@ -137,7 +137,7 @@ function ns_temptargets {
 function ns_meal_carbs {
     #openaps report invoke monitor/carbhistory.json >/dev/null
     nightscout ns $NIGHTSCOUT_HOST $API_SECRET carb_history > monitor/carbhistory.json.new
-    cat monitor/carbhistory.json.new | jq .[0].carbs | egrep -q "[0-9]" && mv monitor/carbhistory.json.new monitor/carbhistory.json
+    cat monitor/carbhistory.json.new | jq .[0].carbs | egrep "[0-9]" >/dev/null && mv monitor/carbhistory.json.new monitor/carbhistory.json
     
     dir_name=~/test_data/oref0-meal$(date +"%Y-%m-%d-%H%M")
     #echo dir_name = $dir_name
@@ -194,7 +194,7 @@ function upload {
 function upload_ns_status {
     set -o pipefail
     #echo Uploading devicestatus
-    grep -q iob monitor/iob.json || die "IOB not found"
+    grep iob monitor/iob.json >/dev/null || die "IOB not found"
     # set the timestamp on enact/suggested.json to match the deliverAt time
     touch -d $(cat enact/suggested.json | jq .deliverAt | sed 's/"//g') enact/suggested.json
     if ! file_is_recent_and_min_size enact/suggested.json 10; then
@@ -203,12 +203,12 @@ function upload_ns_status {
         return 1
     fi
     ns_status_file_name=ns-status$(date +"%Y-%m-%d-%T").json
-    format_ns_status $ns_status_file_name && grep -q iob upload/$ns_status_file_name || die "Couldn't generate ns-status.json"
+    format_ns_status $ns_status_file_name && grep iob upload/$ns_status_file_name >/dev/null || die "Couldn't generate ns-status.json"
     # Delete files older than 24 hours.
     find upload -maxdepth 1 -mmin +1440 -type f -name "ns-status*.json" -delete
     # Upload the files one by one according to their order.
     ls upload/ns-status*.json | while read -r file_name ; do
-        if ! grep -q iob $file_name ; then
+        if ! grep iob $file_name >/dev/null ; then
             #echo deleteing file $file_name
             rm $file_name
             continue

--- a/bin/oref0-ns-loop.sh
+++ b/bin/oref0-ns-loop.sh
@@ -124,11 +124,11 @@ function ns_temptargets {
 
     run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || die "Couldn't refresh profile"
     ls -la settings/profile.json.new
+    cat settings/profile.json.new | jq . | grep basal
     if cat settings/profile.json.new | jq . | grep -q basal; then
         mv settings/profile.json.new settings/profile.json
     else
         ls -la settings/profile.json.new
-        cat settings/profile.json.new | jq . | grep basal
         die "Invalid profile.json.new after refresh"
     fi
 }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -488,7 +488,7 @@ function refresh_after_bolus_or_enact {
 
 function unsuspend_if_no_temp {
     # If temp basal duration is zero, unsuspend pump
-    if (cat monitor/temp_basal.json | jq '. | select(.duration == 0)' | grep -q duration); then
+    if (cat monitor/temp_basal.json | jq '. | select(.duration == 0)' | grep duration); then
         if check_pref_bool .unsuspend_if_no_temp false; then
             echo Temp basal has ended: unsuspending pump
             mdt resume 2>&3

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -72,8 +72,8 @@ main() {
             PUSHOVER_TOKEN="$(get_pref_string .pushover_token "")"
             PUSHOVER_USER="$(get_pref_string .pushover_user "")"
             if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
-                echo "Running pushover"
-                oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log &
+                echo "Running pushover."
+                oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER # 2>&1 >> /var/log/openaps/pushover.log &
             fi
 
             # before each of these (optional) refresh checks, make sure we don't have fresh glucose data

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -69,7 +69,7 @@ main() {
             fi
             touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
             # run pushover immediately after completing loop for more timely carbsReq notifications without race conditions
-            $(dirname $0)/oref0-pushover.sh
+            oref0-pushover
             # before each of these (optional) refresh checks, make sure we don't have fresh glucose data
             # if we do, then skip the optional checks to finish up this loop and start the next one
             if ! glucose-fresh; then

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -744,7 +744,7 @@ function onbattery {
 function wait_for_bg {
     if [ "$(get_pref_string .cgm '')" == "mdt" ]; then
         echo "MDT CGM configured; not waiting"
-    elif egrep -q "Warning:" enact/smb-suggested.json 2>&3; then
+    elif egrep -q "Warning:" enact/smb-suggested.json 2>&3 || egrep -q "Could not parse clock data" monitor/meal.json 2>&3; then
         echo "Retrying without waiting for new BG"
     elif egrep -q "Waiting [0](\.[0-9])?m ([0-6]?[0-9]s )?to microbolus again." enact/smb-suggested.json 2>&3; then
         echo "Retrying microbolus without waiting for new BG"

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -68,6 +68,8 @@ main() {
                 fi
             fi
             touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
+            # run pushover immediately after completing loop for more timely carbsReq notifications without race conditions
+            $(dirname $0)/oref0-pushover.sh
             # before each of these (optional) refresh checks, make sure we don't have fresh glucose data
             # if we do, then skip the optional checks to finish up this loop and start the next one
             if ! glucose-fresh; then

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -615,8 +615,8 @@ function refresh_pumphistory_and_meal {
         return 1
     fi
     try_return check_cp_meal || return 1
-    echo -n "refreshed: COB: "
-    cat monitor/meal.json | jq .mealCOB
+    echo -n "refreshed: "
+    cat monitor/meal.json | jq -cC .
 }
 
 function check_cp_meal {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -69,7 +69,13 @@ main() {
             fi
             touch /tmp/pump_loop_completed -r /tmp/pump_loop_enacted
             # run pushover immediately after completing loop for more timely carbsReq notifications without race conditions
-            oref0-pushover
+            PUSHOVER_TOKEN="$(get_pref_string .pushover_token "")"
+            PUSHOVER_USER="$(get_pref_string .pushover_user "")"
+            if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
+                echo "Running pushover"
+                oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER 2>&1 >> /var/log/openaps/pushover.log &
+            fi
+
             # before each of these (optional) refresh checks, make sure we don't have fresh glucose data
             # if we do, then skip the optional checks to finish up this loop and start the next one
             if ! glucose-fresh; then

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -325,7 +325,7 @@ function smb_suggest {
 }
 
 function determine_basal {
-    cat monitor/meal.json
+    #cat monitor/meal.json
 
     update_glucose_noise
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -615,8 +615,8 @@ function refresh_pumphistory_and_meal {
         return 1
     fi
     try_return check_cp_meal || return 1
-    echo -n "refreshed: "
-    #cat monitor/meal.json
+    echo -n "refreshed: COB: "
+    cat monitor/meal.json | jq .mealCOB
 }
 
 function check_cp_meal {

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -78,6 +78,7 @@ main() {
             # before each of these (optional) refresh checks, make sure we don't have fresh glucose data
             # if we do, then skip the optional checks to finish up this loop and start the next one
             if ! glucose-fresh; then
+                wait_for_silence $upto10s
                 if onbattery; then
                     refresh_profile 30
                 else

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -608,7 +608,7 @@ function refresh_pumphistory_and_meal {
     
     dir_name=~/test_data/oref0-meal$(date +"%Y-%m-%d-%H%M")
     #echo dir_name = $dir_name
-    mkdir -p $dir_name
+    # mkdir -p $dir_name
     #cp monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json $dir_name
     if ! retry_return run_remote_command 'oref0-meal monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json monitor/glucose.json settings/basal_profile.json monitor/carbhistory.json' > monitor/meal.json.new ; then
         echo; echo "Couldn't calculate COB"
@@ -639,7 +639,7 @@ function check_cp_meal {
 function calculate_iob {
     dir_name=~/test_data/oref0-calculate-iob$(date +"%Y-%m-%d-%H%M")
     #echo dir_name = $dir_name
-    mkdir -p $dir_name
+    # mkdir -p $dir_name
     #cp  monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json settings/autosens.json $dir_name
 
     run_remote_command 'oref0-calculate-iob monitor/pumphistory-24h-zoned.json settings/profile.json monitor/clock-zoned.json settings/autosens.json' > monitor/iob.json.new || { echo; echo "Couldn't calculate IOB"; fail "$@"; }
@@ -695,7 +695,7 @@ function get_settings {
 
     #dir_name=~/test_data/oref0-get-profile$(date +"%Y-%m-%d-%H%M")-pump
     #echo dir_name = $dir_name
-    mkdir -p $dir_name
+    # mkdir -p $dir_name
     #cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json $dir_name
     
     run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json' 2>&3 | jq . > settings/pumpprofile.json.new || { echo "Couldn't refresh pumpprofile"; fail "$@"; }
@@ -709,7 +709,7 @@ function get_settings {
     # generate settings/profile.json.new with autotune
     dir_name=~/test_data/oref0-get-profile$(date +"%Y-%m-%d-%H%M")-pump-auto
     #echo dir_name = $dir_name
-    mkdir -p $dir_name
+    # mkdir -p $dir_name
     #cp  settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json settings/model.json settings/autotune.json $dir_name
 
     run_remote_command 'oref0-get-profile settings/settings.json settings/bg_targets.json settings/insulin_sensitivities.json settings/basal_profile.json preferences.json settings/carb_ratios.json settings/temptargets.json --model=settings/model.json --autotune settings/autotune.json' | jq . > settings/profile.json.new || { echo "Couldn't refresh profile"; fail "$@"; }

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -72,7 +72,6 @@ main() {
             PUSHOVER_TOKEN="$(get_pref_string .pushover_token "")"
             PUSHOVER_USER="$(get_pref_string .pushover_user "")"
             if [[ ! -z "$PUSHOVER_TOKEN" && ! -z "$PUSHOVER_USER" ]]; then
-                echo "Running pushover."
                 oref0-pushover $PUSHOVER_TOKEN $PUSHOVER_USER # 2>&1 >> /var/log/openaps/pushover.log &
             fi
 

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -616,7 +616,7 @@ function refresh_pumphistory_and_meal {
     fi
     try_return check_cp_meal || return 1
     echo -n "refreshed: "
-    cat monitor/meal.json
+    #cat monitor/meal.json
 }
 
 function check_cp_meal {

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -89,7 +89,7 @@ date
 
     if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes | grep -v null); then
         #echo $snooze
-        echo date -Is -d @$snooze; echo
+        #echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) monitor/pushover-sent
         ls -la monitor/pushover-sent
     fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -180,7 +180,7 @@ else
                                                                                                                                            title="${bgNow} ${direction}        @ ${curTime}"
     text="IOB ${iob}, COB ${cob}"
     if cat $FILE | egrep "add'l"; then
-      carbsMsg="carbsReq ${carbsReq}g "
+      carbsMsg="${carbsReq}g req "
     fi
     subtext="$carbsMsg${rate}U/h ${duration}m"
 

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -156,19 +156,22 @@ else
     #echo lastDirection=$lastDirection
 
     if [ "${lastDirection}" == "SingleUp" ]; then
-      direction="^"
+      direction="↑"
     elif [ "${lastDirection}" == "FortyFiveUp" ]; then
-      direction="/"
+      direction="↗"
     elif [ "${lastDirection}" == "DoubleUp" ]; then
-      direction="++"
+      direction="↑↑"
     elif [ "${lastDirection}" == "SingleDown" ]; then
-      direction="v"
+      direction="↓"
     elif [ "${lastDirection}" == "FortyFiveDown" ]; then
-      direction='\'
-    elif [ "${lastDirection}" == "DoubleDown" ]; then                                                                                        direction="--"                                                                                                                       else                                                                                                                                     direction="->" # default for NONE or Flat
+      direction="↘"
+    elif [ "${lastDirection}" == "DoubleDown" ]; then
+      direction="↓↓"
+    else
+      direction="→" # default for NONE or Flat
     fi
                                                                                                                                            title="${bgNow} ${direction}        @ ${curTime}"
-    text="COB ${cob}, IOB ${iob}"
+    text="IOB ${iob}, COB ${cob}"
     if cat $FILE | egrep "add'l"; then
       carbsMsg="carbsReq ${carbsReq}g "
     fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -186,7 +186,7 @@ else
     fi
                                                                                                                                            title="${bgNow} ${direction}        @ ${curTime}"
     text="IOB ${iob}, COB ${cob}"
-    if cat $FILE | egrep "add'l"; then
+    if cat $FILE | egrep "add'l" >/dev/null; then
       carbsMsg="${carbsReq}g req "
     fi
     subtext="$carbsMsg${rate}U/h ${duration}m"

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -192,7 +192,7 @@ else
     subtext="$carbsMsg${rate}U/h ${duration}m"
 
 #    echo "pushover glance text=${text}  subtext=${subtext}  delta=${delta} title=${title}  battery percent=${battery}"
-    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' | tee /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json
+    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json && echo "Glance snooze uploaded"
     touch $GLANCES
   else
     echo -n "Pushover glance last updated less than $glanceDelay minutes ago. "

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -191,7 +191,7 @@ fi
 #   call with this event that will read out in human language the additional carbs and other
 #   vital facts. It will leave a voice mail if not answered.
 
-if [[ "$MAKER_KEY" != "null" ]] && cat $FILE | egrep "add'l"; then
+if ! [ -z "$MAKER_KEY" ] && [[ "$MAKER_KEY" != "null" ]] && cat $FILE | egrep "add'l"; then
   if file_is_recent monitor/ifttt-sent 60; then
      echo "carbsReq=${carbsReq} but last IFTTT event sent less than 60 minutes ago."
   else

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -76,7 +76,7 @@ else
     PRIORITY_OPTIONS=""
 fi
 
-date
+#date
 
 #function pushover_snooze {
 # check Nightscout to see if another rig has already sent a carbsReq pushover recently

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -91,7 +91,7 @@ fi
         #echo $snooze
         #echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) monitor/pushover-sent
-        ls -la monitor/pushover-sent | awk '{print $8,$9}'
+        #ls -la monitor/pushover-sent | awk '{print $8,$9}'
     fi
 #}
 
@@ -154,7 +154,7 @@ else
         #echo $snooze
         #echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) $GLANCES
-        ls -la $GLANCES | awk '{print $8,$9}'
+        #ls -la $GLANCES | awk '{print $8,$9}'
   fi
 
   if test `find $GLANCES -mmin +$glanceDelay` || cat $FILE | egrep "add'l" >/dev/null

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -185,7 +185,7 @@ else
       direction="→" # default for NONE or Flat
     fi
 
-    title="${bgNow} ${direction} ${tick}    @ ${curTime}"
+    title="${bgNow} ${tick} ${direction}      @ ${curTime}"
     text="IOB ${iob}, COB ${cob}"
     if cat $FILE | egrep "add'l" >/dev/null; then
       carbsMsg="${carbsReq}g req "

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -136,7 +136,9 @@ pushoverGlances=$(get_prefs_json | jq -M '.pushoverGlances')
 if [ "${pushoverGlances}" == "null" -o "${pushoverGlances}" == "false" ]; then
     echo "pushoverGlances not enabled in preferences.json"
 else
-  if ${pushoverGlances} > 1; then
+  # if pushoverGlances is a number instead of just true, use it to set the minutes allowed between glances
+  # syntax from https://stackoverflow.com/a/808740
+  if [ -n "${pushoverGlances}" ] && [ "${pushoverGlances}" -eq "${pushoverGlances}" ] 2>/dev/null; then
     glanceDelay=${pushoverGlances}
   else
     glaceDelay=10

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -107,7 +107,7 @@ elif [[ $ONLYFOR =~ "insulin" ]] && ! cat $FILE | egrep "maxBolus" > /dev/null; 
 elif file_is_recent monitor/pushover-sent $SNOOZE; then
     echo -n "Last pushover sent less than $SNOOZE minutes ago. "
 else
-    curl -s -F token=$TOKEN -F user=$USER $SOUND_OPTION -F priority=$PRIORITY $PRIORITY_OPTIONS -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"carbsReq"}' | tee /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json
+    curl -s -F token=$TOKEN -F user=$USER $SOUND_OPTION -F priority=$PRIORITY $PRIORITY_OPTIONS -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"carbsReq"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null
     echo
 fi
 
@@ -192,7 +192,7 @@ else
     subtext="$carbsMsg${rate}U/h ${duration}m"
 
 #    echo "pushover glance text=${text}  subtext=${subtext}  delta=${delta} title=${title}  battery percent=${battery}"
-    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json | jq .status| grep 1 >/dev/null && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json && echo "Glance snooze uploaded"
+    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json | jq .status| grep 1 >/dev/null && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null && echo "Glance snooze uploaded"
     touch $GLANCES
   else
     echo -n "Pushover glance last updated less than $glanceDelay minutes ago. "

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -101,11 +101,11 @@ elif ! file_is_recent "$FILE"; then
     echo "$FILE more than 5 minutes old"
     exit
 elif ! cat $FILE | egrep "add'l|maxBolus"; then
-    echo "No additional carbs or bolus required."
+    echo -n "No additional carbs or bolus required. "
 elif [[ $ONLYFOR =~ "carb" ]] && ! cat $FILE | egrep "add'l"; then
-    echo "No additional carbs required."   
+    echo -n "No additional carbs required. "
 elif [[ $ONLYFOR =~ "insulin" ]] && ! cat $FILE | egrep "maxBolus"; then
-    echo "No additional insulin required."
+    echo -n "No additional insulin required. "
 else
     curl -s -F token=$TOKEN -F user=$USER $SOUND_OPTION -F priority=$PRIORITY $PRIORITY_OPTIONS -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"carbsReq"}' | tee /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json
     echo

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -175,7 +175,7 @@ else
     if cat $FILE | egrep "add'l"; then
       carbsMsg="carbsReq ${carbsReq}g "
     fi
-    subtext="$carbsMsg${rate}U*${duration}m"
+    subtext="$carbsMsg${rate}U/h ${duration}m"
 
 #    echo "pushover glance text=${text}  subtext=${subtext}  delta=${delta} title=${title}  battery percent=${battery}"
     curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -99,9 +99,9 @@ if ! file_is_recent "$FILE"; then
     echo "$FILE more than 5 minutes old"
     exit
 elif ! cat $FILE | egrep "add'l|maxBolus" > /dev/null; then
-    echo -n "No additional carbs or bolus required. "
+    echo -n "No carbsReq. "
 elif [[ $ONLYFOR =~ "carb" ]] && ! cat $FILE | egrep "add'l" > /dev/null; then
-    echo -n "No additional carbs required. "
+    echo -n "No carbsReq. "
 elif [[ $ONLYFOR =~ "insulin" ]] && ! cat $FILE | egrep "maxBolus" > /dev/null; then
     echo -n "No additional insulin required. "
 elif file_is_recent monitor/pushover-sent $SNOOZE; then

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -87,8 +87,7 @@ date
         CURL_AUTH='-H api-secret:'${API_SECRET}
     fi
 
-    echo "curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes"
-    if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes); then
+    if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -es .[0].date | noquotes); then
         #echo $snooze
         echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) monitor/pushover-sent

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -107,7 +107,7 @@ elif [[ $ONLYFOR =~ "insulin" ]] && ! cat $FILE | egrep "maxBolus" > /dev/null; 
 elif file_is_recent monitor/pushover-sent $SNOOZE; then
     echo -n "Last pushover sent less than $SNOOZE minutes ago. "
 else
-    curl -s -F token=$TOKEN -F user=$USER $SOUND_OPTION -F priority=$PRIORITY $PRIORITY_OPTIONS -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"carbsReq"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null
+    curl -s -F token=$TOKEN -F user=$USER $SOUND_OPTION -F priority=$PRIORITY $PRIORITY_OPTIONS -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"carbsReq"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null && echo "carbsReq pushover sent."
     echo
 fi
 

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -87,7 +87,7 @@ date
         CURL_AUTH='-H api-secret:'${API_SECRET}
     fi
 
-    echo curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes
+    echo "curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes"
     if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes); then
         #echo $snooze
         echo date -Is -d @$snooze; echo

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -143,6 +143,13 @@ else
     touch $GLANCES && touch -r $GLANCES -d '-11 mins' $GLANCES
   fi
 
+  if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="glance") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes | grep -v null); then
+        #echo $snooze
+        #echo date -Is -d @$snooze; echo
+        touch -d $(date -Is -d @$snooze) $GLANCES
+        ls -la $GLANCES
+  fi
+
   if test `find $GLANCES -mmin +10`
   then
     curTime=$(ls -l  --time-style=+"%l:%M" ${FILE} | awk '{printf ($6)}')
@@ -178,7 +185,7 @@ else
     subtext="$carbsMsg${rate}U/h ${duration}m"
 
 #    echo "pushover glance text=${text}  subtext=${subtext}  delta=${delta} title=${title}  battery percent=${battery}"
-    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json
+    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' | tee /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json
     touch $GLANCES
   fi
 fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -192,7 +192,7 @@ else
     subtext="$carbsMsg${rate}U/h ${duration}m"
 
 #    echo "pushover glance text=${text}  subtext=${subtext}  delta=${delta} title=${title}  battery percent=${battery}"
-    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json && echo "Glance snooze uploaded"
+    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json | jq .status| grep 1 >/dev/null && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json && echo "Glance snooze uploaded"
     touch $GLANCES
   else
     echo -n "Pushover glance last updated less than $glanceDelay minutes ago. "

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -185,7 +185,7 @@ else
       direction="→" # default for NONE or Flat
     fi
 
-    title="${bgNow} ${direction} ${delta}    @ ${curTime}"
+    title="${bgNow} ${direction} ${tick}    @ ${curTime}"
     text="IOB ${iob}, COB ${cob}"
     if cat $FILE | egrep "add'l" >/dev/null; then
       carbsMsg="${carbsReq}g req "

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -98,11 +98,11 @@ fi
 if ! file_is_recent "$FILE"; then
     echo "$FILE more than 5 minutes old"
     exit
-elif ! cat $FILE | egrep "add'l|maxBolus"; then
+elif ! cat $FILE | egrep "add'l|maxBolus" > /dev/null; then
     echo -n "No additional carbs or bolus required. "
-elif [[ $ONLYFOR =~ "carb" ]] && ! cat $FILE | egrep "add'l"; then
+elif [[ $ONLYFOR =~ "carb" ]] && ! cat $FILE | egrep "add'l" > /dev/null; then
     echo -n "No additional carbs required. "
-elif [[ $ONLYFOR =~ "insulin" ]] && ! cat $FILE | egrep "maxBolus"; then
+elif [[ $ONLYFOR =~ "insulin" ]] && ! cat $FILE | egrep "maxBolus" > /dev/null; then
     echo -n "No additional insulin required. "
 elif file_is_recent monitor/pushover-sent $SNOOZE; then
     echo -n "Last pushover sent less than $SNOOZE minutes ago. "

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -89,7 +89,7 @@ date
 
     if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes); then
         #echo $snooze
-        #echo date -Is -d @$snooze; echo
+        echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) monitor/pushover-sent
         ls -la monitor/pushover-sent
     fi

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -137,7 +137,8 @@ if [ "${pushoverGlances}" == "null" -o "${pushoverGlances}" == "false" ]; then
     echo "pushoverGlances not enabled in preferences.json"
 else
   # if pushoverGlances is a number instead of just true, use it to set the minutes allowed between glances
-  if [[ "${pushoverGlances}" =~ '^[0-9]+$'  ]]; then
+  re='^[0-9]+$'
+  if [[ ${pushoverGlances} =~ $re  ]]; then
     glanceDelay=${pushoverGlances}
   else
     glanceDelay=10

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -184,7 +184,8 @@ else
     else
       direction="→" # default for NONE or Flat
     fi
-                                                                                                                                           title="${bgNow} ${direction}        @ ${curTime}"
+
+    title="${bgNow} ${direction} ${delta}    @ ${curTime}"
     text="IOB ${iob}, COB ${cob}"
     if cat $FILE | egrep "add'l" >/dev/null; then
       carbsMsg="${carbsReq}g req "

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -78,6 +78,23 @@ fi
 
 date
 
+#function pushover_snooze {
+# check Nightscout to see if another rig has already sent a carbsReq pushover recently
+    URL=$NIGHTSCOUT_HOST/api/v1/devicestatus.json?count=100
+    if [[ "${API_SECRET}" =~ "token=" ]]; then
+        URL="${URL}&${API_SECRET}"
+    else
+        CURL_AUTH='-H api-secret:'${API_SECRET}
+    fi
+
+    if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes); then
+        #echo $snooze
+        #echo date -Is -d @$snooze; echo
+        touch -d $(date -Is -d @$snooze) monitor/pushover-sent
+        ls -la monitor/pushover-sent
+    fi
+#}
+
 if file_is_recent monitor/pushover-sent $SNOOZE; then
     echo "Last pushover sent less than $SNOOZE minutes ago."
 elif ! file_is_recent "$FILE"; then

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -123,6 +123,8 @@ source $HOME/.bash_profile
 key=${MAKER_KEY:-"null"}
 carbsReq=`jq .carbsReq ${FILE}`
 tick=`jq .tick ${FILE}`
+tick="${tick%\"}"
+tick="${tick#\"}"
 bgNow=`jq .bg ${FILE}`
 delta=`echo "${tick}" | tr -d +`
 delta="${delta%\"}"

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -157,7 +157,7 @@ else
         ls -la $GLANCES | awk '{print $8,$9}'
   fi
 
-  if test `find $GLANCES -mmin +$glanceDelay` || cat $FILE | egrep "add'l"
+  if test `find $GLANCES -mmin +$glanceDelay` || cat $FILE | egrep "add'l" >/dev/null
   then
     curTime=$(ls -l  --time-style=+"%l:%M" ${FILE} | awk '{printf ($6)}')
 

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -87,6 +87,7 @@ date
         CURL_AUTH='-H api-secret:'${API_SECRET}
     fi
 
+    echo snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes)
     if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes); then
         #echo $snooze
         echo date -Is -d @$snooze; echo

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -91,7 +91,7 @@ fi
         #echo $snooze
         #echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) monitor/pushover-sent
-        ls -la monitor/pushover-sent | awk '{print $8 $9}'
+        ls -la monitor/pushover-sent | awk '{print $8,$9}'
     fi
 #}
 
@@ -137,11 +137,10 @@ if [ "${pushoverGlances}" == "null" -o "${pushoverGlances}" == "false" ]; then
     echo "pushoverGlances not enabled in preferences.json"
 else
   # if pushoverGlances is a number instead of just true, use it to set the minutes allowed between glances
-  # syntax from https://stackoverflow.com/a/808740
-  if [ -n "${pushoverGlances}" ] && [ "${pushoverGlances}" -eq "${pushoverGlances}" ] 2>/dev/null; then
+  if [[ "${pushoverGlances}" =~ '^[0-9]+$'  ]]; then
     glanceDelay=${pushoverGlances}
   else
-    glaceDelay=10
+    glanceDelay=10
   fi
   GLANCES="monitor/last_glance"
   GLUCOSE="monitor/glucose.json"
@@ -154,7 +153,7 @@ else
         #echo $snooze
         #echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) $GLANCES
-        ls -la $GLANCES | awk '{print $8 $9}'
+        ls -la $GLANCES | awk '{print $8,$9}'
   fi
 
   if test `find $GLANCES -mmin +$glanceDelay` || cat $FILE | egrep "add'l"

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -87,7 +87,7 @@ date
         CURL_AUTH='-H api-secret:'${API_SECRET}
     fi
 
-    echo snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes)
+    echo curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes
     if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes); then
         #echo $snooze
         echo date -Is -d @$snooze; echo

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -196,7 +196,8 @@ else
     curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json | jq .status| grep 1 >/dev/null && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null && echo "Glance uploaded and snoozed"
     touch $GLANCES
   else
-    echo -n "Pushover glance last updated less than $glanceDelay minutes ago. "
+    echo -n "Pushover glance last updated less than $glanceDelay minutes ago @ "
+    ls -la $GLANCES | awk '{print $8}'
   fi
 fi
 

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -107,7 +107,7 @@ elif [[ $ONLYFOR =~ "insulin" ]] && ! cat $FILE | egrep "maxBolus" > /dev/null; 
 elif file_is_recent monitor/pushover-sent $SNOOZE; then
     echo -n "Last pushover sent less than $SNOOZE minutes ago. "
 else
-    curl -s -F token=$TOKEN -F user=$USER $SOUND_OPTION -F priority=$PRIORITY $PRIORITY_OPTIONS -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json && touch monitor/pushover-sent && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"carbsReq"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null && echo "carbsReq pushover sent."
+    curl -s -F token=$TOKEN -F user=$USER $SOUND_OPTION -F priority=$PRIORITY $PRIORITY_OPTIONS -F "message=$(jq -c "{bg, tick, carbsReq, insulinReq, reason}|del(.[] | nulls)" $FILE) - $(hostname)" https://api.pushover.net/1/messages.json | jq .status| grep 1 >/dev/null && touch monitor/pushover-sent && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"carbsReq"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null && echo "carbsReq pushover sent."
     echo
 fi
 
@@ -192,7 +192,7 @@ else
     subtext="$carbsMsg${rate}U/h ${duration}m"
 
 #    echo "pushover glance text=${text}  subtext=${subtext}  delta=${delta} title=${title}  battery percent=${battery}"
-    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json | jq .status| grep 1 >/dev/null && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null && echo "Glance snooze uploaded"
+    curl -s -F "token=$TOKEN" -F "user=$USER" -F "text=${text}" -F "subtext=${subtext}" -F "count=$bgNow" -F "percent=${battery}" -F "title=${title}"   https://api.pushover.net/1/glances.json | jq .status| grep 1 >/dev/null && echo '{"date":'$(epochtime_now)',"device":"openaps://'$(hostname)'","snooze":"glance"}' > /tmp/snooze.json && ns-upload $NIGHTSCOUT_HOST $API_SECRET devicestatus.json /tmp/snooze.json >/dev/null && echo "Glance uploaded and snoozed"
     touch $GLANCES
   else
     echo -n "Pushover glance last updated less than $glanceDelay minutes ago. "

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -87,7 +87,7 @@ date
         CURL_AUTH='-H api-secret:'${API_SECRET}
     fi
 
-    if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -es .[0].date | noquotes); then
+    if snooze=$(curl -s ${CURL_AUTH} ${URL} | jq '.[] | select(.snooze=="carbsReq") | select(.date>'$(date +%s -d "10 minutes ago")')' | jq -s .[0].date | noquotes | grep -v null); then
         #echo $snooze
         echo date -Is -d @$snooze; echo
         touch -d $(date -Is -d @$snooze) monitor/pushover-sent

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -895,7 +895,9 @@ var maxDelta_bg_threshold;
     zeroTempEffect = round(zeroTempEffect);
     carbsReq = round(carbsReq);
     console.error("naive_eventualBG:",naive_eventualBG,"bgUndershoot:",bgUndershoot,"zeroTempDuration:",zeroTempDuration,"zeroTempEffect:",zeroTempEffect,"carbsReq:",carbsReq);
-    if ( carbsReq >= profile.carbsReqThreshold && minutesAboveThreshold <= 45 ) {
+    if ( meal_data.reason == "Could not parse clock data" ) {
+        console.error("carbsReq unknown: Could not parse clock data");
+    } else if ( carbsReq >= profile.carbsReqThreshold && minutesAboveThreshold <= 45 ) {
         rT.carbsReq = carbsReq;
         rT.reason += carbsReq + " add'l carbs req w/in " + minutesAboveThreshold + "m; ";
     }


### PR DESCRIPTION
This PR cuts down on spurious/duplicate carbsReq pushover noise:

- don't send carbsReq alerts if COB is zero due to clock data parsing error
- run pushover from pump-loop immediately after completing a loop
- check Nightscout for pushover snoozes (created when another rig has already sent a pushover) immediately before sending one

The latter two combine to eliminate the race condition where two rigs would both send pushover alerts if they completed loops within a minute or two of each other (before cron had a chance to run pushover, update the snooze file to Nightscout, and then run ns-loop to download it to the other rig).