### PR TITLE
use archive.debian.org for stretch sources.list

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -44,6 +44,15 @@ if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /de
     echo -e "deb http://security.debian.org/ jessie/updates main\n#deb-src http://security.debian.org/ jessie/updates main\n\ndeb http://archive.debian.org/debian/ jessie-backports main\n#deb-src http://archive.debian.org/debian/ jessie-backports main\n\ndeb http://archive.debian.org/debian/ jessie main contrib non-free\n#deb-src http://archive.debian.org/debian/ jessie main contrib non-free" > /etc/apt/sources.list
     echo "Please consider upgrading your rig to Jubilinux 0.3.0 (Debian Stretch)!"
     echo "Jubilinux 0.2.0, based on Debian Jessie, is no longer receiving security or software updates!"
+else
+    # Replace Debian Stretch apt sources.list with archive.debian.org locations
+    echo "Old sources.list:"
+    cat /etc/apt/sources.list
+    echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list
+    echo "deb http://archive.debian.org/debian/ stretch-proposed-updates main contrib non-free" >> /etc/apt/sources.list
+    echo "deb http://archive.debian.org/debian-security stretch/updates main contrib non-free" >> /etc/apt/sources.list
+    echo "Updated sources.list:"
+    cat /etc/apt/sources.list
 fi
 
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6

--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -44,7 +44,7 @@ if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /de
     echo -e "deb http://security.debian.org/ jessie/updates main\n#deb-src http://security.debian.org/ jessie/updates main\n\ndeb http://archive.debian.org/debian/ jessie-backports main\n#deb-src http://archive.debian.org/debian/ jessie-backports main\n\ndeb http://archive.debian.org/debian/ jessie main contrib non-free\n#deb-src http://archive.debian.org/debian/ jessie main contrib non-free" > /etc/apt/sources.list
     echo "Please consider upgrading your rig to Jubilinux 0.3.0 (Debian Stretch)!"
     echo "Jubilinux 0.2.0, based on Debian Jessie, is no longer receiving security or software updates!"
-else
+elif cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 9 (stretch)"' &> /dev/null; then
     # Replace Debian Stretch apt sources.list with archive.debian.org locations
     echo "Old sources.list:"
     cat /etc/apt/sources.list


### PR DESCRIPTION
The sources.list that shipped with jubilinux-stretch is no longer valid, so we have to use archive.debian.org instead.