### PR TITLE
Node and npm versions conflict fix during the installation of 0.7.1 o…

### DIFF
--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -30,9 +30,6 @@ if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' &> /dev/null ; then
    else
      sudo apt-get install -y nodejs npm || die "Couldn't install nodejs and npm"
    fi
-   
-   # Upgrade npm to the latest version using its self-updater
-   sudo npm install npm@latest -g || die "Couldn't update npm"
 
    ## You may also need development tools to build native addons:
    ## sudo apt-get install gcc g++ make


### PR DESCRIPTION
…penaps

Installing the nodejs 8.x package puts npm version 6.13.4. The installation line of the latest version of npm leads to a conflict between the versions of npm and nodejs. Too new npm cannot run on too old nodejs. So I just removed the npm update to the latest version so that the Openaps installation script would not crash.