### PR TITLE
[Bug fix] Always check for out of range values for carb ratios in profile

### DIFF
--- a/lib/profile/carbs.js
+++ b/lib/profile/carbs.js
@@ -4,8 +4,10 @@ var getTime = require('../medtronic-clock');
 var shared_node_utils = require('../../bin/oref0-shared-node-utils');
 var console_error = shared_node_utils.console_error;
 
-function carbRatioLookup (final_result, inputs, profile) {
-    var now = new Date();
+function carbRatioLookup (final_result, inputs, profile, now) {
+    if (now === "undefined") {
+	now = new Date();
+    }
     var carbratio_data = inputs.carbratio;
     if (typeof(carbratio_data) !== "undefined" && typeof(carbratio_data.schedule) !== "undefined") {
         var carbRatio;
@@ -16,14 +18,15 @@ function carbRatioLookup (final_result, inputs, profile) {
             for (var i = 0; i < carbratio_data.schedule.length - 1; i++) {
                 if ((now >= getTime(carbratio_data.schedule[i].offset)) && (now < getTime(carbratio_data.schedule[i + 1].offset))) {
                     carbRatio = carbratio_data.schedule[i];
-                    // disallow impossibly high/low carbRatios due to bad decoding
-                    if (carbRatio < 3 || carbRatio > 150) {
-                        console_error(final_result, "Error: carbRatio of " + carbRatio + " out of bounds.");
-                        return;
-                    }
                     break;
                 }
             }
+            // disallow impossibly high/low carbRatios due to bad decoding
+            if (carbRatio.ratio < 3 || carbRatio.ratio > 150) {
+                console_error(final_result, "Error: carbRatio of " + carbRatio.ratio + " out of bounds.");
+                return;
+            }
+
             if (carbratio_data.units === "exchanges") {
                 carbRatio.ratio = 12 / carbRatio.ratio
             }

--- a/tests/profile-carbs.test.js
+++ b/tests/profile-carbs.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+require('should');
+var _ = require('lodash');
+var carb_ratios = require('../lib/profile/carbs');
+
+describe('Carb Ratio Profile', function() {
+    var carbratio_input = {
+        units: 'grams',
+        schedule: [
+            { offset: 0, ratio: 15, start: '00:00:00' },
+            { offset: 180, ratio: 18, start: '03:00:00' },
+            { offset: 360, ratio: 20, start: '06:00:00' }
+        ]
+    };
+
+    it('should return current carb ratio from schedule', function() {
+        var now = new Date('2025-01-26T02:00:00');
+        var ratio = carb_ratios.carbRatioLookup(null, {carbratio: carbratio_input}, null, now);
+        ratio.should.equal(15);
+    });
+
+    it('should handle ratio schedule changes', function() {
+        var now = new Date('2025-01-26T04:00:00');
+        var ratio = carb_ratios.carbRatioLookup(null, {carbratio: carbratio_input}, null, now);
+        ratio.should.equal(18);
+    });
+
+    it('should handle exchanges unit conversion', function() {
+        var exchange_input = {
+            units: 'exchanges',
+            schedule: [
+                { offset: 0, ratio: 12, start: '00:00:00' }
+            ]
+        };
+	var now = new Date('2025-01-26T04:00:00');
+        var ratio = carb_ratios.carbRatioLookup(null, {carbratio: exchange_input}, null, now);
+        ratio.should.equal(1); // 12 grams per exchange
+    });
+
+    it('should reject invalid ratios', function() {
+        var invalid_input = {
+            units: 'grams',
+            schedule: [
+                { offset: 0, ratio: 2, start: '00:00:00' } // Less than min of 3
+            ]
+        };
+
+	var final_result = {
+	    stdout: ''
+	    , err: ''
+	    , return_val : 0
+	};
+	
+        var ratio = carb_ratios.carbRatioLookup(final_result, {carbratio: invalid_input});
+        should.not.exist(ratio);
+    });
+});


### PR DESCRIPTION
The check for bad carb ratios does not run if the current carb ratio is the last one in the list.

I already have a [PR](https://github.com/nightscout/trio-oref/pull/38) posted to `trio-oref`, but I'm posting it here as well in case it's useful.