### PR TITLE
#1455: Don’t cancel a <10m old high temp due to lack of BG data

### DIFF
--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -201,7 +201,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 // Then, for all such error conditions, cancel any running high temp or shorten any long zero temp, and return.
     if ((minAgo > 12 || minAgo < -5) && lastTempAge < 10) {
-        rT.reason += "lastTempAge of " + lastTempAge + " < 10m; doing nothing. ";
+        rT.reason += ", but lastTempAge of " + lastTempAge + " < 10m; doing nothing. ";
         return rT;
     } else if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || tooflat ) {
         if (currenttemp.rate > basal) { // high temp is running
@@ -227,6 +227,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
         }
     }
+
 // Get configured target, and return if unable to do so.
 // This should occur after checking that we're not in one of the CGM-data-related error conditions handled above,
 // and before using target_bg to adjust sensitivityRatio below.

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -184,9 +184,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
-    var lastTempAge = 0;
+    var lastTempAge;
     if (typeof iob_data.lastTemp !== 'undefined' ) {
         lastTempAge = round(( new Date(systemTime).getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
+    } else if (typeof currenttemp.duration !== 'undefined' ) {
+        // the second % 30 converts any lastTempAge of 30 to 0
+        lastTempAge = (30 - currenttemp.duration % 30) % 30;
     }
 
     if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -189,7 +189,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         lastTempAge = round(( new Date(systemTime).getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
     }
 
-    if ((minAgo > 12 || minAgo < -5) && lastTempAge >= 10) { // Dexcom data is too old, or way in the future
+    if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     // if BG is too old/noisy, or is changing less than 1 mg/dL/5m for 45m, cancel any high temps and shorten any long zero temps
     } else if ( tooflat ) {
@@ -200,7 +200,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 // Then, for all such error conditions, cancel any running high temp or shorten any long zero temp, and return.
-    if (bg <= 10 || bg === 38 || noise >= 3 || ((minAgo > 12 || minAgo < -5) && lastTempAge >= 10) || tooflat ) {
+    if ((minAgo > 12 || minAgo < -5) && lastTempAge < 10) {
+        rT.reason += "lastTempAge of " + lastTempAge + " < 10m; doing nothing. ";
+        return rT;
+    } else if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || tooflat ) {
         if (currenttemp.rate > basal) { // high temp is running
             rT.reason += ". Replacing high temp basal of "+currenttemp.rate+" with neutral temp of "+basal;
             rT.deliverAt = deliverAt;
@@ -224,7 +227,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
         }
     }
-
 // Get configured target, and return if unable to do so.
 // This should occur after checking that we're not in one of the CGM-data-related error conditions handled above,
 // and before using target_bg to adjust sensitivityRatio below.

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -184,7 +184,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
-    if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
+    var lastTempAge = 0;
+    if (typeof iob_data.lastTemp !== 'undefined' ) {
+        lastTempAge = round(( new Date(systemTime).getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
+    }
+
+    if ((minAgo > 12 || minAgo < -5) && lastTempAge >= 10) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     // if BG is too old/noisy, or is changing less than 1 mg/dL/5m for 45m, cancel any high temps and shorten any long zero temps
     } else if ( tooflat ) {
@@ -195,7 +200,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 // Then, for all such error conditions, cancel any running high temp or shorten any long zero temp, and return.
-    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || tooflat ) {
+    if (bg <= 10 || bg === 38 || noise >= 3 || ((minAgo > 12 || minAgo < -5) && lastTempAge >= 10) || tooflat ) {
         if (currenttemp.rate > basal) { // high temp is running
             rT.reason += ". Replacing high temp basal of "+currenttemp.rate+" with neutral temp of "+basal;
             rT.deliverAt = deliverAt;


### PR DESCRIPTION
https://github.com/openaps/oref0/issues/1455


When running offline with multiple rigs, the rig with connected CGM will set a high temp, and the other without CGM data will immediately cancel it.

Let's not cancel a high temp due to lack of BG data if the temp has been running for less than 10m.

