### PR TITLE
Fix archived Debian stretch install scripts

### DIFF
--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -46,6 +46,16 @@ if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 8 (jessie)"' &> /de
     echo "Jubilinux 0.2.0, based on Debian Jessie, is no longer receiving security or software updates!"
 fi
 
+# Workaround for Debian Stretch migration to LTS
+if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 9 (stretch)"' &> /dev/null; then
+    # Disable valid-until check for archived Debian repos (expired certs)
+    echo "Acquire::Check-Valid-Until false;" | tee -a /etc/apt/apt.conf.d/10-nocheckvalid
+    # Replace apt sources.list with archive.debian.org locations
+    echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list
+    echo "deb http://archive.debian.org/debian/ stretch-proposed-updates main contrib non-free" >> /etc/apt/sources.list
+    echo "deb http://archive.debian.org/debian-security stretch/updates main contrib non-free" >> /etc/apt/sources.list
+fi
+
 # TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
 apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim locate ntpdate ntp

--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 set -e
 
+configure_archived_debian_repos() {
+    if grep 'PRETTY_NAME="Debian GNU/Linux 9 (stretch)"' /etc/os-release >/dev/null 2>&1; then
+        cat >/etc/apt/apt.conf.d/99stretch-archive <<'EOF'
+Acquire::Check-Valid-Until "false";
+Acquire::AllowInsecureRepositories "true";
+Acquire::AllowDowngradeToInsecureRepositories "true";
+APT::Get::AllowUnauthenticated "true";
+EOF
+        cat >/etc/apt/sources.list <<'EOF'
+deb [trusted=yes] http://archive.debian.org/debian stretch main contrib non-free
+deb [trusted=yes] http://archive.debian.org/debian-security stretch/updates main contrib non-free
+EOF
+        if [ -d /etc/apt/sources.list.d ]; then
+            find /etc/apt/sources.list.d -type f -name '*.list' -exec sed -i \
+                -e '/deb\.debian\.org/d' \
+                -e '/security\.debian\.org/d' \
+                -e '/stretch-updates/d' \
+                -e '/stretch-proposed-updates/d' \
+                {} +
+        fi
+    fi
+}
+
 BRANCH=${1:-dev}
 read -p "Enter your rig's new hostname (this will be your rig's "name" in the future, so make sure to write it down): " -r
 myrighostname=$REPLY
@@ -48,12 +71,7 @@ fi
 
 # Workaround for Debian Stretch migration to LTS
 if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 9 (stretch)"' &> /dev/null; then
-    # Disable valid-until check for archived Debian repos (expired certs)
-    echo "Acquire::Check-Valid-Until false;" | tee -a /etc/apt/apt.conf.d/10-nocheckvalid
-    # Replace apt sources.list with archive.debian.org locations
-    echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list
-    echo "deb http://archive.debian.org/debian/ stretch-proposed-updates main contrib non-free" >> /etc/apt/sources.list
-    echo "deb http://archive.debian.org/debian-security stretch/updates main contrib non-free" >> /etc/apt/sources.list
+    configure_archived_debian_repos
 fi
 
 apt-get update && apt-get -o Dpkg::Options::="--force-confdef" -y dist-upgrade && apt-get -y autoremove

--- a/bin/openaps-install.sh
+++ b/bin/openaps-install.sh
@@ -56,9 +56,8 @@ if cat /etc/os-release | grep 'PRETTY_NAME="Debian GNU/Linux 9 (stretch)"' &> /d
     echo "deb http://archive.debian.org/debian-security stretch/updates main contrib non-free" >> /etc/apt/sources.list
 fi
 
-# TODO: remove the `-o Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
-apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true -y dist-upgrade && apt-get -o Acquire::ForceIPv4=true -y autoremove
-apt-get -o Acquire::ForceIPv4=true update && apt-get -o Acquire::ForceIPv4=true install -y sudo strace tcpdump screen acpid vim locate ntpdate ntp
+apt-get update && apt-get -o Dpkg::Options::="--force-confdef" -y dist-upgrade && apt-get -y autoremove
+apt-get update && apt-get install -y sudo strace tcpdump screen acpid vim locate ntpdate ntp
 #check if edison user exists before trying to add it to groups
 
 grep "PermitRootLogin yes" /etc/ssh/sshd_config || echo "PermitRootLogin yes" >>/etc/ssh/sshd_config

