### PR TITLE
Add support for Bullseye (address Python3 default/no python2 pip)

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -28,7 +28,7 @@ dpkg-reconfigure tzdata
 #dpkg -P nodejs nodejs-dev
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
-apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate ntpdate
+apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim locate ntpdate
 #check if edison user exists before trying to add it to groups
 
 if  getent passwd edison > /dev/null; then

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -3,7 +3,17 @@
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true install -y sudo
 sudo apt-get -o Acquire::ForceIPv4=true update && sudo apt-get -o Acquire::ForceIPv4=true -y upgrade
-sudo apt-get -o Acquire::ForceIPv4=true install -y git python python-dev software-properties-common python-numpy python-pip nodejs-legacy npm watchdog strace tcpdump screen acpid vim locate jq lm-sensors && \
+## Debian Bullseye (Raspberry Pi OS 64bit, etc) is python3 by default and does not support python2-pip.
+if ! cat /etc/os-release | grep bullseye &> /dev/null; then
+   sudo apt-get install -y git python python-dev software-properties-common python-numpy python-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
+else
+   # Bullseye based OS. Get PIP2 from pypa and pip-install python packages rather than using the py3 ones from apt
+   # Also, install python-is-python2, to override the distro default of linking python to python3
+   sudo apt-get install -y git python-is-python2 python-dev-is-python2 software-properties-common watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
+   curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2
+   python2 -m pip install numpy
+fi
+#sudo apt-get -o Acquire::ForceIPv4=true install -y git python python-dev software-properties-common python-numpy python-pip nodejs-legacy npm watchdog strace tcpdump screen acpid vim locate jq lm-sensors && \
 sudo pip install -U openaps && \
 sudo pip install -U openaps-contrib && \
 sudo openaps-install-udev-rules && \


### PR DESCRIPTION
This is being proposed for merge to master because 'master' is where new-installs (even of dev branch) start.

The changes are as follows:
1) Wait to install pip until in 'openaps-packages.sh'
2) When in openaps-packages.sh, check for 'bullseye' OS version, and if found do the following: change the default python to python2, then manually install pip & use it to install all subsequent python packages (a/o APT which will be installing py3 versions of them). 

A similar, parallels pull will be proposed to address the same issues in DEV, plus to enable aarch64 based GO in the event that someone is running raspbian-bullseye64. 