### PR TITLE
Add vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+    "name": "oref0",
+    "dockerComposeFile": [
+        "../docker-compose.yml",
+        "../docker-compose.override.yml",
+        "docker-compose.yml"
+    ],
+    "service": "node",
+    "workspaceFolder": "/app",
+    "features": {},
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "Orta.vscode-jest",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "rvest.vs-code-prettier-eslint"
+            ]
+        }
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,3 @@
+services:
+    node:
+        command: /bin/sh -c "while sleep 1000; do :; done"

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ package-lock.json
 *.pyc
 
 bash-unit-test-temp
-
+docker-compose.override.yml

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,0 +1,2 @@
+services:
+    node: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+    node:
+        build:
+            context: ./docker/node
+        working_dir: '/app'
+        volumes:
+            - ./:/app

--- a/docker/node/.zshrc
+++ b/docker/node/.zshrc
@@ -1,0 +1,6 @@
+export ZSH="$HOME/.oh-my-zsh"
+ZSH_THEME="robbyrussell"
+zstyle ':omz:update' mode disabled
+plugins=(git)
+
+source $ZSH/oh-my-zsh.sh

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,0 +1,7 @@
+ARG NODE_VERSION="20-slim"
+FROM node:${NODE_VERSION}
+RUN apt update -y && apt install -y openssh-client curl zsh git vim make jq python3
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \
+    && chsh -s $(which zsh)
+COPY .zshrc /root/.zshrc
+RUN corepack enable


### PR DESCRIPTION
Add docker configuration and [vscode devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) configuration for local development, without need to install dependencies on developer host. It works on every platform.