### PR TITLE
Compress data

### DIFF
--- a/bin/ns-upload-entries.sh
+++ b/bin/ns-upload-entries.sh
@@ -28,7 +28,7 @@ fi
 
 # requires API_SECRET and NIGHTSCOUT_HOST to be set in calling environment (i.e. in crontab)
 (
-curl -m 30 -s -X POST --data-binary @${ENTRIES} \
+curl --compressed -m 30 -s -X POST --data-binary @${ENTRIES} \
   ${API_SECRET_HEADER}  -H "content-type: application/json" \
   ${REST_ENDPOINT}
 ) && ( test -n "${OUTPUT}" && touch ${OUTPUT} ; logger "Uploaded ${ENTRIES} to ${NIGHTSCOUT_HOST}" ) || logger "Unable to upload to ${NIGHTSCOUT_HOST}"

--- a/bin/ns-upload.sh
+++ b/bin/ns-upload.sh
@@ -38,13 +38,13 @@ fi
 if [[ "${API_SECRET,,}" =~ "token=" ]]; then
   REST_ENDPOINT="${REST_ENDPOINT}?${API_SECRET}"
     (test "$ENTRIES" != "-" && cat $ENTRIES || cat )| (
-    curl -m 30 -s -X POST --data-binary @- \
+    curl --compressed -m 30 -s -X POST --data-binary @- \
         -H "content-type: application/json" \
         $REST_ENDPOINT
     ) && ( test -n "$OUTPUT" && touch $OUTPUT ; logger "Uploaded $ENTRIES to $NIGHTSCOUT_HOST" ) || ( logger "Unable to upload to $NIGHTSCOUT_HOST"; exit 2 )
 else
     (test "$ENTRIES" != "-" && cat $ENTRIES || cat )| (
-    curl -m 30 -s -X POST --data-binary @- \
+    curl --compressed -m 30 -s -X POST --data-binary @- \
         -H "API-SECRET: $API_SECRET" \
         -H "content-type: application/json" \
         $REST_ENDPOINT

--- a/bin/oref0-get-ns-entries.js
+++ b/bin/oref0-get-ns-entries.js
@@ -180,12 +180,14 @@ var oref0_get_ns_engtires = function oref0_get_ns_engtires(argv_params, print_ca
       headers["If-Modified-Since"] = lastDate.toISOString();
     }
 
+    headers["User-Agent"] = 'openaps';
     var uri = nsurl + '/api/v1/entries/sgv.json?count=' + records + tokenAuth;
     var options = {
       uri: uri
       , json: true
       , timeout: 90000
       , headers: headers
+      , gzip : true
     };
 
     request(options, function(error, res, data) {


### PR DESCRIPTION
Using nightscout on google cloud there is a limit on the BW that can be used for free.
The maximum free amount that can be used is 1G per month.
It seems that two rigs use that BW in a day, not in a month.

This checkin decreases the amount of data that is used significantly by doing two things:
1) Compressing in a few places where curl was not used to compress.
2) Compress the js usage of the code.
3) Decrease the number of device status entries that are brought for pushover from 100 to 20. It seems to me that 20 entries should cover one hour of data, but I'm not 100% sure how things work.

Without this changes each pushover takes 250k and there is one of this calls every minute. After compressing, we get to ~10k of data. This is still too much, so I have changed this to be 20 entries only.
If that does not make sense, please let me know.