### PR TITLE
Introduce smb_delivery_ratio setting

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1094,10 +1094,18 @@ var maxDelta_bg_threshold;
                 maxBolus = round( profile.current_basal * profile.maxSMBBasalMinutes / 60 ,1);
             }
             // bolus 1/2 the insulinReq, up to maxBolus, rounding down to nearest bolus increment
+            
+            // New smb_delivery_ratio setting. Default is 1/2 the insulinReq (0.5), like before.
+            var smb_delivery_ratio = 0.5;
+            if (profile.smb_delivery_ratio) {
+                smb_delivery_ratio = Math.min(Math.max(profile.smb_delivery_ratio, 0.1), 1);
+                process.stderr.write("SMB Ratio: " + smb_delivery_ratio);
+            }
+            
             bolusIncrement = 0.1;
             if (profile.bolus_increment) { bolusIncrement=profile.bolus_increment };
             var roundSMBTo = 1 / bolusIncrement;
-            var microBolus = Math.floor(Math.min(insulinReq/2,maxBolus)*roundSMBTo)/roundSMBTo;
+            var microBolus = Math.floor(Math.min(insulinReq*smb_delivery_ratio,maxBolus)*roundSMBTo)/roundSMBTo;
             // calculate a long enough zero temp to eventually correct back up to target
             var smbTarget = target_bg;
             worstCaseInsulinReq = (smbTarget - (naive_eventualBG + minIOBPredBG)/2 ) / sens;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -75,6 +75,7 @@ function defaults ( ) {
     , target_bg: false // set to an integer value in mg/dL to override pump min_bg
     , edison_battery_shutdown_voltage: 3050
     , pi_battery_shutdown_percent: 2
+    , smb_delivery_ratio: 0.5 // Ratio of insulinReq, up to maxBolus, to deliver as SMB, when enabled. Default is 1/2 of insulinReq (0.5)
   }
 }
 
@@ -98,6 +99,7 @@ function displayedDefaults (final_result) {
     profile.offline_hotspot = allDefaults.offline_hotspot;
     profile.edison_battery_shutdown_voltage = allDefaults.edison_battery_shutdown_voltage;
     profile.pi_battery_shutdown_percent = allDefaults.pi_battery_shutdown_percent;
+    profile.smb_delivery_ratio = allDefaults.smb_delivery_ratio;
 
     console_error(final_result, profile);
     return profile


### PR DESCRIPTION
This PR has 2 objectives.

1: introduce a variable for the SMB Delivery Ratio, default is 0.5 (50 % of insulinReq) as before. Min/Max 0.1 to 1. 

This has been a setting in iAPS for a long time and allows for adjustment by users of how rapid/slow the insulinReq is delivered. I use it mostly just in an iAPS middleware function, increasing the ratio slightly when glucose is quickly rising and/or decreasing  when glucose is falling.  

2: This will make the Oref0 modules identical to the Oref0 code used in newest version of iAPS (v 4.0.0).Newest iAPS version 4 will be using clean Oref0 code.
 
Currently only difference is 2 variables, in lib/determine_basal.js and lib/profile/index.js), this one and another one. I will make another PR for the other variable, a configurable minimum threshold variable (as some users want to increase the very minimum of 65 mg/dl value when using iAPS).