### PR TITLE
rT.reason missing colons (:)

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -808,12 +808,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     rT.ISF=convert_bg(sens, profile);
     rT.CR=round(profile.carb_ratio, 2);
     rT.target_bg=convert_bg(target_bg, profile);
-    rT.reason="COB: " + rT.COB + ", Dev: " + rT.deviation + ", BGI: " + rT.BGI+ ", ISF: " + rT.ISF + ", CR: " + rT.CR + ", minPredBG " + convert_bg(minPredBG, profile) + ", minGuardBG " + convert_bg(minGuardBG, profile) + ", IOBpredBG " + convert_bg(lastIOBpredBG, profile);
+    rT.reason="COB: " + rT.COB + ", Dev: " + rT.deviation + ", BGI: " + rT.BGI+ ", ISF: " + rT.ISF + ", CR: " + rT.CR + ", minPredBG: " + convert_bg(minPredBG, profile) + ", minGuardBG: " + convert_bg(minGuardBG, profile) + ", IOBpredBG: " + convert_bg(lastIOBpredBG, profile);
     if (lastCOBpredBG > 0) {
-        rT.reason += ", COBpredBG " + convert_bg(lastCOBpredBG, profile);
+        rT.reason += ", COBpredBG: " + convert_bg(lastCOBpredBG, profile);
     }
     if (lastUAMpredBG > 0) {
-        rT.reason += ", UAMpredBG " + convert_bg(lastUAMpredBG, profile)
+        rT.reason += ", UAMpredBG: " + convert_bg(lastUAMpredBG, profile)
     }
     rT.reason += "; ";
 
@@ -910,7 +910,7 @@ var maxDelta_bg_threshold;
         rT.reason += " and minDelta " + convert_bg(minDelta, profile) + " > " + "expectedDelta " + convert_bg(expectedDelta, profile) + "; ";
     // predictive low glucose suspend mode: BG is / is projected to be < threshold
     } else if ( bg < threshold || minGuardBG < threshold ) {
-        rT.reason += "minGuardBG " + convert_bg(minGuardBG, profile) + "<" + convert_bg(threshold, profile);
+        rT.reason += "minGuardBG: " + convert_bg(minGuardBG, profile) + "<" + convert_bg(threshold, profile);
         bgUndershoot = target_bg - minGuardBG;
         var worstCaseInsulinReq = bgUndershoot / sens;
         var durationReq = round(60*worstCaseInsulinReq / profile.current_basal);


### PR DESCRIPTION
In some places a space is used instead of a colon. This probably has no impact on OpenAPS users, but for iAPS the colon can be used as a separator when reading the reasons-string (the variables): reasons.components(separatedBy: ":")

This would also make the format of the OpenAPS variables in the NS OpenAPS pill more homogenous.

This change isn't super important as I'm currently using a workaround for IAPS to read also the reasons with space separator, but at the same time this PR wouldn't brake anything.
