### PR TITLE
Changed to python3-pip

### DIFF
--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -12,7 +12,7 @@ apt-get install -y sudo
 sudo apt-get update && sudo apt-get -y upgrade
 ## Debian Bullseye (Raspberry Pi OS 64bit, etc) is python3 by default and does not support python2-pip.
 if ! cat /etc/os-release | grep bullseye >& /dev/null; then
-   sudo apt-get install -y git python python-dev software-properties-common python-numpy python-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
+   sudo apt-get install -y git python python-dev software-properties-common python-numpy python3-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
 else
    # Bullseye based OS. Get PIP2 from pypa and pip-install python packages rather than using the py3 ones from apt
    # Also, install python-is-python2, to override the distro default of linking python to python3

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -12,7 +12,7 @@ apt-get install -y sudo
 sudo apt-get update && sudo apt-get -y upgrade
 ## Debian Bullseye (Raspberry Pi OS 64bit, etc) is python3 by default and does not support python2-pip.
 if ! cat /etc/os-release | grep bullseye >& /dev/null; then
-   sudo apt-get install -y git python python-dev software-properties-common python-numpy python3-pip watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
+   sudo apt-get install -y git python python-dev software-properties-common python-numpy python3-pip libdbus-1-3 libdbus-1-dev libglib2.0-dev watchdog strace tcpdump screen acpid vim locate lm-sensors || die "Couldn't install packages"
 else
    # Bullseye based OS. Get PIP2 from pypa and pip-install python packages rather than using the py3 ones from apt
    # Also, install python-is-python2, to override the distro default of linking python to python3
@@ -53,6 +53,7 @@ fi
 sudo pip install setuptools -U # no need to die if this fails
 sudo pip install -U --default-timeout=1000 git+https://github.com/openaps/openaps.git || die "Couldn't install openaps toolkit"
 sudo pip install -U openaps-contrib || die "Couldn't install openaps-contrib"
+sudo pip install -U dbus-python
 sudo openaps-install-udev-rules || die "Couldn't run openaps-install-udev-rules"
 sudo activate-global-python-argcomplete || die "Couldn't run activate-global-python-argcomplete"
 sudo npm install -g json || die "Couldn't install npm json"


### PR DESCRIPTION
When setting up a new version of my rig, I encountered an error about python-pip being replaced by python3-pip. For reference, here's some applicable terminal interactions:

```
pi@loop:~ $ sudo apt install python-pip
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package python-pip is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python3-pip

E: Package 'python-pip' has no installation candidate
```
```
pi@loop:~ $ python --version
Python 3.9.2
```
```
pi@loop:~ $ cat /etc/os-release 
PRETTY_NAME="Raspbian GNU/Linux 11 (bullseye)"
NAME="Raspbian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```

I changed the package name, and it seems to be working so far.