### PR TITLE
wait upto45s and try preflight; if successful, refresh pumphistory, else mmtune

### DIFF
--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -169,7 +169,8 @@ function fail {
         refresh_after_bolus_or_enact
         echo "Incomplete oref0-pump-loop (pump suspended) at $(date)"
     else
-        # retry preflight; if successful, refresh pumphistory, else mmtune
+        # wait upto45s and retry preflight; if successful, refresh pumphistory, else mmtune
+        wait_for_silence $upto45s
         if retry_fail preflight; then
             pumphistory_daily_refresh
         else

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -171,7 +171,7 @@ function fail {
     else
         # wait upto45s and retry preflight; if successful, refresh pumphistory, else mmtune
         wait_for_silence $upto45s
-        if retry_fail preflight; then
+        if retry_return preflight; then
             pumphistory_daily_refresh
         else
             maybe_mmtune

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -169,8 +169,12 @@ function fail {
         refresh_after_bolus_or_enact
         echo "Incomplete oref0-pump-loop (pump suspended) at $(date)"
     else
-        pumphistory_daily_refresh
-        maybe_mmtune
+        # retry preflight; if successful, refresh pumphistory, else mmtune
+        if retry_fail preflight; then
+            pumphistory_daily_refresh
+        else
+            maybe_mmtune
+        fi
         echo "If pump and rig are close enough, this error usually self-resolves. Stand by for the next loop."
         echo Unsuccessful oref0-pump-loop at $(date)
     fi

--- a/bin/oref0-pump-loop.sh
+++ b/bin/oref0-pump-loop.sh
@@ -169,9 +169,9 @@ function fail {
         refresh_after_bolus_or_enact
         echo "Incomplete oref0-pump-loop (pump suspended) at $(date)"
     else
-        # wait upto45s and retry preflight; if successful, refresh pumphistory, else mmtune
+        # wait upto45s and try preflight; if successful, refresh pumphistory, else mmtune
         wait_for_silence $upto45s
-        if retry_return preflight; then
+        if try_return preflight; then
             pumphistory_daily_refresh
         else
             maybe_mmtune


### PR DESCRIPTION
This cuts down on how noisy out-of-range rigs are, to allow in-range rigs to proceed.

We've been running this on all of our rigs for months.