### PR TITLE
skip_neutral_temps only if SMB's somehow disabled

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -922,9 +922,13 @@ var maxDelta_bg_threshold;
 
     // if not in LGS mode, cancel temps before the top of the hour to reduce beeping/vibration
     // console.error(profile.skip_neutral_temps, rT.deliverAt.getMinutes());
-    if ( profile.skip_neutral_temps && !enableSMB && rT.deliverAt.getMinutes() >= 55 ) {
-        rT.reason += "; Canceling temp at " + (60 - rT.deliverAt.getMinutes()) + "min before turn of the hour to avoid beeping of MDT. SMB disabled anyways.";
-        return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+    if ( profile.skip_neutral_temps && rT.deliverAt.getMinutes() >= 55 ) {
+        if (!enableSMB) {
+            rT.reason += "; Canceling temp at " + (60 - rT.deliverAt.getMinutes()) + "min before turn of the hour to avoid beeping of MDT. SMB disabled anyways.";
+            return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
+        } else {
+             console.error((60 - rT.deliverAt.getMinutes()) + "min before turn of the hour, but SMB's are enabled - no skipping neutral temps")
+        }
     }
 
     if (eventualBG < min_bg) { // if eventual BG is below target:

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -922,8 +922,8 @@ var maxDelta_bg_threshold;
 
     // if not in LGS mode, cancel temps before the top of the hour to reduce beeping/vibration
     // console.error(profile.skip_neutral_temps, rT.deliverAt.getMinutes());
-    if ( profile.skip_neutral_temps && rT.deliverAt.getMinutes() >= 55 ) {
-        rT.reason += "; Canceling temp at " + rT.deliverAt.getMinutes() + "m past the hour. ";
+    if ( profile.skip_neutral_temps && !enableSMB && rT.deliverAt.getMinutes() >= 55 ) {
+        rT.reason += "; Canceling temp at " + (60 - rT.deliverAt.getMinutes()) + "min before turn of the hour to avoid beeping of MDT. SMB disabled anyways.";
         return tempBasalFunctions.setTempBasal(0, 0, profile, rT, currenttemp);
     }
 


### PR DESCRIPTION
fixes #1451 so that one doesnt miss out on any necessary SMB's if `skip_neutral_temps`is enabled