### PR TITLE
Fixes to the install scripts for bullseye & 64bit Raspberry Pi OS installs. 

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -53,7 +53,7 @@ fi
 #dpkg -P nodejs nodejs-dev
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
-apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim python-pip locate ntpdate ntp
+apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim locate ntpdate ntp
 #check if edison user exists before trying to add it to groups
 
 grep "PermitRootLogin yes" /etc/ssh/sshd_config || echo "PermitRootLogin yes" > /etc/ssh/sshd_config

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -10,8 +10,17 @@ echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
 
 apt-get install -y sudo
 sudo apt-get update && sudo apt-get -y upgrade
-sudo apt-get install -y git python python-dev software-properties-common python-numpy python-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
-
+#sudo apt-get install -y git python python-dev software-properties-common python-numpy python-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
+## Debian Bullseye (Raspberry Pi OS 64bit, etc) is python3 by default and does not support python2-pip.
+if ! cat /etc/os-release | grep bullseye >& /dev/null; then
+   sudo apt-get install -y git git python python-dev software-properties-common python-numpy python-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
+else
+   # Bullseye based OS. Get PIP2 from pypa and pip-install python packages rather than using the py3 ones from apt
+   # Also, install python-is-python2, to override the distro default of linking python to python3
+   sudo apt-get install -y git python-is-python2 python-dev-is-python2 software-properties-common watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
+   curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2 || die "Couldn't install pip"
+   python2 -m pip install numpy || die "Couldn't install numpy package"
+fi
 # We require jq >= 1.5 for --slurpfile for merging preferences. Debian Jessie ships with 1.4
 if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /dev/null; then
    sudo apt-get -y -t jessie-backports install jq || die "Couldn't install jq from jessie-backports"

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -1135,6 +1135,8 @@ if prompt_yn "" N; then
         echo "Installing Golang..."
         if uname -m | grep armv; then
             cd /tmp && wget -c https://storage.googleapis.com/golang/go${golangversion}.linux-armv6l.tar.gz && tar -C /usr/local -xzvf /tmp/go${golangversion}.linux-armv6l.tar.gz
+        elif uname -m | grep aarch64; then
+            cd /tmp && wget -c https://storage.googleapis.com/golang/go${golangversion}.linux-arm64.tar.gz && tar -C /usr/local -xzvf /tmp/go${golangversion}.linux-arm64.tar.gz
         elif uname -m | grep i686; then
             cd /tmp && wget -c https://dl.google.com/go/go${golangversion}.linux-386.tar.gz && tar -C /usr/local -xzvf /tmp/go${golangversion}.linux-386.tar.gz
         fi


### PR DESCRIPTION
Fixes the following issues:
openaps-setup trying to install python-pip, which does not exist under bullseye

openaps-packages trying to install python, python-pip, and python-numpy expecting Python2, when Bullseye is python3-based and does not include the python-pip package (just python3-pip).

oref0-setup not having an 'elif' for aarch64/not installing go because of this.  Note that armv61l go will not work on an aarch64 OS - you need the arm64 version.

closes #1422 