### PR TITLE
2 new variables

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -815,12 +815,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     rT.ISF=convert_bg(sens, profile);
     rT.CR=round(profile.carb_ratio, 2);
     rT.target_bg=convert_bg(target_bg, profile);
-    rT.reason="COB: " + rT.COB + ", Dev: " + rT.deviation + ", BGI: " + rT.BGI+ ", ISF: " + rT.ISF + ", CR: " + rT.CR + ", minPredBG " + convert_bg(minPredBG, profile) + ", minGuardBG " + convert_bg(minGuardBG, profile) + ", IOBpredBG " + convert_bg(lastIOBpredBG, profile);
+    rT.reason="COB: " + rT.COB + ", Dev: " + rT.deviation + ", BGI: " + rT.BGI+ ", ISF: " + rT.ISF + ", CR: " + rT.CR + ", minPredBG: " + convert_bg(minPredBG, profile) + ", minGuardBG: " + convert_bg(minGuardBG, profile) + ", IOBpredBG: " + convert_bg(lastIOBpredBG, profile);
     if (lastCOBpredBG > 0) {
-        rT.reason += ", COBpredBG " + convert_bg(lastCOBpredBG, profile);
+        rT.reason += ", COBpredBG: " + convert_bg(lastCOBpredBG, profile);
     }
     if (lastUAMpredBG > 0) {
-        rT.reason += ", UAMpredBG " + convert_bg(lastUAMpredBG, profile)
+        rT.reason += ", UAMpredBG: " + convert_bg(lastUAMpredBG, profile)
     }
     rT.reason += "; ";
 
@@ -917,7 +917,7 @@ var maxDelta_bg_threshold;
         rT.reason += " and minDelta " + convert_bg(minDelta, profile) + " > " + "expectedDelta " + convert_bg(expectedDelta, profile) + "; ";
     // predictive low glucose suspend mode: BG is / is projected to be < threshold
     } else if ( bg < threshold || minGuardBG < threshold ) {
-        rT.reason += "minGuardBG " + convert_bg(minGuardBG, profile) + "<" + convert_bg(threshold, profile);
+        rT.reason += "minGuardBG: " + convert_bg(minGuardBG, profile) + "<" + convert_bg(threshold, profile);
         bgUndershoot = target_bg - minGuardBG;
         var worstCaseInsulinReq = bgUndershoot / sens;
         var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -326,7 +326,14 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 
     // min_bg of 90 -> threshold of 65, 100 -> 70 110 -> 75, and 130 -> 85
-    var threshold = min_bg - 0.5*(min_bg-40);
+
+    // But if profile.threshold_setting is over 65 increase the very minimum glucose threshold
+    var minimum_threshold = 65;
+    if (profile.threshold_setting) {
+        minimum_threshold = profile.threshold_setting;
+    }
+    var threshold = Math.max(min_bg - 0.5*(min_bg-40), minimum_threshold);
+    process.stderr.write("Glucose threshold: " + convert_bg(threshold,profile));
 
 // If iob_data or its required properties are missing, return.
 // This has to be checked after checking that we're not in one of the CGM-data-related error conditions handled above,
@@ -1094,10 +1101,18 @@ var maxDelta_bg_threshold;
                 maxBolus = round( profile.current_basal * profile.maxSMBBasalMinutes / 60 ,1);
             }
             // bolus 1/2 the insulinReq, up to maxBolus, rounding down to nearest bolus increment
+            
+            // New smb_delivery_ratio setting. Default is 1/2 the insulinReq (0.5), like before.
+            var smb_delivery_ratio = 0.5;
+            if (profile.smb_delivery_ratio) {
+                smb_delivery_ratio = Math.min(Math.max(profile.smb_delivery_ratio, 0.1), 1);
+                process.stderr.write("SMB Ratio: " + smb_delivery_ratio);
+            }
+            
             bolusIncrement = 0.1;
             if (profile.bolus_increment) { bolusIncrement=profile.bolus_increment };
             var roundSMBTo = 1 / bolusIncrement;
-            var microBolus = Math.floor(Math.min(insulinReq/2,maxBolus)*roundSMBTo)/roundSMBTo;
+            var microBolus = Math.floor(Math.min(insulinReq*smb_delivery_ratio,maxBolus)*roundSMBTo)/roundSMBTo;
             // calculate a long enough zero temp to eventually correct back up to target
             var smbTarget = target_bg;
             worstCaseInsulinReq = (smbTarget - (naive_eventualBG + minIOBPredBG)/2 ) / sens;

--- a/lib/profile/index.js
+++ b/lib/profile/index.js
@@ -75,6 +75,8 @@ function defaults ( ) {
     , target_bg: false // set to an integer value in mg/dL to override pump min_bg
     , edison_battery_shutdown_voltage: 3050
     , pi_battery_shutdown_percent: 2
+    , threshold_setting: 65 // The minimum glucose threshold
+    , smb_delivery_ratio: 0.5 // Ratio of insulinReq, up to maxBolus, to deliver as SMB, when enabled. Default is 1/2 of insulinReq (0.5)
   }
 }
 
@@ -98,6 +100,8 @@ function displayedDefaults (final_result) {
     profile.offline_hotspot = allDefaults.offline_hotspot;
     profile.edison_battery_shutdown_voltage = allDefaults.edison_battery_shutdown_voltage;
     profile.pi_battery_shutdown_percent = allDefaults.pi_battery_shutdown_percent;
+    profile.threshold_setting = allDefaults.profile.threshold_setting;
+    profile.smb_delivery_ratio = allDefaults.smb_delivery_ratio;
 
     console_error(final_result, profile);
     return profile


### PR DESCRIPTION
This PR has 2 objectives.

1: introduce 2 new variables.

2: This will make the Oref0 modules identical to the Oref0 code used in newest version of iAPS (v 4.0.0).Newest iAPS version 4 will be using clean Oref0 code.
Currently only difference is these 2 variables, in lib/determine_basal.js and lib/profile/index.js).

Variable 1: SMB Delivery Ratio.
Introduces a variable for the SMB Delivery Ratio, default is 0.5 (50 % of insulinReq) as before. Min/Max 0.1 to 1.

This has been a setting in iAPS for a long time and allows for adjustment by users of how rapid/slow the insulinReq is delivered. I use it mostly just in an iAPS middleware function, increasing the ratio slightly when glucose is quickly rising and/or decreasing when glucose is falling.

Variable 2: Minimum Glucose Threshold.
This variable allows to increase the very minimum glucose threshold of 65 mg/dl.

Some iAPS users think the the 65 mg/dl sometime is too low. This will allow users to increase this value. Default is 65, as before.