--- a/bin/openaps-packages.sh
+++ b/bin/openaps-packages.sh
@@ -5,8 +5,33 @@ die() {
     exit 1
 }
 
+configure_archived_debian_repos() {
+    if grep 'PRETTY_NAME="Debian GNU/Linux 9 (stretch)"' /etc/os-release >/dev/null 2>&1; then
+        cat >/etc/apt/apt.conf.d/99stretch-archive <<'EOF'
+Acquire::Check-Valid-Until "false";
+Acquire::AllowInsecureRepositories "true";
+Acquire::AllowDowngradeToInsecureRepositories "true";
+APT::Get::AllowUnauthenticated "true";
+EOF
+        cat >/etc/apt/sources.list <<'EOF'
+deb [trusted=yes] http://archive.debian.org/debian stretch main contrib non-free
+deb [trusted=yes] http://archive.debian.org/debian-security stretch/updates main contrib non-free
+EOF
+        if [ -d /etc/apt/sources.list.d ]; then
+            find /etc/apt/sources.list.d -type f -name '*.list' -exec sed -i \
+                -e '/deb\.debian\.org/d' \
+                -e '/security\.debian\.org/d' \
+                -e '/stretch-updates/d' \
+                -e '/stretch-proposed-updates/d' \
+                {} +
+        fi
+    fi
+}
+
 # TODO: remove the `Acquire::ForceIPv4=true` once Debian's mirrors work reliably over IPv6
 echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
+
+configure_archived_debian_repos
 
 apt-get install -y sudo
 sudo apt-get update && sudo apt-get -y upgrade

--- a/bin/oref0-pushover.sh
+++ b/bin/oref0-pushover.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 
 source $(dirname $0)/oref0-bash-common-functions.sh || (echo "ERROR: Failed to run oref0-bash-common-functions.sh. Is oref0 correctly installed?"; exit 1)
 

--- a/bin/oref0-setup.sh
+++ b/bin/oref0-setup.sh
@@ -717,6 +717,26 @@ if prompt_yn "" N; then
         # Replace apt sources.list with archive.debian.org locations
         echo -e "deb http://security.debian.org/ jessie/updates main\n#deb-src http://security.debian.org/ jessie/updates main\n\ndeb http://archive.debian.org/debian/ jessie-backports main\n#deb-src http://archive.debian.org/debian/ jessie-backports main\n\ndeb http://archive.debian.org/debian/ jessie main contrib non-free\n#deb-src http://archive.debian.org/debian/ jessie main contrib non-free" > /etc/apt/sources.list
     fi
+    if grep 'PRETTY_NAME="Debian GNU/Linux 9 (stretch)"' /etc/os-release >/dev/null 2>&1; then
+        cat >/etc/apt/apt.conf.d/99stretch-archive <<'EOF'
+Acquire::Check-Valid-Until "false";
+Acquire::AllowInsecureRepositories "true";
+Acquire::AllowDowngradeToInsecureRepositories "true";
+APT::Get::AllowUnauthenticated "true";
+EOF
+        cat >/etc/apt/sources.list <<'EOF'
+deb [trusted=yes] http://archive.debian.org/debian stretch main contrib non-free
+deb [trusted=yes] http://archive.debian.org/debian-security stretch/updates main contrib non-free
+EOF
+        if [ -d /etc/apt/sources.list.d ]; then
+            find /etc/apt/sources.list.d -type f -name '*.list' -exec sed -i \
+                -e '/deb\.debian\.org/d' \
+                -e '/security\.debian\.org/d' \
+                -e '/stretch-updates/d' \
+                -e '/stretch-proposed-updates/d' \
+                {} +
+        fi
+    fi
     
     #Mount the Edison's fat32 partition at /usr/local/go to give us lots of room to install golang
     if is_edison && [ -e /dev/mmcblk0p9 ] && ! mount | grep -qa mmcblk0p9 ; then

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -201,7 +201,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
     }
 // Then, for all such error conditions, cancel any running high temp or shorten any long zero temp, and return.
     if ((minAgo > 12 || minAgo < -5) && lastTempAge < 10) {
-        rT.reason += "lastTempAge of " + lastTempAge + " < 10m; doing nothing. ";
+        rT.reason += ", but lastTempAge of " + lastTempAge + " < 10m; doing nothing. ";
         return rT;
     } else if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || tooflat ) {
         if (currenttemp.rate > basal) { // high temp is running
@@ -227,6 +227,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
         }
     }
+
 // Get configured target, and return if unable to do so.
 // This should occur after checking that we're not in one of the CGM-data-related error conditions handled above,
 // and before using target_bg to adjust sensitivityRatio below.

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -184,9 +184,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
-    var lastTempAge = 0;
+    var lastTempAge;
     if (typeof iob_data.lastTemp !== 'undefined' ) {
         lastTempAge = round(( new Date(systemTime).getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
+    } else if (typeof currenttemp.duration !== 'undefined' ) {
+        // the second % 30 converts any lastTempAge of 30 to 0
+        lastTempAge = (30 - currenttemp.duration % 30) % 30;
     }
 
     if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -189,7 +189,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         lastTempAge = round(( new Date(systemTime).getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
     }
 
-    if ((minAgo > 12 || minAgo < -5) && lastTempAge >= 10) { // Dexcom data is too old, or way in the future
+    if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     // if BG is too old/noisy, or is changing less than 1 mg/dL/5m for 45m, cancel any high temps and shorten any long zero temps
     } else if ( tooflat ) {
@@ -200,7 +200,10 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 // Then, for all such error conditions, cancel any running high temp or shorten any long zero temp, and return.
-    if (bg <= 10 || bg === 38 || noise >= 3 || ((minAgo > 12 || minAgo < -5) && lastTempAge >= 10) || tooflat ) {
+    if ((minAgo > 12 || minAgo < -5) && lastTempAge < 10) {
+        rT.reason += "lastTempAge of " + lastTempAge + " < 10m; doing nothing. ";
+        return rT;
+    } else if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || tooflat ) {
         if (currenttemp.rate > basal) { // high temp is running
             rT.reason += ". Replacing high temp basal of "+currenttemp.rate+" with neutral temp of "+basal;
             rT.deliverAt = deliverAt;
@@ -224,7 +227,6 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
             return rT;
         }
     }
-
 // Get configured target, and return if unable to do so.
 // This should occur after checking that we're not in one of the CGM-data-related error conditions handled above,
 // and before using target_bg to adjust sensitivityRatio below.

--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -184,7 +184,12 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 
-    if (minAgo > 12 || minAgo < -5) { // Dexcom data is too old, or way in the future
+    var lastTempAge = 0;
+    if (typeof iob_data.lastTemp !== 'undefined' ) {
+        lastTempAge = round(( new Date(systemTime).getTime() - iob_data.lastTemp.date ) / 60000); // in minutes
+    }
+
+    if ((minAgo > 12 || minAgo < -5) && lastTempAge >= 10) { // Dexcom data is too old, or way in the future
         rT.reason = "If current system time "+systemTime+" is correct, then BG data is too old. The last BG data was read "+minAgo+"m ago at "+bgTime;
     // if BG is too old/noisy, or is changing less than 1 mg/dL/5m for 45m, cancel any high temps and shorten any long zero temps
     } else if ( tooflat ) {
@@ -195,7 +200,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
         }
     }
 // Then, for all such error conditions, cancel any running high temp or shorten any long zero temp, and return.
-    if (bg <= 10 || bg === 38 || noise >= 3 || minAgo > 12 || minAgo < -5 || tooflat ) {
+    if (bg <= 10 || bg === 38 || noise >= 3 || ((minAgo > 12 || minAgo < -5) && lastTempAge >= 10) || tooflat ) {
         if (currenttemp.rate > basal) { // high temp is running
             rT.reason += ". Replacing high temp basal of "+currenttemp.rate+" with neutral temp of "+basal;
             rT.deliverAt = deliverAt;


### PR DESCRIPTION
Debian Stretch is archived and no longer supported, so we need to use archive.debian.org and disable signature verification.

Don't do the initial install of your OpenAPS rig on public or untrusted wifi networks where someone might choose to MitM your connections to archive.debian.org and backdoor your rig. Also don't leave your car doors unlocked with the keys inside.

This also includes a lastTempAge commit that hadn't made it to dev yet. See comment below for details.